### PR TITLE
README.md - Merging 'StickyList' comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,7 @@ Cactoos | Guava | Apache Commons | JDK 8
 `ReversedText` | - | - | `StringBuilder#reverse()`
 `RotatedText` | - | `StringUtils.rotate()`| -
 `SplitText` | - | - | `String#split()`
-`StickyList` | ? | ? | `Arrays.asList()`
-`StickyList` | `Lists.newArrayList()` | ? | -
+`StickyList` | `Lists.newArrayList()` | ? | `Arrays.asList()`
 `SubText` | - | - | `String#substring()`
 `SwappedCaseText` | - | `StringUtils.swapCase()` | -
 `TextOf` | ? | `IOUtils.toString()` | -


### PR DESCRIPTION
The README file has two lines for `StickyList` comparisons. This PR merges the two lines into one.