### PR TITLE
#49: StringUtils methods into org.cactoos.text

### DIFF
--- a/src/main/java/org/cactoos/text/AbbreviatedText.java
+++ b/src/main/java/org/cactoos/text/AbbreviatedText.java
@@ -33,7 +33,7 @@ import org.cactoos.Text;
  *
  * @author Fabricio Cabral (fabriciofx@gmail.com)
  * @version $Id$
- * @since 0.2
+ * @since 0.3
  */
 public final class AbbreviatedText implements Text {
 

--- a/src/main/java/org/cactoos/text/AbbreviatedText.java
+++ b/src/main/java/org/cactoos/text/AbbreviatedText.java
@@ -1,0 +1,93 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.text;
+
+import java.io.IOException;
+import org.cactoos.Text;
+
+/**
+ * Abbreviates a Text using ellipses.
+ *
+ * <p>There is no thread-safety guarantee.
+ *
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.2
+ */
+public final class AbbreviatedText implements Text {
+
+    /**
+     * The text.
+     */
+    private final Text origin;
+
+    /**
+     * The initial position in the text.
+     */
+    private final int offset;
+
+    /**
+     * The max width of the abbreviated text.
+     */
+    private final int width;
+
+    /**
+     * Ctor.
+     * @param text The Text
+     */
+    public AbbreviatedText(final Text text) {
+        // @checkstyle MagicNumber (1 line)
+        this(text, 80);
+    }
+
+    /**
+     * Ctor.
+     * @param text The Text
+     * @param width Width of the result string
+     */
+    public AbbreviatedText(final Text text, final int width) {
+        // @checkstyle MagicNumber (1 line)
+        this(text, 0, width);
+    }
+
+    /**
+     * Ctor.
+     * @param text The Text
+     * @param offset Text position where to start
+     * @param width Width of the result string
+     */
+    public AbbreviatedText(final Text text, final int offset, final int width) {
+        this.origin = text;
+        this.offset = offset;
+        this.width = width;
+    }
+
+    @Override
+    public String asString() throws IOException {
+        return new FormattedText(
+            "%s...",
+            this.origin.asString().substring(this.offset, this.width)
+        ).asString();
+    }
+}

--- a/src/main/java/org/cactoos/text/CapitalizeWordFunc.java
+++ b/src/main/java/org/cactoos/text/CapitalizeWordFunc.java
@@ -23,40 +23,26 @@
  */
 package org.cactoos.text;
 
-import java.io.IOException;
+import org.cactoos.Func;
 import org.cactoos.Text;
-import org.cactoos.list.TransformedIterable;
 
 /**
- * Capitalize the Text.
+ * Func that capitalize a word.
+ *
+ * <p>There is no thread-safety guarantee.
  *
  * @author Fabricio Cabral (fabriciofx@gmail.com)
  * @version $Id$
  * @since 0.3
  */
-public final class CapitalizedText implements Text {
-
-    /**
-     * The text.
-     */
-    private final Text origin;
-
-    /**
-     * Ctor.
-     * @param text A Text
-     */
-    public CapitalizedText(final Text text) {
-        this.origin = text;
-    }
-
+public final class CapitalizeWordFunc implements Func<Text, Text> {
     @Override
-    public String asString() throws IOException {
-        return new JoinedText(
-            new TransformedIterable<Text, Text>(
-                new SplitText(this.origin),
-                new CapitalizeWordFunc()
-            )
-        ).asString();
+    public Text apply(final Text input) throws Exception {
+        return new FormattedText(
+            "%s%s",
+            input.asString().substring(0, 1).toUpperCase(),
+            input.asString().substring(1)
+        );
     }
-}
 
+}

--- a/src/main/java/org/cactoos/text/CapitalizedText.java
+++ b/src/main/java/org/cactoos/text/CapitalizedText.java
@@ -53,15 +53,15 @@ public final class CapitalizedText implements Text {
     @Override
     public String asString() throws IOException {
         return new JoinedText(
-            new TransformedIterable<String, Text>(
+            new TransformedIterable<Text, Text>(
                 new SplitText(this.origin),
-                new Func<String, Text>() {
+                new Func<Text, Text>() {
                     @Override
-                    public Text apply(final String input) throws Exception {
+                    public Text apply(final Text input) throws Exception {
                         return new FormattedText(
                             "%s%s",
-                            input.substring(0, 1).toUpperCase(),
-                            input.substring(1)
+                            input.asString().substring(0, 1).toUpperCase(),
+                            input.asString().substring(1)
                         );
                     }
                 }

--- a/src/main/java/org/cactoos/text/CapitalizedText.java
+++ b/src/main/java/org/cactoos/text/CapitalizedText.java
@@ -1,0 +1,72 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.text;
+
+import java.io.IOException;
+import org.cactoos.Func;
+import org.cactoos.Text;
+import org.cactoos.list.TransformedIterable;
+
+/**
+ * Capitalize the Text.
+ *
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.3
+ */
+public final class CapitalizedText implements Text {
+
+    /**
+     * The text.
+     */
+    private final Text origin;
+
+    /**
+     * Ctor.
+     * @param text A Text
+     */
+    public CapitalizedText(final Text text) {
+        this.origin = text;
+    }
+
+    @Override
+    public String asString() throws IOException {
+        return new JoinedText(
+            new TransformedIterable<String, Text>(
+                new SplitText(this.origin),
+                new Func<String, Text>() {
+                    @Override
+                    public Text apply(final String input) throws Exception {
+                        return new FormattedText(
+                            "%s%s",
+                            input.substring(0, 1).toUpperCase(),
+                            input.substring(1)
+                        );
+                    }
+                }
+            )
+        ).asString();
+    }
+}
+

--- a/src/main/java/org/cactoos/text/JoinedText.java
+++ b/src/main/java/org/cactoos/text/JoinedText.java
@@ -1,0 +1,86 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.text;
+
+import java.io.IOException;
+import java.util.StringJoiner;
+import org.cactoos.Text;
+import org.cactoos.list.ArrayAsIterable;
+
+/**
+ * Join a Text.
+ *
+ * <p>There is no thread-safety guarantee.
+ *
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.2
+ */
+public final class JoinedText implements Text {
+
+    /**
+     * The texts.
+     */
+    private final Iterable<Text> texts;
+
+    /**
+     * The delimiter.
+     */
+    private final String delimiter;
+
+    /**
+     * Ctor.
+     * @param texts Texts to be joined
+     */
+    public JoinedText(final Text... texts) {
+        this(" ", new ArrayAsIterable<>(texts));
+    }
+
+    /**
+     * Ctor.
+     * @param texts Texts to be joined
+     */
+    public JoinedText(final Iterable<Text> texts) {
+        this(" ", texts);
+    }
+
+    /**
+     * Ctor.
+     * @param delimiter Delimit among texts
+     * @param texts Texts to be joined
+     */
+    public JoinedText(final String delimiter, final Iterable<Text> texts) {
+        this.delimiter = delimiter;
+        this.texts = texts;
+    }
+
+    @Override
+    public String asString() throws IOException {
+        final StringJoiner joint = new StringJoiner(this.delimiter);
+        for (final Text text : this.texts) {
+            joint.add(text.asString());
+        }
+        return joint.toString();
+    }
+}

--- a/src/main/java/org/cactoos/text/JoinedText.java
+++ b/src/main/java/org/cactoos/text/JoinedText.java
@@ -47,7 +47,7 @@ public final class JoinedText implements Text {
     /**
      * The delimiter.
      */
-    private final String delimiter;
+    private final Text delimiter;
 
     /**
      * Ctor.
@@ -71,13 +71,22 @@ public final class JoinedText implements Text {
      * @param texts Texts to be joined
      */
     public JoinedText(final String delimiter, final Iterable<Text> texts) {
+        this(new StringAsText(delimiter), texts);
+    }
+
+    /**
+     * Ctor.
+     * @param delimiter Delimit among texts
+     * @param texts Texts to be joined
+     */
+    public JoinedText(final Text delimiter, final Iterable<Text> texts) {
         this.delimiter = delimiter;
         this.texts = texts;
     }
 
     @Override
     public String asString() throws IOException {
-        final StringJoiner joint = new StringJoiner(this.delimiter);
+        final StringJoiner joint = new StringJoiner(this.delimiter.asString());
         for (final Text text : this.texts) {
             joint.add(text.asString());
         }

--- a/src/main/java/org/cactoos/text/JoinedText.java
+++ b/src/main/java/org/cactoos/text/JoinedText.java
@@ -35,7 +35,7 @@ import org.cactoos.list.ArrayAsIterable;
  *
  * @author Fabricio Cabral (fabriciofx@gmail.com)
  * @version $Id$
- * @since 0.2
+ * @since 0.3
  */
 public final class JoinedText implements Text {
 

--- a/src/main/java/org/cactoos/text/NormalizedText.java
+++ b/src/main/java/org/cactoos/text/NormalizedText.java
@@ -1,0 +1,57 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.text;
+
+import java.io.IOException;
+import org.cactoos.Text;
+
+/**
+ * Normalize (replace sequences of whitespace characters by a single space)
+ * a Text.
+ *
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.3
+ */
+public final class NormalizedText implements Text {
+
+    /**
+     * The text.
+     */
+    private final Text origin;
+
+    /**
+     * Ctor.
+     * @param text A Text
+     */
+    public NormalizedText(final Text text) {
+        this.origin = text;
+    }
+
+    @Override
+    public String asString() throws IOException {
+        return new TrimmedText(this.origin).asString().replaceAll("\\s+", " ");
+    }
+}
+

--- a/src/main/java/org/cactoos/text/RepeatedText.java
+++ b/src/main/java/org/cactoos/text/RepeatedText.java
@@ -1,0 +1,68 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.text;
+
+import java.io.IOException;
+import org.cactoos.Text;
+
+/**
+ * Repeat an text count times.
+ *
+ * <p>There is no thread-safety guarantee.
+ *
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.3
+ */
+public final class RepeatedText implements Text {
+
+    /**
+     * The text.
+     */
+    private final Text origin;
+
+    /**
+     * How many times repeat the Text.
+     */
+    private final int count;
+
+    /**
+     * Ctor.
+     * @param text The Text
+     * @param count How many times repeat the Text
+     */
+    public RepeatedText(final Text text, final int count) {
+        this.origin = text;
+        this.count = count;
+    }
+
+    @Override
+    public String asString() throws IOException {
+        final StringBuilder out = new StringBuilder(0);
+        for (int cnt = 0; cnt < this.count; ++cnt) {
+            out.append(this.origin.asString());
+        }
+        return out.toString();
+    }
+}

--- a/src/main/java/org/cactoos/text/SplitText.java
+++ b/src/main/java/org/cactoos/text/SplitText.java
@@ -39,7 +39,7 @@ import org.cactoos.Text;
  * @version $Id$
  * @since 0.3
  */
-public final class SplitedText implements Iterable<String> {
+public final class SplitText implements Iterable<String> {
 
     /**
      * The text.
@@ -60,7 +60,7 @@ public final class SplitedText implements Iterable<String> {
      * Ctor.
      * @param text The text
      */
-    public SplitedText(final Text text) {
+    public SplitText(final Text text) {
         this(text, " ");
     }
 
@@ -69,7 +69,7 @@ public final class SplitedText implements Iterable<String> {
      * @param text The text
      * @param pattern The pattern used to split
      */
-    public SplitedText(final Text text, final String pattern) {
+    public SplitText(final Text text, final String pattern) {
         this(text, pattern, Integer.MAX_VALUE);
     }
 
@@ -79,7 +79,7 @@ public final class SplitedText implements Iterable<String> {
      * @param pattern The pattern used to split
      * @param limit The max limit of pieces
      */
-    public SplitedText(final Text text, final String pattern, final int limit) {
+    public SplitText(final Text text, final String pattern, final int limit) {
         this.origin = text;
         this.pattern = pattern;
         this.limit = limit;

--- a/src/main/java/org/cactoos/text/SplitText.java
+++ b/src/main/java/org/cactoos/text/SplitText.java
@@ -25,10 +25,9 @@ package org.cactoos.text;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.Arrays;
 import java.util.Iterator;
-import java.util.stream.Collectors;
 import org.cactoos.Text;
+import org.cactoos.list.ArrayAsIterable;
 
 /**
  * Split a Text.
@@ -88,12 +87,10 @@ public final class SplitText implements Iterable<String> {
     @Override
     public Iterator<String> iterator() {
         try {
-            return Arrays.stream(
+            return new ArrayAsIterable<>(
                 this.origin.asString()
                 .split(this.pattern, this.limit)
-            )
-            .collect(Collectors.toList())
-            .iterator();
+            ).iterator();
         } catch (final IOException ex) {
             throw new UncheckedIOException(ex);
         }

--- a/src/main/java/org/cactoos/text/SplitText.java
+++ b/src/main/java/org/cactoos/text/SplitText.java
@@ -26,7 +26,6 @@ package org.cactoos.text;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Iterator;
-import org.cactoos.Func;
 import org.cactoos.Text;
 import org.cactoos.list.ArrayAsIterable;
 import org.cactoos.list.TransformedIterable;
@@ -94,12 +93,7 @@ public final class SplitText implements Iterable<Text> {
                     this.origin.asString()
                     .split(this.pattern, this.limit)
                 ),
-                new Func<String, Text>() {
-                    @Override
-                    public Text apply(final String input) throws Exception {
-                        return new StringAsText(input);
-                    }
-                }
+                new StringAsTextFunc()
             ).iterator();
         } catch (final IOException ex) {
             throw new UncheckedIOException(ex);

--- a/src/main/java/org/cactoos/text/SplitText.java
+++ b/src/main/java/org/cactoos/text/SplitText.java
@@ -26,8 +26,10 @@ package org.cactoos.text;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Iterator;
+import org.cactoos.Func;
 import org.cactoos.Text;
 import org.cactoos.list.ArrayAsIterable;
+import org.cactoos.list.TransformedIterable;
 
 /**
  * Split a Text.
@@ -38,7 +40,7 @@ import org.cactoos.list.ArrayAsIterable;
  * @version $Id$
  * @since 0.3
  */
-public final class SplitText implements Iterable<String> {
+public final class SplitText implements Iterable<Text> {
 
     /**
      * The text.
@@ -85,11 +87,19 @@ public final class SplitText implements Iterable<String> {
     }
 
     @Override
-    public Iterator<String> iterator() {
+    public Iterator<Text> iterator() {
         try {
-            return new ArrayAsIterable<>(
-                this.origin.asString()
-                .split(this.pattern, this.limit)
+            return new TransformedIterable<>(
+                new ArrayAsIterable<>(
+                    this.origin.asString()
+                    .split(this.pattern, this.limit)
+                ),
+                new Func<String, Text>() {
+                    @Override
+                    public Text apply(final String input) throws Exception {
+                        return new StringAsText(input);
+                    }
+                }
             ).iterator();
         } catch (final IOException ex) {
             throw new UncheckedIOException(ex);

--- a/src/main/java/org/cactoos/text/SplitedText.java
+++ b/src/main/java/org/cactoos/text/SplitedText.java
@@ -24,8 +24,11 @@
 package org.cactoos.text;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.stream.Collectors;
 import org.cactoos.Text;
-import org.cactoos.list.ArrayAsIterable;
 
 /**
  * Split a Text.
@@ -34,9 +37,9 @@ import org.cactoos.list.ArrayAsIterable;
  *
  * @author Fabricio Cabral (fabriciofx@gmail.com)
  * @version $Id$
- * @since 0.1
+ * @since 0.3
  */
-public final class SplitedText implements Text {
+public final class SplitedText implements Text, Iterable<Text> {
 
     /**
      * The text.
@@ -90,12 +93,20 @@ public final class SplitedText implements Text {
     /**
      * Split the Text.
      * @return The pieces of Text
-     * @throws IOException If fails
      */
-    public Iterable<String> pieces() throws IOException {
-        return new ArrayAsIterable<>(
-            this.origin.asString().split(this.pattern, this.limit)
-        );
+    @Override
+    public Iterator<Text> iterator() {
+        try {
+            return Arrays.stream(
+                this.origin.asString()
+                .split(this.pattern, this.limit)
+            )
+            .map(s -> new StringAsText(s))
+            .collect(Collectors.<Text>toList())
+            .iterator();
+        } catch (final IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
     }
 
 }

--- a/src/main/java/org/cactoos/text/SplitedText.java
+++ b/src/main/java/org/cactoos/text/SplitedText.java
@@ -1,0 +1,101 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.text;
+
+import java.io.IOException;
+import org.cactoos.Text;
+import org.cactoos.list.ArrayAsIterable;
+
+/**
+ * Split a Text.
+ *
+ * <p>There is no thread-safety guarantee.
+ *
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.1
+ */
+public final class SplitedText implements Text {
+
+    /**
+     * The text.
+     */
+    private final Text origin;
+
+    /**
+     * The pattern separator.
+     */
+    private final String pattern;
+
+    /**
+     * The limit of pieces.
+     */
+    private final int limit;
+
+    /**
+     * Ctor.
+     * @param text The text
+     */
+    public SplitedText(final Text text) {
+        this(text, " ");
+    }
+
+    /**
+     * Ctor.
+     * @param text The text
+     * @param pattern The pattern used to split
+     */
+    public SplitedText(final Text text, final String pattern) {
+        this(text, pattern, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Ctor.
+     * @param text The text
+     * @param pattern The pattern used to split
+     * @param limit The max limit of pieces
+     */
+    public SplitedText(final Text text, final String pattern, final int limit) {
+        this.origin = text;
+        this.pattern = pattern;
+        this.limit = limit;
+    }
+
+    @Override
+    public String asString() throws IOException {
+        return this.origin.asString();
+    }
+
+    /**
+     * Split the Text.
+     * @return The pieces of Text
+     * @throws IOException If fails
+     */
+    public Iterable<String> pieces() throws IOException {
+        return new ArrayAsIterable<>(
+            this.origin.asString().split(this.pattern, this.limit)
+        );
+    }
+
+}

--- a/src/main/java/org/cactoos/text/SplitedText.java
+++ b/src/main/java/org/cactoos/text/SplitedText.java
@@ -39,7 +39,7 @@ import org.cactoos.Text;
  * @version $Id$
  * @since 0.3
  */
-public final class SplitedText implements Text, Iterable<Text> {
+public final class SplitedText implements Iterable<String> {
 
     /**
      * The text.
@@ -86,23 +86,13 @@ public final class SplitedText implements Text, Iterable<Text> {
     }
 
     @Override
-    public String asString() throws IOException {
-        return this.origin.asString();
-    }
-
-    /**
-     * Split the Text.
-     * @return The pieces of Text
-     */
-    @Override
-    public Iterator<Text> iterator() {
+    public Iterator<String> iterator() {
         try {
             return Arrays.stream(
                 this.origin.asString()
                 .split(this.pattern, this.limit)
             )
-            .map(s -> new StringAsText(s))
-            .collect(Collectors.<Text>toList())
+            .collect(Collectors.toList())
             .iterator();
         } catch (final IOException ex) {
             throw new UncheckedIOException(ex);

--- a/src/main/java/org/cactoos/text/StringAsText.java
+++ b/src/main/java/org/cactoos/text/StringAsText.java
@@ -53,12 +53,5 @@ public final class StringAsText implements Text {
     public String asString() {
         return this.source;
     }
-    
-    @Override
-    public boolean equals(final Object text) {
-        return text != null
-            && text instanceof StringAsText
-            && StringAsText.class.cast(text).asString().equals(this.source);
-    }
 
 }

--- a/src/main/java/org/cactoos/text/StringAsText.java
+++ b/src/main/java/org/cactoos/text/StringAsText.java
@@ -54,4 +54,17 @@ public final class StringAsText implements Text {
         return this.source;
     }
 
+    @Override
+    public boolean equals(final Object text) {
+        return text != null
+            && text instanceof StringAsText
+            && StringAsText.class.cast(text).source.equals(this.source);
+    }
+
+    @Override
+    public int hashCode() {
+        // @checkstyle MagicNumber (1 line)
+        return 31 * this.source.hashCode();
+    }
+
 }

--- a/src/main/java/org/cactoos/text/StringAsText.java
+++ b/src/main/java/org/cactoos/text/StringAsText.java
@@ -53,5 +53,12 @@ public final class StringAsText implements Text {
     public String asString() {
         return this.source;
     }
+    
+    @Override
+    public boolean equals(final Object text) {
+        return text != null
+            && text instanceof StringAsText
+            && StringAsText.class.cast(text).asString().equals(this.source);
+    }
 
 }

--- a/src/main/java/org/cactoos/text/StringAsTextFunc.java
+++ b/src/main/java/org/cactoos/text/StringAsTextFunc.java
@@ -1,0 +1,44 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.text;
+
+import org.cactoos.Func;
+import org.cactoos.Text;
+
+/**
+ * Func that converts a string to Text.
+ *
+ * <p>There is no thread-safety guarantee.
+ *
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.3
+ */
+public final class StringAsTextFunc implements Func<String, Text> {
+    @Override
+    public Text apply(final String input) throws Exception {
+        return new StringAsText(input);
+    }
+
+}

--- a/src/main/java/org/cactoos/text/SubText.java
+++ b/src/main/java/org/cactoos/text/SubText.java
@@ -1,0 +1,71 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.text;
+
+import java.io.IOException;
+import org.cactoos.Text;
+
+/**
+ * Extract a sub Text from a Text.
+ *
+ * <p>There is no thread-safety guarantee.
+ *
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.3
+ */
+public final class SubText implements Text {
+
+    /**
+     * The text.
+     */
+    private final Text origin;
+
+    /**
+     * The start position in the text.
+     */
+    private final int start;
+
+    /**
+     * The end position in the text.
+     */
+    private final int end;
+
+    /**
+     * Ctor.
+     * @param text The Text
+     * @param start Start position in the text
+     * @param end End position in the text
+     */
+    public SubText(final Text text, final int start, final int end) {
+        this.origin = text;
+        this.start = start;
+        this.end = end;
+    }
+
+    @Override
+    public String asString() throws IOException {
+        return this.origin.asString().substring(this.start, this.end);
+    }
+}

--- a/src/main/java/org/cactoos/text/TruncatedText.java
+++ b/src/main/java/org/cactoos/text/TruncatedText.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import org.cactoos.Text;
 
 /**
- * Abbreviates a Text using ellipses.
+ * Truncate a Text to a max width.
  *
  * <p>There is no thread-safety guarantee.
  *
@@ -35,20 +35,30 @@ import org.cactoos.Text;
  * @version $Id$
  * @since 0.3
  */
-public final class AbbreviatedText implements Text {
+public final class TruncatedText implements Text {
 
     /**
-     * The truncated text.
+     * The text.
      */
     private final Text origin;
+
+    /**
+     * The initial position in the text.
+     */
+    private final int offset;
+
+    /**
+     * The max width of the text.
+     */
+    private final int width;
 
     /**
      * Ctor.
      * @param text The Text
      */
-    public AbbreviatedText(final Text text) {
+    public TruncatedText(final Text text) {
         // @checkstyle MagicNumber (1 line)
-        this(text, 0, 77);
+        this(text, 80);
     }
 
     /**
@@ -56,7 +66,7 @@ public final class AbbreviatedText implements Text {
      * @param text The Text
      * @param width Width of the result string
      */
-    public AbbreviatedText(final Text text, final int width) {
+    public TruncatedText(final Text text, final int width) {
         // @checkstyle MagicNumber (1 line)
         this(text, 0, width);
     }
@@ -67,23 +77,14 @@ public final class AbbreviatedText implements Text {
      * @param offset Text position where to start
      * @param width Width of the result string
      */
-    public AbbreviatedText(final Text text, final int offset, final int width) {
-        this(new TruncatedText(text, offset, width));
-    }
-
-    /**
-     * Ctor.
-     * @param text The truncated Text
-     */
-    public AbbreviatedText(final TruncatedText text) {
+    public TruncatedText(final Text text, final int offset, final int width) {
         this.origin = text;
+        this.offset = offset;
+        this.width = width;
     }
 
     @Override
     public String asString() throws IOException {
-        return new FormattedText(
-            "%s...",
-            this.origin.asString()
-        ).asString();
+        return this.origin.asString().substring(this.offset, this.width);
     }
 }

--- a/src/test/java/org/cactoos/text/AbbreviatedTextTest.java
+++ b/src/test/java/org/cactoos/text/AbbreviatedTextTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
  * Test case for {@link AbbreviatedText}.
  * @author Fabricio Cabral (fabriciofx@gmail.com)
  * @version $Id$
- * @since 0.2
+ * @since 0.3
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 public final class AbbreviatedTextTest {

--- a/src/test/java/org/cactoos/text/AbbreviatedTextTest.java
+++ b/src/test/java/org/cactoos/text/AbbreviatedTextTest.java
@@ -1,0 +1,49 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.text;
+
+import org.cactoos.TextHasString;
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+
+/**
+ * Test case for {@link AbbreviatedText}.
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.2
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class AbbreviatedTextTest {
+
+    @Test
+    public void abbreviatesText() {
+        MatcherAssert.assertThat(
+            "Can't abbreviated a text",
+            // @checkstyle MagicNumber (1 line)
+            new AbbreviatedText(new StringAsText("Hello World"), 5),
+            new TextHasString("Hello...")
+        );
+    }
+
+}

--- a/src/test/java/org/cactoos/text/CapitalizeWordFuncTest.java
+++ b/src/test/java/org/cactoos/text/CapitalizeWordFuncTest.java
@@ -1,0 +1,48 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.text;
+
+import org.cactoos.TextHasString;
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+
+/**
+ * Test case for {@link CapitalizeWordFunc}.
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.3
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class CapitalizeWordFuncTest {
+
+    @Test
+    public void capitalizesWord() throws Exception {
+        MatcherAssert.assertThat(
+            "Can't capitalize a word",
+            new CapitalizeWordFunc().apply(new StringAsText("hello")),
+            new TextHasString("Hello")
+        );
+    }
+
+}

--- a/src/test/java/org/cactoos/text/CapitalizedTextTest.java
+++ b/src/test/java/org/cactoos/text/CapitalizedTextTest.java
@@ -1,0 +1,62 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.text;
+
+import java.io.IOException;
+import org.cactoos.TextHasString;
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+
+/**
+ * Test case for {@link CapitalizedText}.
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.3
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class CapitalizedTextTest {
+
+    @Test
+    public void capitalizesText() throws IOException {
+        MatcherAssert.assertThat(
+            "Can't capitalize a text",
+            new CapitalizedText(
+                new StringAsText("hello")
+            ),
+            new TextHasString("Hello")
+        );
+    }
+
+    @Test
+    public void capitalizesManyText() throws IOException {
+        MatcherAssert.assertThat(
+            "Can't capitalize many texts",
+            new CapitalizedText(
+                new StringAsText("one two three four five")
+            ),
+            new TextHasString("One Two Three Four Five")
+        );
+    }
+
+}

--- a/src/test/java/org/cactoos/text/JoinedTextTest.java
+++ b/src/test/java/org/cactoos/text/JoinedTextTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
  * Test case for {@link JoinedText}.
  * @author Fabricio Cabral (fabriciofx@gmail.com)
  * @version $Id$
- * @since 0.2
+ * @since 0.3
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 public final class JoinedTextTest {

--- a/src/test/java/org/cactoos/text/JoinedTextTest.java
+++ b/src/test/java/org/cactoos/text/JoinedTextTest.java
@@ -1,0 +1,59 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.text;
+
+import java.io.IOException;
+import org.cactoos.Text;
+import org.cactoos.TextHasString;
+import org.cactoos.list.ArrayAsIterable;
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+
+/**
+ * Test case for {@link JoinedText}.
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.2
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class JoinedTextTest {
+
+    @Test
+    public void joinesText() throws IOException {
+        MatcherAssert.assertThat(
+            "Can't join a text",
+            new JoinedText(
+                new ArrayAsIterable<Text>(
+                    new StringAsText("one"),
+                    new StringAsText("two"),
+                    new StringAsText("three"),
+                    new StringAsText("four"),
+                    new StringAsText("five")
+                )
+            ),
+            new TextHasString("one two three four five")
+        );
+    }
+
+}

--- a/src/test/java/org/cactoos/text/NormalizedTextTest.java
+++ b/src/test/java/org/cactoos/text/NormalizedTextTest.java
@@ -1,0 +1,51 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.text;
+
+import java.io.IOException;
+import org.cactoos.TextHasString;
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+
+/**
+ * Test case for {@link NormalizedText}.
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.3
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class NormalizedTextTest {
+
+    @Test
+    public void normalizesText() throws IOException {
+        MatcherAssert.assertThat(
+            "Can't normalize a text",
+            new NormalizedText(
+                new StringAsText(" \t Hello  \t\tWorld   ")
+            ),
+            new TextHasString("Hello World")
+        );
+    }
+
+}

--- a/src/test/java/org/cactoos/text/RepeatedTextTest.java
+++ b/src/test/java/org/cactoos/text/RepeatedTextTest.java
@@ -1,0 +1,58 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.text;
+
+import org.cactoos.TextHasString;
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+
+/**
+ * Test case for {@link RepeatedText}.
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.3
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class RepeatedTextTest {
+
+    @Test
+    public void repeatsWordsText() {
+        MatcherAssert.assertThat(
+            "Can't repeats a text",
+            // @checkstyle MagicNumber (1 line)
+            new RepeatedText(new StringAsText("Hello"), 2),
+            new TextHasString("HelloHello")
+        );
+    }
+
+    @Test
+    public void repeatsCharText() {
+        MatcherAssert.assertThat(
+            "Can't repeats a char",
+            // @checkstyle MagicNumber (1 line)
+            new RepeatedText(new StringAsText("A"), 5),
+            new TextHasString("AAAAA")
+        );
+    }
+}

--- a/src/test/java/org/cactoos/text/SplitTextTest.java
+++ b/src/test/java/org/cactoos/text/SplitTextTest.java
@@ -29,19 +29,19 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
- * Test case for {@link SplitedText}.
+ * Test case for {@link SplitText}.
  * @author Fabricio Cabral (fabriciofx@gmail.com)
  * @version $Id$
  * @since 0.3
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class SplitedTextTest {
+public final class SplitTextTest {
 
     @Test
     public void splitsText() throws IOException {
         MatcherAssert.assertThat(
             "Can't split a text",
-            new SplitedText(
+            new SplitText(
                 new StringAsText("one two three four five")
             ),
             Matchers.contains("one", "two", "three", "four", "five")
@@ -52,7 +52,7 @@ public final class SplitedTextTest {
     public void splitsEmptyText() throws IOException {
         MatcherAssert.assertThat(
             "Can't split an empty text",
-            new SplitedText(
+            new SplitText(
                 new StringAsText("")
             ),
             Matchers.contains("")

--- a/src/test/java/org/cactoos/text/SplitTextTest.java
+++ b/src/test/java/org/cactoos/text/SplitTextTest.java
@@ -44,7 +44,13 @@ public final class SplitTextTest {
             new SplitText(
                 new StringAsText("one two three four five")
             ),
-            Matchers.contains("one", "two", "three", "four", "five")
+            Matchers.contains(
+                new StringAsText("one"),
+                new StringAsText("two"),
+                new StringAsText("three"),
+                new StringAsText("four"),
+                new StringAsText("five")
+             )
         );
     }
 
@@ -55,7 +61,7 @@ public final class SplitTextTest {
             new SplitText(
                 new StringAsText("")
             ),
-            Matchers.contains("")
+            Matchers.contains(new StringAsText(""))
         );
     }
 

--- a/src/test/java/org/cactoos/text/SplitedTextTest.java
+++ b/src/test/java/org/cactoos/text/SplitedTextTest.java
@@ -32,30 +32,36 @@ import org.junit.Test;
  * Test case for {@link SplitedText}.
  * @author Fabricio Cabral (fabriciofx@gmail.com)
  * @version $Id$
- * @since 0.2
+ * @since 0.3
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 public final class SplitedTextTest {
 
     @Test
-    public void abbreviatesText() throws IOException {
+    public void splitsText() throws IOException {
         MatcherAssert.assertThat(
             "Can't split a text",
             new SplitedText(
                 new StringAsText("one two three four five")
-            ).pieces(),
-            Matchers.contains("one", "two", "three", "four", "five")
+            ),
+            Matchers.containsInAnyOrder(
+                new StringAsText("one"),
+                new StringAsText("two"),
+                new StringAsText("three"),
+                new StringAsText("four"),
+                new StringAsText("five")
+            )
         );
     }
 
     @Test
-    public void abbreviatesEmptyText() throws IOException {
+    public void splitsEmptyText() throws IOException {
         MatcherAssert.assertThat(
             "Can't split an empty text",
             new SplitedText(
                 new StringAsText("")
-            ).pieces(),
-            Matchers.contains("")
+            ),
+            Matchers.contains(new StringAsText(""))
         );
     }
 

--- a/src/test/java/org/cactoos/text/SplitedTextTest.java
+++ b/src/test/java/org/cactoos/text/SplitedTextTest.java
@@ -1,0 +1,62 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.text;
+
+import java.io.IOException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link SplitedText}.
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.2
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class SplitedTextTest {
+
+    @Test
+    public void abbreviatesText() throws IOException {
+        MatcherAssert.assertThat(
+            "Can't split a text",
+            new SplitedText(
+                new StringAsText("one two three four five")
+            ).pieces(),
+            Matchers.contains("one", "two", "three", "four", "five")
+        );
+    }
+
+    @Test
+    public void abbreviatesEmptyText() throws IOException {
+        MatcherAssert.assertThat(
+            "Can't split an empty text",
+            new SplitedText(
+                new StringAsText("")
+            ).pieces(),
+            Matchers.contains("")
+        );
+    }
+
+}

--- a/src/test/java/org/cactoos/text/SplitedTextTest.java
+++ b/src/test/java/org/cactoos/text/SplitedTextTest.java
@@ -44,13 +44,7 @@ public final class SplitedTextTest {
             new SplitedText(
                 new StringAsText("one two three four five")
             ),
-            Matchers.containsInAnyOrder(
-                new StringAsText("one"),
-                new StringAsText("two"),
-                new StringAsText("three"),
-                new StringAsText("four"),
-                new StringAsText("five")
-            )
+            Matchers.contains("one", "two", "three", "four", "five")
         );
     }
 
@@ -61,7 +55,7 @@ public final class SplitedTextTest {
             new SplitedText(
                 new StringAsText("")
             ),
-            Matchers.contains(new StringAsText(""))
+            Matchers.contains("")
         );
     }
 

--- a/src/test/java/org/cactoos/text/StringAsTextFuncTest.java
+++ b/src/test/java/org/cactoos/text/StringAsTextFuncTest.java
@@ -37,9 +37,10 @@ import org.junit.Test;
 public final class StringAsTextFuncTest {
 
     @Test
+    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
     public void convertsStringToText() throws Exception {
         MatcherAssert.assertThat(
-            "Can't capitalize a word",
+            "Can't convert a string to a Text",
             new StringAsTextFunc().apply("Hello"),
             new TextHasString("Hello")
         );

--- a/src/test/java/org/cactoos/text/StringAsTextFuncTest.java
+++ b/src/test/java/org/cactoos/text/StringAsTextFuncTest.java
@@ -1,0 +1,48 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.text;
+
+import org.cactoos.TextHasString;
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+
+/**
+ * Test case for {@link StringAsTextFunc}.
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.3
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class StringAsTextFuncTest {
+
+    @Test
+    public void convertsStringToText() throws Exception {
+        MatcherAssert.assertThat(
+            "Can't capitalize a word",
+            new StringAsTextFunc().apply("Hello"),
+            new TextHasString("Hello")
+        );
+    }
+
+}

--- a/src/test/java/org/cactoos/text/SubTextTest.java
+++ b/src/test/java/org/cactoos/text/SubTextTest.java
@@ -1,0 +1,49 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.text;
+
+import org.cactoos.TextHasString;
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+
+/**
+ * Test case for {@link SubText}.
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.3
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class SubTextTest {
+
+    @Test
+    public void subsText() {
+        MatcherAssert.assertThat(
+            "Can't cut a text",
+            // @checkstyle MagicNumber (1 line)
+            new SubText(new StringAsText("Hello World"), 2, 9),
+            new TextHasString("llo Wor")
+        );
+    }
+
+}

--- a/src/test/java/org/cactoos/text/TruncatedTextTest.java
+++ b/src/test/java/org/cactoos/text/TruncatedTextTest.java
@@ -1,0 +1,49 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.text;
+
+import org.cactoos.TextHasString;
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+
+/**
+ * Test case for {@link TruncatedText}.
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.3
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class TruncatedTextTest {
+
+    @Test
+    public void truncatesText() {
+        MatcherAssert.assertThat(
+            "Can't truncated a text",
+            // @checkstyle MagicNumber (1 line)
+            new TruncatedText(new StringAsText("Hello World"), 8),
+            new TextHasString("Hello Wo")
+        );
+    }
+
+}


### PR DESCRIPTION
As per #49:

- `AbbreviatedText` introduced
- `SplitText` introduced
- `JoinedText` introduced
- `CapitalizedText` introduced
- `TruncatedText` introduced
- `SubText` introduced
- `RepeatedText` introduced
- `NormalizedText` introduced