### PR TITLE
#327: Eclipse cannot infer type arguments for AndTest

### DIFF
--- a/src/test/java/org/cactoos/func/AndTest.java
+++ b/src/test/java/org/cactoos/func/AndTest.java
@@ -97,7 +97,7 @@ public final class AndTest {
         MatcherAssert.assertThat(
             "Can't iterate a list with a procedure",
             new And(
-                new MappedIterable<>(
+                new MappedIterable<String, Scalar<Boolean>>(
                     new ArrayAsIterable<>("hello", "world"),
                     new FuncOf<>(list::add, () -> true)
                 )


### PR DESCRIPTION
As per #327 .