### PR TITLE
#267: Eclipse cannot infer type arguments for ChainedFuncTest

### DIFF
--- a/src/test/java/org/cactoos/func/ChainedFuncTest.java
+++ b/src/test/java/org/cactoos/func/ChainedFuncTest.java
@@ -50,7 +50,7 @@ public final class ChainedFuncTest {
                 new FilteredIterable<>(
                     new MappedIterable<>(
                         new ArrayAsIterable<>("public", "final", "class"),
-                        new ChainedFunc<>(
+                        new ChainedFunc<String, String, String>(
                             input -> input.concat("1"),
                             input -> input.concat("2")
                         )


### PR DESCRIPTION
As per #267 .