### PR TITLE
Removed calls to size() and cache from IterableAsList

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Note: [Checkstyle](https://en.wikipedia.org/wiki/Checkstyle) is used as a static
   - [Andriy Kryvtsun](https://github.com/englishman)
   - [Vseslav Sekorin](https://github.com/VsSekorin)
   - [Andrey Valyaev](https://github.com/DronMDF)
+  - [Tim Hinkes](https://github.com/timmeey) [Blog](https://blog.timmeey.de)
 
 ## License (MIT)
 

--- a/src/main/java/org/cactoos/list/IterableAsList.java
+++ b/src/main/java/org/cactoos/list/IterableAsList.java
@@ -24,7 +24,6 @@
 package org.cactoos.list;
 
 import java.util.AbstractList;
-import java.util.ArrayList;
 import java.util.List;
 import org.cactoos.func.StickyScalar;
 import org.cactoos.func.UncheckedScalar;
@@ -49,11 +48,6 @@ public final class IterableAsList<T> extends AbstractList<T> {
     private final Iterable<T> source;
 
     /**
-     * Cache for source.
-     */
-    private final List<T> cache;
-
-    /**
      * Iterable length.
      */
     private final UncheckedScalar<Integer> length;
@@ -66,7 +60,6 @@ public final class IterableAsList<T> extends AbstractList<T> {
     public IterableAsList(final Iterable<T> iterable) {
         super();
         this.source = iterable;
-        this.cache = new ArrayList<>(0);
         this.length = new UncheckedScalar<>(
             new StickyScalar<>(
                 new LengthOfIterable(iterable)
@@ -76,19 +69,23 @@ public final class IterableAsList<T> extends AbstractList<T> {
 
     @Override
     public T get(final int index) {
-        if (index < 0 || index >= this.size()) {
-            throw new IndexOutOfBoundsException(
-                new UncheckedText(
-                    new FormattedText(
-                        "index=%d, bounds=[%d; %d]",
-                        index,
-                        0,
-                        this.size()
-                    )
-                ).asString()
-            );
+        int position = 0;
+        for (final T elem : this.source) {
+            if (position == index) {
+                return elem;
+            }
+            position += 1;
         }
-        return this.cachedItem(index);
+        throw new IndexOutOfBoundsException(
+            new UncheckedText(
+                new FormattedText(
+                    "index=%d, bounds=[%d; %d]",
+                    index,
+                    0,
+                    this.size()
+                )
+            ).asString()
+        );
     }
 
     @Override
@@ -96,18 +93,4 @@ public final class IterableAsList<T> extends AbstractList<T> {
         return this.length.asValue();
     }
 
-    /**
-     * Find item in cache by index.
-     *
-     * @param index Item index
-     * @return Cached item
-     */
-    private T cachedItem(final int index) {
-        if (this.cache.size() != this.size()) {
-            for (final T item : this.source) {
-                this.cache.add(item);
-            }
-        }
-        return this.cache.get(index);
-    }
 }

--- a/src/main/java/org/cactoos/list/IterableAsList.java
+++ b/src/main/java/org/cactoos/list/IterableAsList.java
@@ -25,7 +25,6 @@ package org.cactoos.list;
 
 import java.util.AbstractList;
 import java.util.List;
-import org.cactoos.func.StickyScalar;
 import org.cactoos.func.UncheckedScalar;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.UncheckedText;
@@ -61,9 +60,7 @@ public final class IterableAsList<T> extends AbstractList<T> {
         super();
         this.source = iterable;
         this.length = new UncheckedScalar<>(
-            new StickyScalar<>(
-                new LengthOfIterable(iterable)
-            )
+            new LengthOfIterable(iterable)
         );
     }
 


### PR DESCRIPTION
No more calls to size() if not needed.

Modifications in the underlying Iterable would lead to inconsistent cache. Removed cache completely.
Caches do not work for modifyable Iterables.