### PR TITLE
#152: Eclipse cannot infer type arguments for IterableAsMap error

### DIFF
--- a/src/test/java/org/cactoos/list/IterableAsMapTest.java
+++ b/src/test/java/org/cactoos/list/IterableAsMapTest.java
@@ -39,11 +39,10 @@ import org.junit.Test;
 public final class IterableAsMapTest {
 
     @Test
-    @SuppressWarnings("unchecked")
     public void convertsIterableToMap() {
         MatcherAssert.assertThat(
             "Can't convert iterable to map",
-            new IterableAsMap<>(
+            new IterableAsMap<Integer, String>(
                 new AbstractMap.SimpleEntry<>(0, "hello, "),
                 new AbstractMap.SimpleEntry<>(1, "world!")
             ),


### PR DESCRIPTION
As per #152:
- Changed IterableAsMap to use types to avoid an apparently Eclipse IDE bug.