### PR TITLE
Text encoding

### DIFF
--- a/src/main/java/org/cactoos/io/InputAsText.java
+++ b/src/main/java/org/cactoos/io/InputAsText.java
@@ -24,6 +24,7 @@
 package org.cactoos.io;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import org.cactoos.Input;
 import org.cactoos.Text;
 
@@ -44,15 +45,35 @@ public final class InputAsText implements Text {
     private final Input source;
 
     /**
-     * Ctor.
+     * Text encoding.
+     */
+    private final Charset charset;
+
+    /**
+     * New {@link InputAsText} with default charset.
+     *
      * @param input The input
      */
     public InputAsText(final Input input) {
+        this(input, Charset.defaultCharset());
+    }
+
+    /**
+     * New {@link InputAsText} with specified charset.
+     *
+     * @param input The input
+     * @param encoding Text charset
+     */
+    public InputAsText(final Input input, final Charset encoding) {
         this.source = input;
+        this.charset = encoding;
     }
 
     @Override
     public String asString() throws IOException {
-        return new String(new InputAsBytes(this.source).asBytes());
+        return new String(
+            new InputAsBytes(this.source).asBytes(),
+            this.charset
+        );
     }
 }

--- a/src/main/java/org/cactoos/io/TextAsInput.java
+++ b/src/main/java/org/cactoos/io/TextAsInput.java
@@ -26,6 +26,7 @@ package org.cactoos.io;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import org.cactoos.Input;
 import org.cactoos.Text;
 
@@ -46,16 +47,35 @@ public final class TextAsInput implements Input {
     private final Text source;
 
     /**
-     * Ctor.
+     * Text charset.
+     */
+    private final Charset charset;
+
+    /**
+     * New {@link TextAsInput} with default charset.
+     *
      * @param text The text
      */
     public TextAsInput(final Text text) {
+        this(text, Charset.defaultCharset());
+    }
+
+    /**
+     * New {@link TextAsInput} with specified charset.
+     *
+     * @param text The text
+     * @param charset Text charset
+     */
+    public TextAsInput(final Text text, final Charset charset) {
         this.source = text;
+        this.charset = charset;
     }
 
     @Override
     public InputStream open() throws IOException {
-        return new ByteArrayInputStream(this.source.asString().getBytes());
+        return new ByteArrayInputStream(
+            this.source.asString().getBytes(this.charset)
+        );
     }
 
 }

--- a/src/test/java/org/cactoos/io/FileAsInputTest.java
+++ b/src/test/java/org/cactoos/io/FileAsInputTest.java
@@ -62,7 +62,10 @@ public final class FileAsInputTest {
             ).asString(),
             Matchers.allOf(
                 Matchers.equalTo(
-                    new InputAsText(new FileAsInput(temp)).asString()
+                    new InputAsText(
+                        new FileAsInput(temp),
+                        StandardCharsets.UTF_8
+                    ).asString()
                 ),
                 Matchers.startsWith("Hello, "),
                 Matchers.endsWith("друг!")

--- a/src/test/java/org/cactoos/io/FileAsInputTest.java
+++ b/src/test/java/org/cactoos/io/FileAsInputTest.java
@@ -26,6 +26,7 @@ package org.cactoos.io;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.cactoos.text.StringAsText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -45,7 +46,7 @@ public final class FileAsInputTest {
      */
     @Test
     public void readsFileContent() throws IOException {
-        final Charset utf = Charset.forName("UTF-8");
+        final Charset utf = StandardCharsets.UTF_8;
         final File temp = File.createTempFile("cactoos", "txt");
         temp.deleteOnExit();
         MatcherAssert.assertThat(

--- a/src/test/java/org/cactoos/io/FileAsInputTest.java
+++ b/src/test/java/org/cactoos/io/FileAsInputTest.java
@@ -25,6 +25,7 @@ package org.cactoos.io;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import org.cactoos.text.StringAsText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -44,14 +45,16 @@ public final class FileAsInputTest {
      */
     @Test
     public void readsFileContent() throws IOException {
+        final Charset utf = Charset.forName("UTF-8");
         final File temp = File.createTempFile("cactoos", "txt");
         temp.deleteOnExit();
         MatcherAssert.assertThat(
             new InputAsText(
                 new TeeInput(
-                    new TextAsInput(new StringAsText("Hello, друг!")),
+                    new TextAsInput(new StringAsText("Hello, друг!"), utf),
                     new FileAsOutput(temp)
-                )
+                ),
+                utf
             ).asString(),
             Matchers.allOf(
                 Matchers.equalTo(

--- a/src/test/java/org/cactoos/io/FileAsInputTest.java
+++ b/src/test/java/org/cactoos/io/FileAsInputTest.java
@@ -25,7 +25,6 @@ package org.cactoos.io;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import org.cactoos.text.StringAsText;
 import org.hamcrest.MatcherAssert;
@@ -34,6 +33,7 @@ import org.junit.Test;
 
 /**
  * Test case for {@link FileAsInput}.
+ *
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$
  * @since 0.1
@@ -42,20 +42,23 @@ public final class FileAsInputTest {
 
     /**
      * FileAsInput can read file content.
+     *
      * @throws IOException If some problem inside
      */
     @Test
     public void readsFileContent() throws IOException {
-        final Charset utf = StandardCharsets.UTF_8;
         final File temp = File.createTempFile("cactoos", "txt");
         temp.deleteOnExit();
         MatcherAssert.assertThat(
             new InputAsText(
                 new TeeInput(
-                    new TextAsInput(new StringAsText("Hello, друг!"), utf),
+                    new TextAsInput(
+                        new StringAsText("Hello, друг!"),
+                        StandardCharsets.UTF_8
+                    ),
                     new FileAsOutput(temp)
                 ),
-                utf
+                StandardCharsets.UTF_8
             ).asString(),
             Matchers.allOf(
                 Matchers.equalTo(
@@ -66,5 +69,4 @@ public final class FileAsInputTest {
             )
         );
     }
-
 }

--- a/src/test/java/org/cactoos/io/InputAsBytesTest.java
+++ b/src/test/java/org/cactoos/io/InputAsBytesTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 
 /**
  * Test case for {@link InputAsBytes}.
+ *
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$
  * @since 0.1
@@ -39,6 +40,7 @@ public final class InputAsBytesTest {
 
     /**
      * InputAsBytes can read input.
+     *
      * @throws IOException If some problem inside
      */
     @Test
@@ -60,6 +62,7 @@ public final class InputAsBytesTest {
 
     /**
      * InputAsBytes can read input with small buffer.
+     *
      * @throws IOException If some problem inside
      */
     @Test

--- a/src/test/java/org/cactoos/io/InputAsBytesTest.java
+++ b/src/test/java/org/cactoos/io/InputAsBytesTest.java
@@ -24,7 +24,7 @@
 package org.cactoos.io;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.cactoos.text.StringAsText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -40,27 +40,21 @@ import org.junit.Test;
 public final class InputAsBytesTest {
 
     /**
-     * UTF-8 encoding.
-     */
-    private static final String UTF8 = "UTF-8";
-
-    /**
      * InputAsBytes can read input.
      *
      * @throws IOException If some problem inside
      */
     @Test
     public void readsInputIntoBytes() throws IOException {
-        final Charset utf = Charset.forName(InputAsBytesTest.UTF8);
         MatcherAssert.assertThat(
             new String(
                 new InputAsBytes(
                     new TextAsInput(
                         new StringAsText("Hello, друг!"),
-                        utf
+                        StandardCharsets.UTF_8
                     )
                 ).asBytes(),
-                utf
+                StandardCharsets.UTF_8
             ),
             Matchers.allOf(
                 Matchers.startsWith("Hello, "),
@@ -76,17 +70,16 @@ public final class InputAsBytesTest {
      */
     @Test
     public void readsInputIntoBytesWithSmallBuffer() throws IOException {
-        final Charset utf = Charset.forName(InputAsBytesTest.UTF8);
         MatcherAssert.assertThat(
             new String(
                 new InputAsBytes(
                     new TextAsInput(
                         new StringAsText("Hello, товарищ!"),
-                        utf
+                        StandardCharsets.UTF_8
                     ),
                     2
                 ).asBytes(),
-                utf
+                StandardCharsets.UTF_8
             ),
             Matchers.allOf(
                 Matchers.startsWith("Hello,"),

--- a/src/test/java/org/cactoos/io/InputAsBytesTest.java
+++ b/src/test/java/org/cactoos/io/InputAsBytesTest.java
@@ -24,6 +24,7 @@
 package org.cactoos.io;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import org.cactoos.text.StringAsText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -39,19 +40,27 @@ import org.junit.Test;
 public final class InputAsBytesTest {
 
     /**
+     * UTF-8 encoding.
+     */
+    private static final String UTF8 = "UTF-8";
+
+    /**
      * InputAsBytes can read input.
      *
      * @throws IOException If some problem inside
      */
     @Test
     public void readsInputIntoBytes() throws IOException {
+        final Charset utf = Charset.forName(InputAsBytesTest.UTF8);
         MatcherAssert.assertThat(
             new String(
                 new InputAsBytes(
                     new TextAsInput(
-                        new StringAsText("Hello, друг!")
+                        new StringAsText("Hello, друг!"),
+                        utf
                     )
-                ).asBytes()
+                ).asBytes(),
+                utf
             ),
             Matchers.allOf(
                 Matchers.startsWith("Hello, "),
@@ -67,14 +76,17 @@ public final class InputAsBytesTest {
      */
     @Test
     public void readsInputIntoBytesWithSmallBuffer() throws IOException {
+        final Charset utf = Charset.forName(InputAsBytesTest.UTF8);
         MatcherAssert.assertThat(
             new String(
                 new InputAsBytes(
                     new TextAsInput(
-                        new StringAsText("Hello, товарищ!")
+                        new StringAsText("Hello, товарищ!"),
+                        utf
                     ),
                     2
-                ).asBytes()
+                ).asBytes(),
+                utf
             ),
             Matchers.allOf(
                 Matchers.startsWith("Hello,"),

--- a/src/test/java/org/cactoos/io/InputAsTextTest.java
+++ b/src/test/java/org/cactoos/io/InputAsTextTest.java
@@ -24,6 +24,7 @@
 package org.cactoos.io;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import org.cactoos.text.StringAsText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -31,6 +32,7 @@ import org.junit.Test;
 
 /**
  * Test case for {@link InputAsText}.
+ *
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$
  * @since 0.1
@@ -38,16 +40,20 @@ import org.junit.Test;
 public final class InputAsTextTest {
 
     /**
-     * InputAsText can read input.
+     * InputAsText can read with specified encoding.
+     *
      * @throws IOException If some problem inside
      */
     @Test
-    public void readsInputIntoText() throws IOException {
+    public void readsInputWithCharsetIntoText() throws IOException {
+        final Charset charset = Charset.forName("KOI8-R");
         MatcherAssert.assertThat(
             new InputAsText(
                 new TextAsInput(
-                    new StringAsText("Hello, друг!")
-                )
+                    new StringAsText("Hello, друг!"),
+                    charset
+                ),
+                charset
             ).asString(),
             Matchers.allOf(
                 Matchers.startsWith("Hello, "),
@@ -55,5 +61,4 @@ public final class InputAsTextTest {
             )
         );
     }
-
 }


### PR DESCRIPTION
Now we are able to use charset to convert bytes to text and vice verse.
Default (`Charset.defaultCharset()`) charset is used in secondary constructors.
Part of #13 