### PR TITLE
#211: Use .value () instead of .asValue ()

### DIFF
--- a/src/main/java/org/cactoos/Scalar.java
+++ b/src/main/java/org/cactoos/Scalar.java
@@ -52,6 +52,6 @@ public interface Scalar<T> {
      * @return The value
      * @throws Exception If fails
      */
-    T asValue() throws Exception;
+    T value() throws Exception;
 
 }

--- a/src/main/java/org/cactoos/ScalarHasValue.java
+++ b/src/main/java/org/cactoos/ScalarHasValue.java
@@ -64,7 +64,7 @@ public final class ScalarHasValue<T> extends TypeSafeMatcher<Scalar<T>> {
     @Override
     public boolean matchesSafely(final Scalar<T> item) {
         return this.matcher.matches(
-            new UncheckedScalar<>(item).asValue()
+            new UncheckedScalar<>(item).value()
         );
     }
 

--- a/src/main/java/org/cactoos/func/And.java
+++ b/src/main/java/org/cactoos/func/And.java
@@ -110,10 +110,10 @@ public final class And implements Scalar<Boolean> {
     }
 
     @Override
-    public Boolean asValue() throws Exception {
+    public Boolean value() throws Exception {
         boolean result = true;
         for (final Scalar<Boolean> item : this.iterable) {
-            if (!item.asValue()) {
+            if (!item.value()) {
                 result = false;
                 break;
             }

--- a/src/main/java/org/cactoos/func/False.java
+++ b/src/main/java/org/cactoos/func/False.java
@@ -37,7 +37,7 @@ import org.cactoos.Scalar;
 public final class False implements Scalar<Boolean> {
 
     @Override
-    public Boolean asValue() throws Exception {
+    public Boolean value() throws Exception {
         return false;
     }
 }

--- a/src/main/java/org/cactoos/func/IoCheckedScalar.java
+++ b/src/main/java/org/cactoos/func/IoCheckedScalar.java
@@ -53,9 +53,9 @@ public final class IoCheckedScalar<T> implements Scalar<T> {
     }
 
     @Override
-    public T asValue() throws IOException {
+    public T value() throws IOException {
         return new IoCheckedFunc<Scalar<T>, T>(
-            Scalar::asValue
+            Scalar::value
         ).apply(this.scalar);
     }
 

--- a/src/main/java/org/cactoos/func/Neg.java
+++ b/src/main/java/org/cactoos/func/Neg.java
@@ -50,7 +50,7 @@ public final class Neg implements Scalar<Boolean> {
     }
 
     @Override
-    public Boolean asValue() throws Exception {
-        return !this.origin.asValue();
+    public Boolean value() throws Exception {
+        return !this.origin.value();
     }
 }

--- a/src/main/java/org/cactoos/func/Or.java
+++ b/src/main/java/org/cactoos/func/Or.java
@@ -60,10 +60,10 @@ public final class Or implements Scalar<Boolean> {
     }
 
     @Override
-    public Boolean asValue() throws Exception {
+    public Boolean value() throws Exception {
         boolean result = false;
         for (final Scalar<Boolean> item : this.iterable) {
-            if (item.asValue()) {
+            if (item.value()) {
                 result = true;
                 break;
             }

--- a/src/main/java/org/cactoos/func/RetryScalar.java
+++ b/src/main/java/org/cactoos/func/RetryScalar.java
@@ -77,9 +77,9 @@ public final class RetryScalar<T> implements Scalar<T> {
     }
 
     @Override
-    public T asValue() throws Exception {
+    public T value() throws Exception {
         return new RetryFunc<>(
-            (Func<Boolean, T>) input -> this.scalar.asValue(),
+            (Func<Boolean, T>) input -> this.scalar.value(),
             this.exit
         ).apply(true);
     }

--- a/src/main/java/org/cactoos/func/StickyScalar.java
+++ b/src/main/java/org/cactoos/func/StickyScalar.java
@@ -54,12 +54,12 @@ public final class StickyScalar<T> implements Scalar<T> {
      */
     public StickyScalar(final Scalar<T> src) {
         this.func = new StickyFunc<>(
-            input -> src.asValue()
+            input -> src.value()
         );
     }
 
     @Override
-    public T asValue() throws Exception {
+    public T value() throws Exception {
         return this.func.apply(true);
     }
 }

--- a/src/main/java/org/cactoos/func/SyncScalar.java
+++ b/src/main/java/org/cactoos/func/SyncScalar.java
@@ -49,9 +49,9 @@ public final class SyncScalar<T> implements Scalar<T> {
     }
 
     @Override
-    public T asValue() throws Exception {
+    public T value() throws Exception {
         synchronized (this.source) {
-            return this.source.asValue();
+            return this.source.value();
         }
     }
 }

--- a/src/main/java/org/cactoos/func/Ternary.java
+++ b/src/main/java/org/cactoos/func/Ternary.java
@@ -69,9 +69,9 @@ public final class Ternary<T> implements Scalar<T> {
     }
 
     @Override
-    public T asValue() throws Exception {
+    public T value() throws Exception {
         final T result;
-        if (this.condition.asValue()) {
+        if (this.condition.value()) {
             result = this.cons;
         } else {
             result = this.alter;

--- a/src/main/java/org/cactoos/func/True.java
+++ b/src/main/java/org/cactoos/func/True.java
@@ -37,7 +37,7 @@ import org.cactoos.Scalar;
 public final class True implements Scalar<Boolean> {
 
     @Override
-    public Boolean asValue() throws Exception {
+    public Boolean value() throws Exception {
         return true;
     }
 }

--- a/src/main/java/org/cactoos/func/UncheckedScalar.java
+++ b/src/main/java/org/cactoos/func/UncheckedScalar.java
@@ -53,9 +53,9 @@ public final class UncheckedScalar<T> implements Scalar<T> {
     }
 
     @Override
-    public T asValue() {
+    public T value() {
         try {
-            return new IoCheckedScalar<>(this.scalar).asValue();
+            return new IoCheckedScalar<>(this.scalar).value();
         } catch (final IOException ex) {
             throw new UncheckedIOException(ex);
         }

--- a/src/main/java/org/cactoos/io/FileAsInput.java
+++ b/src/main/java/org/cactoos/io/FileAsInput.java
@@ -75,7 +75,7 @@ public final class FileAsInput implements Input {
 
     @Override
     public InputStream stream() throws FileNotFoundException {
-        return new FileInputStream(this.file.asValue());
+        return new FileInputStream(this.file.value());
     }
 
 }

--- a/src/main/java/org/cactoos/io/FileAsOutput.java
+++ b/src/main/java/org/cactoos/io/FileAsOutput.java
@@ -75,7 +75,7 @@ public final class FileAsOutput implements Output {
 
     @Override
     public OutputStream stream() throws FileNotFoundException {
-        return new FileOutputStream(this.file.asValue());
+        return new FileOutputStream(this.file.value());
     }
 
 }

--- a/src/main/java/org/cactoos/io/InputAsProperties.java
+++ b/src/main/java/org/cactoos/io/InputAsProperties.java
@@ -85,7 +85,7 @@ public final class InputAsProperties implements Scalar<Properties> {
     }
 
     @Override
-    public Properties asValue() throws IOException {
+    public Properties value() throws IOException {
         final Properties props = new Properties();
         try (final InputStream input = this.source.stream()) {
             props.load(input);

--- a/src/main/java/org/cactoos/io/LengthOfInput.java
+++ b/src/main/java/org/cactoos/io/LengthOfInput.java
@@ -69,7 +69,7 @@ public final class LengthOfInput implements Scalar<Long> {
     }
 
     @Override
-    public Long asValue() throws IOException {
+    public Long value() throws IOException {
         try (final InputStream stream = this.source.stream()) {
             final byte[] buf = new byte[this.size];
             long length = 0L;

--- a/src/main/java/org/cactoos/io/StickyInput.java
+++ b/src/main/java/org/cactoos/io/StickyInput.java
@@ -58,7 +58,7 @@ public final class StickyInput implements Input {
                 final ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 new LengthOfInput(
                     new TeeInput(input, new OutputStreamAsOutput(baos))
-                ).asValue();
+                ).value();
                 return baos.toByteArray();
             }
         );
@@ -67,7 +67,7 @@ public final class StickyInput implements Input {
     @Override
     public InputStream stream() throws IOException {
         return new ByteArrayInputStream(
-            new IoCheckedScalar<>(this.cache).asValue()
+            new IoCheckedScalar<>(this.cache).value()
         );
     }
 

--- a/src/main/java/org/cactoos/io/UncheckedInput.java
+++ b/src/main/java/org/cactoos/io/UncheckedInput.java
@@ -53,7 +53,7 @@ public final class UncheckedInput implements Input {
 
     @Override
     public InputStream stream() {
-        return new UncheckedScalar<>(this.input::stream).asValue();
+        return new UncheckedScalar<>(this.input::stream).value();
     }
 
 }

--- a/src/main/java/org/cactoos/io/UncheckedOutput.java
+++ b/src/main/java/org/cactoos/io/UncheckedOutput.java
@@ -53,7 +53,7 @@ public final class UncheckedOutput implements Output {
 
     @Override
     public OutputStream stream() {
-        return new UncheckedScalar<>(this.output::stream).asValue();
+        return new UncheckedScalar<>(this.output::stream).value();
     }
 
 }

--- a/src/main/java/org/cactoos/io/UrlAsInput.java
+++ b/src/main/java/org/cactoos/io/UrlAsInput.java
@@ -83,7 +83,7 @@ public final class UrlAsInput implements Input {
 
     @Override
     public InputStream stream() throws IOException {
-        return new IoCheckedScalar<>(this.source).asValue().openStream();
+        return new IoCheckedScalar<>(this.source).value().openStream();
     }
 
 }

--- a/src/main/java/org/cactoos/list/EndlessIterator.java
+++ b/src/main/java/org/cactoos/list/EndlessIterator.java
@@ -76,6 +76,6 @@ public final class EndlessIterator<T> implements Iterator<T> {
 
     @Override
     public T next() {
-        return this.element.asValue();
+        return this.element.value();
     }
 }

--- a/src/main/java/org/cactoos/list/ItemOfIterable.java
+++ b/src/main/java/org/cactoos/list/ItemOfIterable.java
@@ -136,11 +136,11 @@ public final class ItemOfIterable<T> implements Scalar<T> {
     }
 
     @Override
-    public T asValue() throws Exception {
+    public T value() throws Exception {
         return new ItemOfIterator<>(
             this.src.iterator(),
             this.pos,
             this.fbk
-        ).asValue();
+        ).value();
     }
 }

--- a/src/main/java/org/cactoos/list/ItemOfIterator.java
+++ b/src/main/java/org/cactoos/list/ItemOfIterator.java
@@ -133,7 +133,7 @@ public final class ItemOfIterator<T> implements Scalar<T> {
     }
 
     @Override
-    public T asValue() throws Exception {
+    public T value() throws Exception {
         if (this.pos < 0) {
             throw new IOException(
                 new FormattedText(

--- a/src/main/java/org/cactoos/list/IterableAsList.java
+++ b/src/main/java/org/cactoos/list/IterableAsList.java
@@ -79,7 +79,7 @@ public final class IterableAsList<T> implements List<T> {
 
     @Override
     public int size() {
-        return new LengthOfIterable(this.iterable).asValue();
+        return new LengthOfIterable(this.iterable).value();
     }
 
     @Override

--- a/src/main/java/org/cactoos/list/IterableAsMap.java
+++ b/src/main/java/org/cactoos/list/IterableAsMap.java
@@ -75,7 +75,7 @@ public final class IterableAsMap<X, Y> implements Map<X, Y> {
 
     @Override
     public int size() {
-        return new LengthOfIterable(this.entries).asValue();
+        return new LengthOfIterable(this.entries).value();
     }
 
     @Override

--- a/src/main/java/org/cactoos/list/LengthOfIterable.java
+++ b/src/main/java/org/cactoos/list/LengthOfIterable.java
@@ -50,8 +50,8 @@ public final class LengthOfIterable implements Scalar<Integer> {
     }
 
     @Override
-    public Integer asValue() {
-        return new LengthOfIterator(this.iterable.iterator()).asValue();
+    public Integer value() {
+        return new LengthOfIterator(this.iterable.iterator()).value();
     }
 
 }

--- a/src/main/java/org/cactoos/list/LengthOfIterator.java
+++ b/src/main/java/org/cactoos/list/LengthOfIterator.java
@@ -51,7 +51,7 @@ public final class LengthOfIterator implements Scalar<Integer> {
     }
 
     @Override
-    public Integer asValue() {
+    public Integer value() {
         int size = 0;
         while (this.iterator.hasNext()) {
             this.iterator.next();

--- a/src/main/java/org/cactoos/list/MapAsProperties.java
+++ b/src/main/java/org/cactoos/list/MapAsProperties.java
@@ -70,7 +70,7 @@ public final class MapAsProperties implements Scalar<Properties> {
     }
 
     @Override
-    public Properties asValue() {
+    public Properties value() {
         final Properties props = new Properties();
         for (final Map.Entry<?, ?> entry : this.map.entrySet()) {
             props.setProperty(

--- a/src/main/java/org/cactoos/list/RepeatIterator.java
+++ b/src/main/java/org/cactoos/list/RepeatIterator.java
@@ -86,6 +86,6 @@ public final class RepeatIterator<T> implements Iterator<T> {
     @Override
     public T next() {
         --this.left;
-        return this.element.asValue();
+        return this.element.value();
     }
 }

--- a/src/main/java/org/cactoos/list/SortedIterator.java
+++ b/src/main/java/org/cactoos/list/SortedIterator.java
@@ -79,11 +79,11 @@ public final class
 
     @Override
     public boolean hasNext() {
-        return this.sorted.asValue().hasNext();
+        return this.sorted.value().hasNext();
     }
 
     @Override
     public T next() {
-        return this.sorted.asValue().next();
+        return this.sorted.value().next();
     }
 }

--- a/src/main/java/org/cactoos/list/StickyIterable.java
+++ b/src/main/java/org/cactoos/list/StickyIterable.java
@@ -66,7 +66,7 @@ public final class StickyIterable<X> implements Iterable<X> {
 
     @Override
     public Iterator<X> iterator() {
-        return this.gate.asValue().iterator();
+        return this.gate.value().iterator();
     }
 
 }

--- a/src/main/java/org/cactoos/list/StickyIterator.java
+++ b/src/main/java/org/cactoos/list/StickyIterator.java
@@ -75,11 +75,11 @@ public final class StickyIterator<X> implements Iterator<X> {
 
     @Override
     public boolean hasNext() {
-        return this.gate.asValue().hasNext();
+        return this.gate.value().hasNext();
     }
 
     @Override
     public X next() {
-        return this.gate.asValue().next();
+        return this.gate.value().next();
     }
 }

--- a/src/main/java/org/cactoos/list/StickyList.java
+++ b/src/main/java/org/cactoos/list/StickyList.java
@@ -84,33 +84,33 @@ public final class StickyList<X> implements List<X> {
 
     @Override
     public int size() {
-        return this.gate.asValue().size();
+        return this.gate.value().size();
     }
 
     @Override
     public boolean isEmpty() {
-        return this.gate.asValue().isEmpty();
+        return this.gate.value().isEmpty();
     }
 
     @Override
     public boolean contains(final Object object) {
-        return this.gate.asValue().contains(object);
+        return this.gate.value().contains(object);
     }
 
     @Override
     public Iterator<X> iterator() {
-        return this.gate.asValue().iterator();
+        return this.gate.value().iterator();
     }
 
     @Override
     public Object[] toArray() {
-        return this.gate.asValue().toArray();
+        return this.gate.value().toArray();
     }
 
     @Override
     @SuppressWarnings("PMD.UseVarargs")
     public <Y> Y[] toArray(final Y[] array) {
-        return this.gate.asValue().toArray(array);
+        return this.gate.value().toArray(array);
     }
 
     @Override
@@ -129,7 +129,7 @@ public final class StickyList<X> implements List<X> {
 
     @Override
     public boolean containsAll(final Collection<?> collection) {
-        return this.gate.asValue().containsAll(collection);
+        return this.gate.value().containsAll(collection);
     }
 
     @Override
@@ -170,7 +170,7 @@ public final class StickyList<X> implements List<X> {
 
     @Override
     public X get(final int index) {
-        return this.gate.asValue().get(index);
+        return this.gate.value().get(index);
     }
 
     @Override
@@ -196,26 +196,26 @@ public final class StickyList<X> implements List<X> {
 
     @Override
     public int indexOf(final Object object) {
-        return this.gate.asValue().indexOf(object);
+        return this.gate.value().indexOf(object);
     }
 
     @Override
     public int lastIndexOf(final Object object) {
-        return this.gate.asValue().lastIndexOf(object);
+        return this.gate.value().lastIndexOf(object);
     }
 
     @Override
     public ListIterator<X> listIterator() {
-        return this.gate.asValue().listIterator();
+        return this.gate.value().listIterator();
     }
 
     @Override
     public ListIterator<X> listIterator(final int index) {
-        return this.gate.asValue().listIterator(index);
+        return this.gate.value().listIterator(index);
     }
 
     @Override
     public List<X> subList(final int fromindex, final int toindex) {
-        return this.gate.asValue().subList(fromindex, toindex);
+        return this.gate.value().subList(fromindex, toindex);
     }
 }

--- a/src/main/java/org/cactoos/list/StickyMap.java
+++ b/src/main/java/org/cactoos/list/StickyMap.java
@@ -83,27 +83,27 @@ public final class StickyMap<X, Y> implements Map<X, Y> {
 
     @Override
     public int size() {
-        return this.gate.asValue().size();
+        return this.gate.value().size();
     }
 
     @Override
     public boolean isEmpty() {
-        return this.gate.asValue().isEmpty();
+        return this.gate.value().isEmpty();
     }
 
     @Override
     public boolean containsKey(final Object key) {
-        return this.gate.asValue().containsKey(key);
+        return this.gate.value().containsKey(key);
     }
 
     @Override
     public boolean containsValue(final Object value) {
-        return this.gate.asValue().containsValue(value);
+        return this.gate.value().containsValue(value);
     }
 
     @Override
     public Y get(final Object key) {
-        return this.gate.asValue().get(key);
+        return this.gate.value().get(key);
     }
 
     @Override
@@ -136,17 +136,17 @@ public final class StickyMap<X, Y> implements Map<X, Y> {
 
     @Override
     public Set<X> keySet() {
-        return this.gate.asValue().keySet();
+        return this.gate.value().keySet();
     }
 
     @Override
     public Collection<Y> values() {
-        return this.gate.asValue().values();
+        return this.gate.value().values();
     }
 
     @Override
     public Set<Map.Entry<X, Y>> entrySet() {
-        return this.gate.asValue().entrySet();
+        return this.gate.value().entrySet();
     }
 
 }

--- a/src/main/java/org/cactoos/text/IsBlank.java
+++ b/src/main/java/org/cactoos/text/IsBlank.java
@@ -52,7 +52,7 @@ public final class IsBlank implements Scalar<Boolean> {
     }
 
     @Override
-    public Boolean asValue() throws IOException {
+    public Boolean value() throws IOException {
         return !this.origin.asString().chars()
             .filter(c -> !Character.isWhitespace(c))
             .findFirst()

--- a/src/main/java/org/cactoos/text/StringAsUrl.java
+++ b/src/main/java/org/cactoos/text/StringAsUrl.java
@@ -87,7 +87,7 @@ public final class StringAsUrl implements Scalar<String> {
     }
 
     @Override
-    public String asValue() throws IOException {
+    public String value() throws IOException {
         return URLEncoder.encode(
             this.source.asString(),
             this.encoding.name()

--- a/src/main/java/org/cactoos/text/TextAsBool.java
+++ b/src/main/java/org/cactoos/text/TextAsBool.java
@@ -62,7 +62,7 @@ public final class TextAsBool implements Scalar<Boolean> {
     }
 
     @Override
-    public Boolean asValue() throws IOException {
+    public Boolean value() throws IOException {
         return Boolean.valueOf(this.text.asString());
     }
 }

--- a/src/main/java/org/cactoos/text/TextAsDouble.java
+++ b/src/main/java/org/cactoos/text/TextAsDouble.java
@@ -62,7 +62,7 @@ public final class TextAsDouble implements Scalar<Double> {
     }
 
     @Override
-    public Double asValue() throws IOException {
+    public Double value() throws IOException {
         return Double.valueOf(this.text.asString());
     }
 }

--- a/src/main/java/org/cactoos/text/TextAsFloat.java
+++ b/src/main/java/org/cactoos/text/TextAsFloat.java
@@ -62,7 +62,7 @@ public final class TextAsFloat implements Scalar<Float> {
     }
 
     @Override
-    public Float asValue() throws IOException {
+    public Float value() throws IOException {
         return Float.valueOf(this.text.asString());
     }
 }

--- a/src/main/java/org/cactoos/text/TextAsInt.java
+++ b/src/main/java/org/cactoos/text/TextAsInt.java
@@ -62,7 +62,7 @@ public final class TextAsInt implements Scalar<Integer> {
     }
 
     @Override
-    public Integer asValue() throws IOException {
+    public Integer value() throws IOException {
         return Integer.valueOf(this.text.asString());
     }
 }

--- a/src/main/java/org/cactoos/text/TextAsLong.java
+++ b/src/main/java/org/cactoos/text/TextAsLong.java
@@ -62,7 +62,7 @@ public final class TextAsLong implements Scalar<Long> {
     }
 
     @Override
-    public Long asValue() throws IOException {
+    public Long value() throws IOException {
         return Long.valueOf(this.text.asString());
     }
 }

--- a/src/main/java/org/cactoos/text/UrlAsString.java
+++ b/src/main/java/org/cactoos/text/UrlAsString.java
@@ -87,7 +87,7 @@ public final class UrlAsString implements Scalar<String> {
     }
 
     @Override
-    public String asValue() throws IOException {
+    public String value() throws IOException {
         return URLDecoder.decode(
             this.source.asString(),
             this.encoding.name()

--- a/src/test/java/org/cactoos/func/AndTest.java
+++ b/src/test/java/org/cactoos/func/AndTest.java
@@ -52,7 +52,7 @@ public final class AndTest {
                 new True(),
                 new True(),
                 new True()
-            ).asValue(),
+            ).value(),
             Matchers.equalTo(true)
         );
     }
@@ -64,7 +64,7 @@ public final class AndTest {
                 new True(),
                 new False(),
                 new True()
-            ).asValue(),
+            ).value(),
             Matchers.equalTo(false)
         );
     }
@@ -78,7 +78,7 @@ public final class AndTest {
                     new False(),
                     new False()
                 )
-            ).asValue(),
+            ).value(),
             Matchers.equalTo(false)
         );
     }
@@ -86,7 +86,7 @@ public final class AndTest {
     @Test
     public void emptyIterator() throws Exception {
         MatcherAssert.assertThat(
-            new And(Collections.emptyList()).asValue(),
+            new And(Collections.emptyList()).value(),
             Matchers.equalTo(true)
         );
     }

--- a/src/test/java/org/cactoos/func/FalseTest.java
+++ b/src/test/java/org/cactoos/func/FalseTest.java
@@ -40,7 +40,7 @@ public final class FalseTest {
     @Test
     public void asValue() throws Exception {
         MatcherAssert.assertThat(
-            new False().asValue(),
+            new False().value(),
             Matchers.equalTo(false)
         );
     }

--- a/src/test/java/org/cactoos/func/IoCheckedScalarTest.java
+++ b/src/test/java/org/cactoos/func/IoCheckedScalarTest.java
@@ -47,7 +47,7 @@ public final class IoCheckedScalarTest {
                 (Scalar<Integer>) () -> {
                     throw exception;
                 }
-            ).asValue();
+            ).value();
         } catch (final IOException ex) {
             MatcherAssert.assertThat(
                 ex, Matchers.is(exception)

--- a/src/test/java/org/cactoos/func/NegTest.java
+++ b/src/test/java/org/cactoos/func/NegTest.java
@@ -40,16 +40,16 @@ public final class NegTest {
     @Test
     public void trueToFalse() throws Exception {
         MatcherAssert.assertThat(
-            new Neg(new True()).asValue(),
-            Matchers.equalTo(new False().asValue())
+            new Neg(new True()).value(),
+            Matchers.equalTo(new False().value())
         );
     }
 
     @Test
     public void falseToTrue() throws Exception {
         MatcherAssert.assertThat(
-            new Neg(new False()).asValue(),
-            Matchers.equalTo(new True().asValue())
+            new Neg(new False()).value(),
+            Matchers.equalTo(new True().value())
         );
     }
 }

--- a/src/test/java/org/cactoos/func/OrTest.java
+++ b/src/test/java/org/cactoos/func/OrTest.java
@@ -49,7 +49,7 @@ public final class OrTest {
                 new False(),
                 new False(),
                 new False()
-            ).asValue(),
+            ).value(),
             Matchers.equalTo(false)
         );
     }
@@ -63,7 +63,7 @@ public final class OrTest {
                 new False(),
                 new False(),
                 new False()
-            ).asValue(),
+            ).value(),
             Matchers.equalTo(true)
         );
     }
@@ -79,7 +79,7 @@ public final class OrTest {
                     new True(),
                     new True()
                 )
-            ).asValue(),
+            ).value(),
             Matchers.equalTo(true)
         );
     }
@@ -87,7 +87,7 @@ public final class OrTest {
     @Test
     public void emptyIterator() throws Exception {
         MatcherAssert.assertThat(
-            new Or(Collections.emptyList()).asValue(),
+            new Or(Collections.emptyList()).value(),
             Matchers.equalTo(false)
         );
     }

--- a/src/test/java/org/cactoos/func/RetryScalarTest.java
+++ b/src/test/java/org/cactoos/func/RetryScalarTest.java
@@ -50,7 +50,7 @@ public final class RetryScalarTest {
                     return 0;
                 },
                 Integer.MAX_VALUE
-            ).asValue(),
+            ).value(),
             Matchers.equalTo(0)
         );
     }

--- a/src/test/java/org/cactoos/func/StickyScalarTest.java
+++ b/src/test/java/org/cactoos/func/StickyScalarTest.java
@@ -45,8 +45,8 @@ public final class StickyScalarTest {
             () -> new SecureRandom().nextInt()
         );
         MatcherAssert.assertThat(
-            scalar.asValue() + scalar.asValue(),
-            Matchers.equalTo(scalar.asValue() + scalar.asValue())
+            scalar.value() + scalar.value(),
+            Matchers.equalTo(scalar.value() + scalar.value())
         );
     }
 

--- a/src/test/java/org/cactoos/func/TernaryTest.java
+++ b/src/test/java/org/cactoos/func/TernaryTest.java
@@ -45,7 +45,7 @@ public final class TernaryTest {
                 new True(),
                 6,
                 16
-            ).asValue(),
+            ).value(),
             Matchers.equalTo(6)
         );
     }
@@ -57,7 +57,7 @@ public final class TernaryTest {
                 new False(),
                 6,
                 16
-            ).asValue(),
+            ).value(),
             Matchers.equalTo(16)
         );
     }

--- a/src/test/java/org/cactoos/func/TrueTest.java
+++ b/src/test/java/org/cactoos/func/TrueTest.java
@@ -40,7 +40,7 @@ public final class TrueTest {
     @Test
     public void asValue() throws Exception {
         MatcherAssert.assertThat(
-            new True().asValue(),
+            new True().value(),
             Matchers.equalTo(true)
         );
     }

--- a/src/test/java/org/cactoos/func/UncheckedScalarTest.java
+++ b/src/test/java/org/cactoos/func/UncheckedScalarTest.java
@@ -43,7 +43,7 @@ public final class UncheckedScalarTest {
             () -> {
                 throw new IOException("intended");
             }
-        ).asValue();
+        ).value();
     }
 
 }

--- a/src/test/java/org/cactoos/io/LengthOfInputTest.java
+++ b/src/test/java/org/cactoos/io/LengthOfInputTest.java
@@ -77,7 +77,7 @@ public final class LengthOfInputTest {
                     // @checkstyle LineLength (1 line)
                     "file:src/test/resources/org/cactoos/large-text.txt"
                 )
-            ).asValue(),
+            ).value(),
             // @checkstyle MagicNumber (1 line)
             Matchers.equalTo(73471L)
         );

--- a/src/test/java/org/cactoos/list/ItemOfIterableTest.java
+++ b/src/test/java/org/cactoos/list/ItemOfIterableTest.java
@@ -66,7 +66,7 @@ public final class ItemOfIterableTest {
 
     @Test(expected = IOException.class)
     public void failForEmptyCollectionTest() throws Exception {
-        new ItemOfIterable<>(Collections.emptyList()).asValue();
+        new ItemOfIterable<>(Collections.emptyList()).value();
     }
 
     @Test

--- a/src/test/java/org/cactoos/list/ItemOfIteratorTest.java
+++ b/src/test/java/org/cactoos/list/ItemOfIteratorTest.java
@@ -65,7 +65,7 @@ public final class ItemOfIteratorTest {
 
     @Test(expected = IOException.class)
     public void failForEmptyCollectionTest() throws Exception {
-        new ItemOfIterator<>(Collections.emptyIterator()).asValue();
+        new ItemOfIterator<>(Collections.emptyIterator()).value();
     }
 
     @Test(expected = IOException.class)
@@ -74,7 +74,7 @@ public final class ItemOfIteratorTest {
             // @checkstyle MagicNumber (1 line)
             new ArrayAsIterable<>(1, 2, 3).iterator(),
             -1
-        ).asValue();
+        ).value();
     }
 
     @Test
@@ -96,6 +96,6 @@ public final class ItemOfIteratorTest {
             // @checkstyle MagicNumberCheck (2 lines)
             new ArrayAsIterable<>(1, 2, 3).iterator(),
             3
-        ).asValue();
+        ).value();
     }
 }

--- a/src/test/java/org/cactoos/list/MapAsPropertiesTest.java
+++ b/src/test/java/org/cactoos/list/MapAsPropertiesTest.java
@@ -80,8 +80,8 @@ public final class MapAsPropertiesTest {
         );
         MatcherAssert.assertThat(
             "Can't sense the changes in the underlying map",
-            props.asValue().size(),
-            Matchers.not(Matchers.equalTo(props.asValue().size()))
+            props.value().size(),
+            Matchers.not(Matchers.equalTo(props.value().size()))
         );
     }
 

--- a/src/test/java/org/cactoos/list/StickyIterableTest.java
+++ b/src/test/java/org/cactoos/list/StickyIterableTest.java
@@ -50,7 +50,7 @@ public final class StickyIterableTest {
         MatcherAssert.assertThat(
             "Can't ignore the changes in the underlying iterable",
             new LengthOfIterable(list),
-            new ScalarHasValue<>(new LengthOfIterable(list).asValue())
+            new ScalarHasValue<>(new LengthOfIterable(list).value())
         );
     }
 

--- a/src/test/java/org/cactoos/text/StringAsUrlTest.java
+++ b/src/test/java/org/cactoos/text/StringAsUrlTest.java
@@ -40,7 +40,7 @@ public final class StringAsUrlTest {
     public void encodeStringToUrl() throws Exception {
         MatcherAssert.assertThat(
             "Can't encode a string as URL",
-            new StringAsUrl("друг").asValue(),
+            new StringAsUrl("друг").value(),
             Matchers.equalTo("%D0%B4%D1%80%D1%83%D0%B3")
         );
     }

--- a/src/test/java/org/cactoos/text/TextAsBoolTest.java
+++ b/src/test/java/org/cactoos/text/TextAsBoolTest.java
@@ -42,7 +42,7 @@ public final class TextAsBoolTest {
     public void trueTest() throws IOException {
         MatcherAssert.assertThat(
             "Can't parse 'true' string",
-            new TextAsBool("true").asValue(),
+            new TextAsBool("true").value(),
             Matchers.equalTo(true)
         );
     }
@@ -51,7 +51,7 @@ public final class TextAsBoolTest {
     public void falseTest() throws IOException {
         MatcherAssert.assertThat(
             "Can't parse 'false' string",
-            new TextAsBool("false").asValue(),
+            new TextAsBool("false").value(),
             Matchers.equalTo(false)
         );
     }
@@ -60,7 +60,7 @@ public final class TextAsBoolTest {
     public void isFalseIfTextDoesNotRepresentABoolean() throws IOException {
         MatcherAssert.assertThat(
             "Can't parse a non-boolean string",
-            new TextAsBool("abc").asValue(),
+            new TextAsBool("abc").value(),
             Matchers.equalTo(false)
         );
     }

--- a/src/test/java/org/cactoos/text/TextAsDoubleTest.java
+++ b/src/test/java/org/cactoos/text/TextAsDoubleTest.java
@@ -42,7 +42,7 @@ public final class TextAsDoubleTest {
     public strictfp void numberTest() throws IOException {
         MatcherAssert.assertThat(
             "Can't parse double number",
-            new TextAsDouble("185.65156465123").asValue(),
+            new TextAsDouble("185.65156465123").value(),
             // @checkstyle MagicNumber (1 line)
             Matchers.equalTo(185.65156465123)
         );
@@ -50,6 +50,6 @@ public final class TextAsDoubleTest {
 
     @Test(expected = NumberFormatException.class)
     public void failsIfTextDoesNotRepresentADouble() throws IOException {
-        new TextAsDouble("abc").asValue();
+        new TextAsDouble("abc").value();
     }
 }

--- a/src/test/java/org/cactoos/text/TextAsFloatTest.java
+++ b/src/test/java/org/cactoos/text/TextAsFloatTest.java
@@ -42,7 +42,7 @@ public final class TextAsFloatTest {
     public strictfp void numberTest() throws IOException {
         MatcherAssert.assertThat(
             "Can't parse float number",
-            new TextAsFloat("1656.894").asValue(),
+            new TextAsFloat("1656.894").value(),
             // @checkstyle MagicNumber (1 line)
             Matchers.equalTo(1656.894F)
         );
@@ -50,6 +50,6 @@ public final class TextAsFloatTest {
 
     @Test(expected = NumberFormatException.class)
     public void failsIfTextDoesNotRepresentAFloat() throws IOException {
-        new TextAsFloat("abc").asValue();
+        new TextAsFloat("abc").value();
     }
 }

--- a/src/test/java/org/cactoos/text/TextAsIntTest.java
+++ b/src/test/java/org/cactoos/text/TextAsIntTest.java
@@ -42,7 +42,7 @@ public final class TextAsIntTest {
     public void numberTest() throws IOException {
         MatcherAssert.assertThat(
             "Can't parse integer number",
-            new TextAsInt("1867892354").asValue(),
+            new TextAsInt("1867892354").value(),
             // @checkstyle MagicNumber (1 line)
             Matchers.equalTo(1867892354)
         );
@@ -50,6 +50,6 @@ public final class TextAsIntTest {
 
     @Test(expected = NumberFormatException.class)
     public void failsIfTextDoesNotRepresentAnInt() throws IOException {
-        new TextAsDouble("abc").asValue();
+        new TextAsDouble("abc").value();
     }
 }

--- a/src/test/java/org/cactoos/text/TextAsLongTest.java
+++ b/src/test/java/org/cactoos/text/TextAsLongTest.java
@@ -42,7 +42,7 @@ public final class TextAsLongTest {
     public void numberTest() throws IOException {
         MatcherAssert.assertThat(
             "Can't parse long number",
-            new TextAsLong("186789235425346").asValue(),
+            new TextAsLong("186789235425346").value(),
             // @checkstyle MagicNumber (1 line)
             Matchers.equalTo(186789235425346L)
         );
@@ -50,6 +50,6 @@ public final class TextAsLongTest {
 
     @Test(expected = NumberFormatException.class)
     public void failsIfTextDoesNotRepresentALong() throws IOException {
-        new TextAsLong("abc").asValue();
+        new TextAsLong("abc").value();
     }
 }

--- a/src/test/java/org/cactoos/text/UrlAsStringTest.java
+++ b/src/test/java/org/cactoos/text/UrlAsStringTest.java
@@ -40,7 +40,7 @@ public final class UrlAsStringTest {
     public void decodeUrlToString() throws Exception {
         MatcherAssert.assertThat(
             "Can't convert a string to URL",
-            new UrlAsString("%D0%B0%20%D1%8F").asValue(),
+            new UrlAsString("%D0%B0%20%D1%8F").value(),
             Matchers.equalTo("а я")
         );
     }


### PR DESCRIPTION
As per #211:

Changed `Scalar<T>.asValue()` to `Scalar<T>.value()`.