### PR TITLE
New ctor for iterable as list

### DIFF
--- a/src/main/java/org/cactoos/list/AllOf.java
+++ b/src/main/java/org/cactoos/list/AllOf.java
@@ -35,7 +35,7 @@ import org.cactoos.Scalar;
  *
  * <pre> new AllOf(
  *   new TransformedIterable&lt;String&gt;(
- *     Arrays.asList("hello", "world"),
+ *     new IdentityArrayList<>("hello", "world"),
  *     new ProcAsFunc&lt;&gt;(i -&gt; System.out.println(i))
  *   )
  * ).asValue();</pre>
@@ -44,7 +44,7 @@ import org.cactoos.Scalar;
  *
  * <pre> new AllOf(
  *   new IterableAsBooleans&lt;String&gt;(
- *     Arrays.asList("hello", "world"),
+ *     new IterableAsList&lt;String&gt;("hello", "world"),
  *     i -&gt; System.out.println(i)
  *   )
  * ).asValue();</pre>
@@ -52,7 +52,7 @@ import org.cactoos.Scalar;
  * <p>Or you can even use {@link IterableAsBoolean}:</p>
  *
  * <pre> new IterableAsBoolean&lt;String&gt;(
- *   Arrays.asList("hello", "world"),
+ *   new IterableAsList&lt;String&gt;("hello", "world"),
  *   i -&gt; System.out.println(i)
  * ).asValue();</pre>
  *

--- a/src/main/java/org/cactoos/list/ConcatenatedIterable.java
+++ b/src/main/java/org/cactoos/list/ConcatenatedIterable.java
@@ -23,7 +23,6 @@
  */
 package org.cactoos.list;
 
-import java.util.Arrays;
 import java.util.Iterator;
 import org.cactoos.func.StickyFunc;
 
@@ -51,7 +50,7 @@ public final class ConcatenatedIterable<T> implements Iterable<T> {
     @SafeVarargs
     @SuppressWarnings("varargs")
     public ConcatenatedIterable(final Iterable<T>... items) {
-        this(Arrays.asList(items));
+        this(new IterableAsList<>(items));
     }
 
     /**

--- a/src/main/java/org/cactoos/list/ConcatenatedIterator.java
+++ b/src/main/java/org/cactoos/list/ConcatenatedIterator.java
@@ -23,7 +23,6 @@
  */
 package org.cactoos.list;
 
-import java.util.Arrays;
 import java.util.Iterator;
 
 /**
@@ -50,7 +49,7 @@ public final class ConcatenatedIterator<T> implements Iterator<T> {
     @SafeVarargs
     @SuppressWarnings("varargs")
     public ConcatenatedIterator(final Iterator<T>... items) {
-        this(Arrays.asList(items));
+        this(new IterableAsList<>(items));
     }
 
     /**

--- a/src/main/java/org/cactoos/list/IterableAsBoolean.java
+++ b/src/main/java/org/cactoos/list/IterableAsBoolean.java
@@ -33,7 +33,7 @@ import org.cactoos.Scalar;
  * a collection of items:</p>
  *
  * <pre> new IterableAsBoolean&lt;&gt;(
- *   Arrays.asList("hello", "world"),
+ *   new IterableAsList&lt;String&gt;("hello", "world"),
  *   i -&gt; System.out.println(i)
  * ).asValue();</pre>
  *

--- a/src/main/java/org/cactoos/list/IterableAsBooleans.java
+++ b/src/main/java/org/cactoos/list/IterableAsBooleans.java
@@ -34,7 +34,7 @@ import org.cactoos.Func;
  *
  * <pre> new AllOf(
  *   new IterableAsBooleans&lt;String&gt;(
- *     Arrays.asList("hello", "world"),
+ *     new IterableAsList&lt;String&gt;("hello", "world"),
  *     i -&gt; System.out.println(i)
  *   )
  * ).asValue();</pre>

--- a/src/main/java/org/cactoos/list/IterableAsList.java
+++ b/src/main/java/org/cactoos/list/IterableAsList.java
@@ -58,7 +58,7 @@ public final class IterableAsList<T> extends AbstractList<T> {
      */
     @SafeVarargs
     @SuppressWarnings("varargs")
-    public IterableAsList(T... array) {
+    public IterableAsList(final T... array) {
         this(new ArrayAsIterable<>(array));
     }
 

--- a/src/main/java/org/cactoos/list/IterableAsList.java
+++ b/src/main/java/org/cactoos/list/IterableAsList.java
@@ -54,6 +54,15 @@ public final class IterableAsList<T> extends AbstractList<T> {
     /**
      * Ctor.
      *
+     * @param array An array of some elements
+     */
+    public IterableAsList(T... array) {
+        this(new ArrayAsIterable<>(array));
+    }
+
+    /**
+     * Ctor.
+     *
      * @param iterable An {@link Iterable}
      */
     public IterableAsList(final Iterable<T> iterable) {

--- a/src/main/java/org/cactoos/list/IterableAsList.java
+++ b/src/main/java/org/cactoos/list/IterableAsList.java
@@ -56,6 +56,8 @@ public final class IterableAsList<T> extends AbstractList<T> {
      *
      * @param array An array of some elements
      */
+    @SafeVarargs
+    @SuppressWarnings("varargs")
     public IterableAsList(T... array) {
         this(new ArrayAsIterable<>(array));
     }

--- a/src/main/java/org/cactoos/text/FormattedText.java
+++ b/src/main/java/org/cactoos/text/FormattedText.java
@@ -24,12 +24,12 @@
 package org.cactoos.text;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Formatter;
 import java.util.Locale;
 import org.cactoos.Text;
+import org.cactoos.list.IterableAsList;
 
 /**
  * Text in Sprinf format.
@@ -64,7 +64,7 @@ public final class FormattedText implements Text {
      * @param arguments Arguments
      */
     public FormattedText(final String ptn, final Object... arguments) {
-        this(ptn, Arrays.asList(arguments));
+        this(ptn, new IterableAsList<>(arguments));
     }
 
     /**
@@ -74,7 +74,7 @@ public final class FormattedText implements Text {
      * @param arguments Arguments
      */
     public FormattedText(final Text ptn, final Object... arguments) {
-        this(ptn, Arrays.asList(arguments));
+        this(ptn, new IterableAsList<>(arguments));
     }
 
     /**
@@ -89,7 +89,7 @@ public final class FormattedText implements Text {
         final Locale locale,
         final Object... arguments
     ) {
-        this(ptn, locale, Arrays.asList(arguments));
+        this(ptn, locale, new IterableAsList<>(arguments));
     }
 
     /**
@@ -104,7 +104,7 @@ public final class FormattedText implements Text {
         final Locale locale,
         final Object... arguments
     ) {
-        this(ptn, locale, Arrays.asList(arguments));
+        this(ptn, locale, new IterableAsList<>(arguments));
     }
 
     /**

--- a/src/test/java/org/cactoos/list/IterableAsListTest.java
+++ b/src/test/java/org/cactoos/list/IterableAsListTest.java
@@ -43,9 +43,7 @@ public final class IterableAsListTest {
         final int num = 345;
         MatcherAssert.assertThat(
             "Can't convert an iterable to a list",
-            new IterableAsList<>(
-                    -1, 0, 1, num, 1
-            ).get(3),
+            new IterableAsList<>(-1, num, 0, 1).get(1),
             Matchers.equalTo(num)
         );
     }

--- a/src/test/java/org/cactoos/list/IterableAsListTest.java
+++ b/src/test/java/org/cactoos/list/IterableAsListTest.java
@@ -44,8 +44,7 @@ public final class IterableAsListTest {
         MatcherAssert.assertThat(
             "Can't convert an iterable to a list",
             new IterableAsList<>(
-                // @checkstyle MagicNumber (2 lines)
-                new ArrayAsIterable<>(0, 1, 2, num, 3, 4)
+                    -1, 0, 1, num, 1
             ).get(3),
             Matchers.equalTo(num)
         );


### PR DESCRIPTION
- add new ctor into `IterableAsList`
- reuse the new ctor instead of `Arrays.asList` in other ctors