### PR TITLE
#53 IterableAsList needs cached size()

### DIFF
--- a/src/main/java/org/cactoos/func/CachedScalar.java
+++ b/src/main/java/org/cactoos/func/CachedScalar.java
@@ -1,0 +1,69 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.func;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.cactoos.Scalar;
+
+/**
+ * Cached version of a Scalar.
+ *
+ * <p>There is no thread-safety guarantee.
+ *
+ * @author Tim Hinkes (timmeey@timmeey.de)
+ * @version $Id$
+ * @param <T> Type of result
+ * @since 0.3
+ */
+public final class CachedScalar<T> implements Scalar<T> {
+
+    /**
+     * The scalar to cache.
+     */
+    private final Scalar<T> source;
+
+    /**
+     * The list used as a optional value.
+     */
+    private final List<T> cache;
+
+    /**
+     * Ctor.
+     * @param source The Scalar to cache
+     */
+    public CachedScalar(final Scalar<T> source) {
+        this.source = source;
+        this.cache = new ArrayList<>(1);
+    }
+
+    @Override
+    public T asValue() throws IOException {
+        if (this.cache.isEmpty()) {
+            this.cache.add(this.source.asValue());
+        }
+        return this.cache.get(0);
+    }
+}

--- a/src/main/java/org/cactoos/func/UncheckedScalar.java
+++ b/src/main/java/org/cactoos/func/UncheckedScalar.java
@@ -1,0 +1,64 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.func;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import org.cactoos.Scalar;
+
+/**
+ * Scalar that doesn't throw checked {@link Exception}.
+ *
+ * <p>There is no thread-safety guarantee.
+ *
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @param <T> Type of result
+ * @since 0.3
+ */
+public final class UncheckedScalar<T> implements Scalar<T> {
+
+    /**
+     * Original scalar.
+     */
+    private final Scalar<T> scalar;
+
+    /**
+     * Ctor.
+     * @param scalar Encapsulated scalar
+     */
+    public UncheckedScalar(final Scalar<T> scalar) {
+        this.scalar = scalar;
+    }
+
+    @Override
+    public T asValue() {
+        try {
+            return this.scalar.asValue();
+        } catch (final IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+    }
+
+}

--- a/src/main/java/org/cactoos/io/UncheckedBytes.java
+++ b/src/main/java/org/cactoos/io/UncheckedBytes.java
@@ -1,0 +1,63 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.io;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import org.cactoos.Bytes;
+
+/**
+ * Bytes that doesn't throw checked {@link Exception}.
+ *
+ * <p>There is no thread-safety guarantee.
+ *
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.3
+ */
+public final class UncheckedBytes implements Bytes {
+
+    /**
+     * Original bytes.
+     */
+    private final Bytes bytes;
+
+    /**
+     * Ctor.
+     * @param bytes Encapsulated bytes
+     */
+    public UncheckedBytes(final Bytes bytes) {
+        this.bytes = bytes;
+    }
+
+    @Override
+    public byte[] asBytes() {
+        try {
+            return this.bytes.asBytes();
+        } catch (final IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+    }
+
+}

--- a/src/main/java/org/cactoos/list/IterableAsList.java
+++ b/src/main/java/org/cactoos/list/IterableAsList.java
@@ -26,6 +26,8 @@ package org.cactoos.list;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.List;
+import org.cactoos.func.CachedScalar;
+import org.cactoos.func.UncheckedScalar;
 import org.cactoos.text.FormattedText;
 
 /**
@@ -52,12 +54,8 @@ public final class IterableAsList<T> extends AbstractList<T> {
 
     /**
      * Iterable length.
-     *
-     * @todo #39:30m Needs cached `LengthOfIterable` version
-     *  to improve `IterableAsList` performance. Now each call
-     *  to `size()` goes through all iterable to calculate the size.
      */
-    private final LengthOfIterable length;
+    private final UncheckedScalar<Integer> length;
 
     /**
      * Ctor.
@@ -68,7 +66,11 @@ public final class IterableAsList<T> extends AbstractList<T> {
         super();
         this.source = iterable;
         this.cache = new ArrayList<>(0);
-        this.length = new LengthOfIterable(iterable);
+        this.length = new UncheckedScalar<>(
+            new CachedScalar<>(
+                new LengthOfIterable(iterable)
+            )
+        );
     }
 
     @Override

--- a/src/main/java/org/cactoos/text/UncheckedText.java
+++ b/src/main/java/org/cactoos/text/UncheckedText.java
@@ -1,0 +1,63 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.text;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import org.cactoos.Text;
+
+/**
+ * Text that doesn't throw checked {@link Exception}.
+ *
+ * <p>There is no thread-safety guarantee.
+ *
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.3
+ */
+public final class UncheckedText implements Text {
+
+    /**
+     * Original text.
+     */
+    private final Text text;
+
+    /**
+     * Ctor.
+     * @param text Encapsulated text
+     */
+    public UncheckedText(final Text text) {
+        this.text = text;
+    }
+
+    @Override
+    public String asString() {
+        try {
+            return this.text.asString();
+        } catch (final IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+    }
+
+}

--- a/src/test/java/org/cactoos/func/UncheckedScalarTest.java
+++ b/src/test/java/org/cactoos/func/UncheckedScalarTest.java
@@ -1,0 +1,48 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.func;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * Test case for {@link UncheckedScalar}.
+ *
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.3
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class UncheckedScalarTest {
+
+    @Test(expected = RuntimeException.class)
+    public void rethrowsCheckedToUncheckedException() {
+        new UncheckedScalar<>(
+            () -> {
+                throw new IOException("intended");
+            }
+        ).asValue();
+    }
+
+}

--- a/src/test/java/org/cactoos/io/UncheckedBytesTest.java
+++ b/src/test/java/org/cactoos/io/UncheckedBytesTest.java
@@ -1,0 +1,48 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.io;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * Test case for {@link UncheckedBytes}.
+ *
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.3
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class UncheckedBytesTest {
+
+    @Test(expected = RuntimeException.class)
+    public void rethrowsCheckedToUncheckedException() {
+        new UncheckedBytes(
+            () -> {
+                throw new IOException("intended");
+            }
+        ).asBytes();
+    }
+
+}

--- a/src/test/java/org/cactoos/text/UncheckedTextTest.java
+++ b/src/test/java/org/cactoos/text/UncheckedTextTest.java
@@ -1,0 +1,48 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.text;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * Test case for {@link UncheckedText}.
+ *
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.3
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class UncheckedTextTest {
+
+    @Test(expected = RuntimeException.class)
+    public void rethrowsCheckedToUncheckedException() {
+        new UncheckedText(
+            () -> {
+                throw new IOException("intended");
+            }
+        ).asString();
+    }
+
+}


### PR DESCRIPTION
This PR is based on PR #81 (would need to be merged prior to this PR) due to the usage of UncheckedScalar to be able to use CachedScalar class in a safe way (without requiring to declare size() an unsafe operation).
Closes #53 

Reasoning about the placement of the cache into IterableAsList and not into LengthOfIterable/LengthOfIterator

- LengthOfIterator: is a one-time use Object, it consumes the Iterator, therefore caching would alter how this works
- LengthOfIterable: Seemed a good spot, but the underlying iterable could change, therefore making the cached value inconsistent
- IterableAsList: Same argument here, the underlying iterable could change, but if it would change while being used here, the usage of this Class would not make much sense. Therefore the correct place to use the caching mechanism is in this class directly