### PR TITLE
#460 Max and Min were renamed to HighestOf and LowestOf to support Comparable implementations

### DIFF
--- a/src/main/java/org/cactoos/func/MaxFunc.java
+++ b/src/main/java/org/cactoos/func/MaxFunc.java
@@ -1,0 +1,45 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.func;
+
+import org.cactoos.BiFunc;
+
+/**
+ * Function, finding max among two items.
+ *
+ * @author Alexander Dyadyushenko (gookven@gmail.com)
+ * @version $Id$
+ * @param <T> comparable type
+ * @since 0.9
+ */
+public final class MaxFunc<T extends Comparable<T>> implements BiFunc<T, T, T> {
+    @Override
+    public T apply(final T first, final T second) throws Exception {
+        T max = first;
+        if (second.compareTo(max) > 0) {
+            max = second;
+        }
+        return max;
+    }
+}

--- a/src/main/java/org/cactoos/func/MinFunc.java
+++ b/src/main/java/org/cactoos/func/MinFunc.java
@@ -1,0 +1,45 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.func;
+
+import org.cactoos.BiFunc;
+
+/**
+ * Function, finding min among two items.
+ *
+ * @author Alexander Dyadyushenko (gookven@gmail.com)
+ * @version $Id$
+ * @param <T> comparable type
+ * @since 0.9
+ */
+public final class MinFunc<T extends Comparable<T>> implements BiFunc<T, T, T> {
+    @Override
+    public T apply(final T first, final T second) throws Exception {
+        T min = first;
+        if (second.compareTo(min) < 0) {
+            min = second;
+        }
+        return min;
+    }
+}

--- a/src/main/java/org/cactoos/scalar/Folded.java
+++ b/src/main/java/org/cactoos/scalar/Folded.java
@@ -1,0 +1,83 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.scalar;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import org.cactoos.BiFunc;
+import org.cactoos.Scalar;
+
+/**
+ * Folds iterable via BiFunc
+ *
+ * <p>There is no thread-safety guarantee.
+ *
+ * <p>This class implements {@link Scalar}, which throws a checked
+ * {@link Exception}. This may not be convenient in many cases. To make
+ * it more convenient and get rid of the checked exception you can
+ * use {@link UncheckedScalar} or {@link IoCheckedScalar} decorators.</p>
+ *
+ * @author Alexander Dyadyushenko (gookven@gmail.com)
+ * @version $Id$
+ * @param <T> Scalar type
+ * @since 0.9
+ */
+public final class Folded<T> implements Scalar<T> {
+
+    /**
+     * Items.
+     */
+    private final Iterable<Scalar<T>> items;
+
+    /**
+     * Folding function.
+     */
+    private final BiFunc<T, T, T> fold;
+
+    /**
+     * Ctor.
+     * @param fold Folding function
+     * @param items The items
+     */
+    public Folded(final BiFunc<T, T, T> fold, final Iterable<Scalar<T>> items) {
+        this.items = items;
+        this.fold = fold;
+    }
+
+    @Override
+    public T value() throws Exception {
+        final Iterator<Scalar<T>> iter = this.items.iterator();
+        if (!iter.hasNext()) {
+            throw new NoSuchElementException(
+                "Can't find first element in an empty iterable"
+            );
+        }
+        T acc = iter.next().value();
+        while (iter.hasNext()) {
+            final T next = iter.next().value();
+            acc = this.fold.apply(acc, next);
+        }
+        return acc;
+    }
+}

--- a/src/main/java/org/cactoos/scalar/HighestOf.java
+++ b/src/main/java/org/cactoos/scalar/HighestOf.java
@@ -1,0 +1,79 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.scalar;
+
+import org.cactoos.Scalar;
+import org.cactoos.func.MaxFunc;
+import org.cactoos.iterable.IterableOf;
+
+/**
+ * Find the greater among items.
+ *
+ * <p>This class implements {@link Scalar}, which throws a checked
+ * {@link Exception}. This may not be convenient in many cases. To make
+ * it more convenient and get rid of the checked exception you can
+ * use {@link UncheckedScalar} or {@link IoCheckedScalar} decorators.</p>
+ *
+ * <p>There is no thread-safety guarantee.
+ *
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @param <T> Scalar type
+ * @see UncheckedScalar
+ * @see IoCheckedScalar
+ * @since 0.10
+ */
+public final class HighestOf<T extends Comparable<T>> implements Scalar<T> {
+
+    /**
+     * Items.
+     */
+    private final Scalar<T> result;
+
+    /**
+     * Ctor.
+     * @param scalars The items
+     */
+    @SafeVarargs
+    public HighestOf(final Scalar<T>... scalars) {
+        this(new IterableOf<>(scalars));
+    }
+
+    /**
+     * Ctor.
+     * @param iterable The items
+     */
+    public HighestOf(final Iterable<Scalar<T>> iterable) {
+        this.result = new Folded<>(
+            new MaxFunc<>(),
+            iterable
+        );
+    }
+
+    @Override
+    public T value() throws Exception {
+        return this.result.value();
+    }
+
+}

--- a/src/main/java/org/cactoos/scalar/LowestOf.java
+++ b/src/main/java/org/cactoos/scalar/LowestOf.java
@@ -1,0 +1,77 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.scalar;
+
+import org.cactoos.Scalar;
+import org.cactoos.func.MinFunc;
+import org.cactoos.iterable.IterableOf;
+
+/**
+ * Find the smaller among items.
+ *
+ * <p>There is no thread-safety guarantee.
+ *
+ * <p>This class implements {@link Scalar}, which throws a checked
+ * {@link Exception}. This may not be convenient in many cases. To make
+ * it more convenient and get rid of the checked exception you can
+ * use {@link UncheckedScalar} or {@link IoCheckedScalar} decorators.</p>
+ *
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @version $Id$
+ * @param <T> Scalar type
+ * @since 0.9
+ */
+public final class LowestOf<T extends Comparable<T>> implements Scalar<T> {
+
+    /**
+     * Items.
+     */
+    private final Scalar<T> result;
+
+    /**
+     * Ctor.
+     * @param scalars The items
+     */
+    @SafeVarargs
+    public LowestOf(final Scalar<T>... scalars) {
+        this(new IterableOf<>(scalars));
+    }
+
+    /**
+     * Ctor.
+     * @param iterable The items
+     */
+    public LowestOf(final Iterable<Scalar<T>> iterable) {
+        this.result = new Folded<>(
+            new MinFunc<>(),
+            iterable
+        );
+    }
+
+    @Override
+    public T value() throws Exception {
+        return this.result.value();
+    }
+
+}

--- a/src/test/java/org/cactoos/scalar/HighestOfTest.java
+++ b/src/test/java/org/cactoos/scalar/HighestOfTest.java
@@ -1,0 +1,94 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.scalar;
+
+import java.util.Collections;
+import java.util.NoSuchElementException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link HighestOf}.
+ *
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @author Eduard Balovnev (bedward70@mail.ru)
+ * @version $Id$
+ * @since 0.10
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class HighestOfTest {
+
+    @Test(expected = NoSuchElementException.class)
+    public void maxAmongEmptyTest() throws Exception {
+        new HighestOf<>(() -> Collections.emptyIterator()).value();
+    }
+
+    @Test
+    public void maxAmongOneTest() throws Exception {
+        final int num = 10;
+        MatcherAssert.assertThat(
+            "Can't find the greater among one",
+            new HighestOf<Integer>(() -> new Integer(num)).value(),
+            Matchers.equalTo(num)
+        );
+    }
+
+    @Test
+    public void maxAmongManyTest() throws Exception {
+        final int num = 10;
+        MatcherAssert.assertThat(
+            "Can't find the greater among many",
+            new HighestOf<Integer>(
+                () -> new Integer(num),
+                () -> new Integer(0),
+                () -> new Integer(-1),
+                () -> new Integer(2)
+             ).value(),
+            Matchers.equalTo(num)
+        );
+    }
+
+    @Test
+    public void highestStringTest() throws Exception {
+        final String lowest = "Apple";
+        final String highest = "Orange";
+        MatcherAssert.assertThat(
+            "Can't find the highest string among many",
+            new HighestOf<String>(() -> lowest, () -> highest).value(),
+            Matchers.equalTo(highest)
+        );
+    }
+
+    @Test
+    public void highestCharTest() throws Exception {
+        final char lowest = 'A';
+        final char highest = 'B';
+        MatcherAssert.assertThat(
+            "Can't find the highest char among many",
+            new HighestOf<Character>(() -> lowest, () -> highest).value(),
+            Matchers.equalTo(highest)
+        );
+    }
+}

--- a/src/test/java/org/cactoos/scalar/LowestOfTest.java
+++ b/src/test/java/org/cactoos/scalar/LowestOfTest.java
@@ -1,0 +1,94 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.scalar;
+
+import java.util.Collections;
+import java.util.NoSuchElementException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link LowestOf}.
+ *
+ * @author Fabricio Cabral (fabriciofx@gmail.com)
+ * @author Eduard Balovnev (bedward70@mail.ru)
+ * @version $Id$
+ * @since 0.10
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class LowestOfTest {
+
+    @Test(expected = NoSuchElementException.class)
+    public void minAmongEmptyTest() throws Exception {
+        new LowestOf<>(() -> Collections.emptyIterator()).value();
+    }
+
+    @Test
+    public void minAmongOneTest() throws Exception {
+        final int num = 10;
+        MatcherAssert.assertThat(
+            "Can't find the smaller among one",
+            new LowestOf<Integer>(() -> new Integer(num)).value(),
+            Matchers.equalTo(num)
+        );
+    }
+
+    @Test
+    public void minAmongManyTest() throws Exception {
+        final int num = -1;
+        MatcherAssert.assertThat(
+            "Can't find the smaller among many",
+            new LowestOf<Integer>(
+                () -> new Integer(1),
+                () -> new Integer(0),
+                () -> new Integer(num),
+                () -> new Integer(2)
+             ).value(),
+            Matchers.equalTo(num)
+        );
+    }
+
+    @Test
+    public void lowestStringTest() throws Exception {
+        final String lowest = "Apple";
+        final String highest = "Orange";
+        MatcherAssert.assertThat(
+            "Can't find the lowest string among many",
+            new LowestOf<String>(() -> lowest, () -> highest).value(),
+            Matchers.equalTo(lowest)
+        );
+    }
+
+    @Test
+    public void lowestCharTest() throws Exception {
+        final char lowest = 'A';
+        final char highest = 'B';
+        MatcherAssert.assertThat(
+            "Can't find the lowest char among many",
+            new LowestOf<Character>(() -> lowest, () -> highest).value(),
+            Matchers.equalTo(lowest)
+        );
+    }
+}


### PR DESCRIPTION
_After the discussion_ "MaxOf and MinOf #460".

To support  [Comparable](https://docs.oracle.com/javase/8/docs/api/java/lang/Comparable.html) implementations:
1. Max and Min were renamed to HighestOf and LowestOf.
2. Tests were added for `Comparable` implementations: `String`, `Character`.