### PR TITLE
#90: StringAsUrl and UrlAsString

### DIFF
--- a/src/main/java/org/cactoos/text/StringAsUrl.java
+++ b/src/main/java/org/cactoos/text/StringAsUrl.java
@@ -23,6 +23,8 @@
  */
 package org.cactoos.text;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -86,8 +88,15 @@ public final class StringAsUrl implements Scalar<String> {
     }
 
     @Override
-    public String asValue() throws Exception {
-        return URLEncoder.encode(this.source.asString(), this.encoding.name());
+    public String asValue() {
+        try {
+            return URLEncoder.encode(
+                this.source.asString(),
+                this.encoding.name()
+            );
+        } catch (final IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
     }
 
 }

--- a/src/main/java/org/cactoos/text/StringAsUrl.java
+++ b/src/main/java/org/cactoos/text/StringAsUrl.java
@@ -57,7 +57,7 @@ public final class StringAsUrl implements Scalar<String> {
     public StringAsUrl(final String url) {
         this(url, StandardCharsets.UTF_8);
     }
-    
+
     /**
      * Ctor.
      * @param url The URL as Text
@@ -74,7 +74,7 @@ public final class StringAsUrl implements Scalar<String> {
     public StringAsUrl(final String url, final Charset encoding) {
         this(new StringAsText(url), encoding);
     }
-    
+
     /**
      * Ctor.
      * @param url The URL as Text

--- a/src/main/java/org/cactoos/text/StringAsUrl.java
+++ b/src/main/java/org/cactoos/text/StringAsUrl.java
@@ -1,0 +1,93 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.text;
+
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import org.cactoos.Scalar;
+import org.cactoos.Text;
+
+/**
+ * String as URL.
+ *
+ * <p>There is no thread-safety guarantee.
+ *
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.4
+ */
+public final class StringAsUrl implements Scalar<String> {
+
+    /**
+     * The source.
+     */
+    private final Text source;
+
+    /**
+     * The encoding.
+     */
+    private final Charset encoding;
+
+    /**
+     * Ctor.
+     * @param url The URL as String
+     */
+    public StringAsUrl(final String url) {
+        this(url, StandardCharsets.UTF_8);
+    }
+    
+    /**
+     * Ctor.
+     * @param url The URL as Text
+     */
+    public StringAsUrl(final Text url) {
+        this(url, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Ctor.
+     * @param url The URL as String
+     * @param encoding The encoding
+     */
+    public StringAsUrl(final String url, final Charset encoding) {
+        this(new StringAsText(url), encoding);
+    }
+    
+    /**
+     * Ctor.
+     * @param url The URL as Text
+     * @param encoding The encoding
+     */
+    public StringAsUrl(final Text url, final Charset encoding) {
+        this.source = url;
+        this.encoding = encoding;
+    }
+
+    @Override
+    public String asValue() throws Exception {
+        return URLEncoder.encode(this.source.asString(), this.encoding.name());
+    }
+
+}

--- a/src/main/java/org/cactoos/text/UrlAsString.java
+++ b/src/main/java/org/cactoos/text/UrlAsString.java
@@ -1,0 +1,93 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.text;
+
+import java.net.URLDecoder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import org.cactoos.Scalar;
+import org.cactoos.Text;
+
+/**
+ * URL as String.
+ *
+ * <p>There is no thread-safety guarantee.
+ *
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.4
+ */
+public final class UrlAsString implements Scalar<String> {
+
+    /**
+     * The source.
+     */
+    private final Text source;
+
+    /**
+     * The encoding.
+     */
+    private final Charset encoding;
+
+    /**
+     * Ctor.
+     * @param url The URL as String
+     */
+    public UrlAsString(final String url) {
+        this(url, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Ctor.
+     * @param url The URL as Text
+     */
+    public UrlAsString(final Text url) {
+        this(url, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Ctor.
+     * @param url The URL as String
+     * @param encoding The encoding
+     */
+    public UrlAsString(final String url, final Charset encoding) {
+        this(new StringAsText(url), encoding);
+    }
+    
+    /**
+     * Ctor.
+     * @param url The URL as Text
+     * @param encoding The encoding
+     */
+    public UrlAsString(final Text url, final Charset encoding) {
+        this.source = url;
+        this.encoding = encoding;
+    }
+
+    @Override
+    public String asValue() throws Exception {
+        return URLDecoder.decode(this.source.asString(), this.encoding.name());
+    }
+
+}

--- a/src/main/java/org/cactoos/text/UrlAsString.java
+++ b/src/main/java/org/cactoos/text/UrlAsString.java
@@ -23,6 +23,8 @@
  */
 package org.cactoos.text;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -86,8 +88,15 @@ public final class UrlAsString implements Scalar<String> {
     }
 
     @Override
-    public String asValue() throws Exception {
-        return URLDecoder.decode(this.source.asString(), this.encoding.name());
+    public String asValue() {
+        try {
+            return URLDecoder.decode(
+                this.source.asString(),
+                this.encoding.name()
+            );
+        } catch (final IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
     }
 
 }

--- a/src/main/java/org/cactoos/text/UrlAsString.java
+++ b/src/main/java/org/cactoos/text/UrlAsString.java
@@ -74,7 +74,7 @@ public final class UrlAsString implements Scalar<String> {
     public UrlAsString(final String url, final Charset encoding) {
         this(new StringAsText(url), encoding);
     }
-    
+
     /**
      * Ctor.
      * @param url The URL as Text

--- a/src/test/java/org/cactoos/text/StringAsUrlTest.java
+++ b/src/test/java/org/cactoos/text/StringAsUrlTest.java
@@ -1,0 +1,48 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.text;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link StringAsUrl}.
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.4
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class StringAsUrlTest {
+
+    @Test
+    public void encodeStringToUrl() throws Exception {
+        MatcherAssert.assertThat(
+            "Can't encode a string as URL",
+            new StringAsUrl("друг").asValue(),
+            Matchers.equalTo("%D0%B4%D1%80%D1%83%D0%B3")
+        );
+    }
+
+}

--- a/src/test/java/org/cactoos/text/UrlAsStringTest.java
+++ b/src/test/java/org/cactoos/text/UrlAsStringTest.java
@@ -1,0 +1,48 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.text;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link UrlAsString}.
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @since 0.4
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class UrlAsStringTest {
+
+    @Test
+    public void decodeUrlToString() throws Exception {
+        MatcherAssert.assertThat(
+            "Can't convert a string to URL",
+            new UrlAsString("%D0%B0%20%D1%8F").asValue(),
+            Matchers.equalTo("а я")
+        );
+    }
+
+}


### PR DESCRIPTION
As per #90:

- `StringAsUrl` introduced
- `UrlAsString` introduced