### PR TITLE
Removed remove() operation from FilteredIterator

### DIFF
--- a/src/main/java/org/cactoos/list/FilteredIterator.java
+++ b/src/main/java/org/cactoos/list/FilteredIterator.java
@@ -108,7 +108,9 @@ public final class FilteredIterator<X> implements Iterator<X> {
 
     @Override
     public void remove() {
-        this.iterator.remove();
+        throw new UnsupportedOperationException(
+            "FilteredIterator does not support remove Operation"
+        );
     }
 
 }


### PR DESCRIPTION
FilteredIterator can not support remove() operation at the current time in a correct way since it needs to look ahead on the underlying iterator.

Also read this Issue #82 