### PR TITLE
#54: Rename open() method in Input/Output interfaces

### DIFF
--- a/src/main/java/org/cactoos/Input.java
+++ b/src/main/java/org/cactoos/Input.java
@@ -55,6 +55,6 @@ public interface Input {
      * @return InputStream to read from
      * @throws IOException If something goes wrong
      */
-    InputStream open() throws IOException;
+    InputStream stream() throws IOException;
 
 }

--- a/src/main/java/org/cactoos/Output.java
+++ b/src/main/java/org/cactoos/Output.java
@@ -61,6 +61,6 @@ public interface Output {
      * @return InputStream to read from
      * @throws IOException If something goes wrong
      */
-    OutputStream open() throws IOException;
+    OutputStream stream() throws IOException;
 
 }

--- a/src/main/java/org/cactoos/io/BytesAsInput.java
+++ b/src/main/java/org/cactoos/io/BytesAsInput.java
@@ -54,7 +54,7 @@ public final class BytesAsInput implements Input {
     }
 
     @Override
-    public InputStream open() throws IOException {
+    public InputStream stream() throws IOException {
         return new ByteArrayInputStream(
             this.source.asBytes()
         );

--- a/src/main/java/org/cactoos/io/DeadInput.java
+++ b/src/main/java/org/cactoos/io/DeadInput.java
@@ -40,8 +40,8 @@ import org.cactoos.text.EmptyBytes;
 public final class DeadInput implements Input {
 
     @Override
-    public InputStream open() throws IOException {
-        return new BytesAsInput(new EmptyBytes()).open();
+    public InputStream stream() throws IOException {
+        return new BytesAsInput(new EmptyBytes()).stream();
     }
 
 }

--- a/src/main/java/org/cactoos/io/DeadOutput.java
+++ b/src/main/java/org/cactoos/io/DeadOutput.java
@@ -38,7 +38,7 @@ import org.cactoos.Output;
 public final class DeadOutput implements Output {
 
     @Override
-    public OutputStream open() {
+    public OutputStream stream() {
         return new OutputStream() {
             @Override
             @SuppressWarnings("PMD.UncommentedEmptyMethodBody")

--- a/src/main/java/org/cactoos/io/FileAsInput.java
+++ b/src/main/java/org/cactoos/io/FileAsInput.java
@@ -54,7 +54,7 @@ public final class FileAsInput implements Input {
     }
 
     @Override
-    public InputStream open() throws FileNotFoundException {
+    public InputStream stream() throws FileNotFoundException {
         return new FileInputStream(this.file);
     }
 

--- a/src/main/java/org/cactoos/io/FileAsOutput.java
+++ b/src/main/java/org/cactoos/io/FileAsOutput.java
@@ -54,7 +54,7 @@ public final class FileAsOutput implements Output {
     }
 
     @Override
-    public OutputStream open() throws FileNotFoundException {
+    public OutputStream stream() throws FileNotFoundException {
         return new FileOutputStream(this.file);
     }
 

--- a/src/main/java/org/cactoos/io/InputAsBytes.java
+++ b/src/main/java/org/cactoos/io/InputAsBytes.java
@@ -75,7 +75,7 @@ public final class InputAsBytes implements Bytes {
             final InputStream stream = new TeeInput(
                 this.source,
                 new OutputStreamAsOutput(baos)
-            ).open();
+            ).stream();
             final byte[] buf = new byte[this.size];
             while (true) {
                 if (stream.read(buf) != buf.length) {

--- a/src/main/java/org/cactoos/io/InputStreamAsInput.java
+++ b/src/main/java/org/cactoos/io/InputStreamAsInput.java
@@ -51,7 +51,7 @@ public final class InputStreamAsInput implements Input {
     }
 
     @Override
-    public InputStream open() {
+    public InputStream stream() {
         return this.input;
     }
 

--- a/src/main/java/org/cactoos/io/LengthOfInput.java
+++ b/src/main/java/org/cactoos/io/LengthOfInput.java
@@ -70,7 +70,7 @@ public final class LengthOfInput implements Scalar<Long> {
 
     @Override
     public Long asValue() throws IOException {
-        final InputStream stream = this.source.open();
+        final InputStream stream = this.source.stream();
         final byte[] buf = new byte[this.size];
         long length = 0L;
         while (true) {

--- a/src/main/java/org/cactoos/io/OutputStreamAsOutput.java
+++ b/src/main/java/org/cactoos/io/OutputStreamAsOutput.java
@@ -51,7 +51,7 @@ public final class OutputStreamAsOutput implements Output {
     }
 
     @Override
-    public OutputStream open() {
+    public OutputStream stream() {
         return this.output;
     }
 

--- a/src/main/java/org/cactoos/io/ResourceAsInput.java
+++ b/src/main/java/org/cactoos/io/ResourceAsInput.java
@@ -72,7 +72,7 @@ public final class ResourceAsInput implements Input {
     }
 
     @Override
-    public InputStream open() throws IOException {
+    public InputStream stream() throws IOException {
         final InputStream input = this.loader.getResourceAsStream(this.path);
         if (input == null) {
             throw new IOException(

--- a/src/main/java/org/cactoos/io/TeeInput.java
+++ b/src/main/java/org/cactoos/io/TeeInput.java
@@ -60,9 +60,9 @@ public final class TeeInput implements Input {
     }
 
     @Override
-    public InputStream open() throws IOException {
+    public InputStream stream() throws IOException {
         return new TeeInputStream(
-            this.source.open(), this.target.open()
+            this.source.stream(), this.target.stream()
         );
     }
 

--- a/src/main/java/org/cactoos/io/UrlAsInput.java
+++ b/src/main/java/org/cactoos/io/UrlAsInput.java
@@ -53,7 +53,7 @@ public final class UrlAsInput implements Input {
     }
 
     @Override
-    public InputStream open() throws IOException {
+    public InputStream stream() throws IOException {
         return this.source.openStream();
     }
 


### PR DESCRIPTION
I renamed `Output` too, due the same reason of renamed `Input` interface.