### PR TITLE
Refactoring dependencies of Unhecked/IOChecked classes.

### DIFF
--- a/src/main/java/org/cactoos/func/IoCheckedBiFunc.java
+++ b/src/main/java/org/cactoos/func/IoCheckedBiFunc.java
@@ -25,6 +25,7 @@ package org.cactoos.func;
 
 import java.io.IOException;
 import org.cactoos.BiFunc;
+import org.cactoos.scalar.IoCheckedScalar;
 
 /**
  * Func that doesn't throw checked {@link Exception}, but throws
@@ -54,26 +55,10 @@ public final class IoCheckedBiFunc<X, Y, Z> implements BiFunc<X, Y, Z> {
     }
 
     @Override
-    @SuppressWarnings
-        (
-            {
-                "PMD.AvoidCatchingGenericException",
-                "PMD.AvoidRethrowingException"
-            }
-        )
     public Z apply(final X first, final Y second) throws IOException {
-        try {
-            return this.func.apply(first, second);
-            // @checkstyle IllegalCatchCheck (1 line)
-        } catch (final IOException | RuntimeException ex) {
-            throw ex;
-        } catch (final InterruptedException ex) {
-            Thread.currentThread().interrupt();
-            throw new IOException(ex);
-            // @checkstyle IllegalCatchCheck (1 line)
-        } catch (final Exception ex) {
-            throw new IOException(ex);
-        }
+        return new IoCheckedScalar<>(
+            () -> this.func.apply(first, second)
+        ).value();
     }
 
 }

--- a/src/main/java/org/cactoos/func/IoCheckedBiProc.java
+++ b/src/main/java/org/cactoos/func/IoCheckedBiProc.java
@@ -24,7 +24,6 @@
 package org.cactoos.func;
 
 import java.io.IOException;
-import org.cactoos.BiFunc;
 import org.cactoos.BiProc;
 
 /**
@@ -57,10 +56,7 @@ public final class IoCheckedBiProc<X, Y> implements BiProc<X, Y> {
     @Override
     public void exec(final X first, final Y second) throws IOException {
         new IoCheckedBiFunc<>(
-            (BiFunc<X, Y, Boolean>) (fst, snd) -> {
-                this.proc.exec(fst, snd);
-                return true;
-            }
+            new BiFuncOf<>(this.proc, null)
         ).apply(first, second);
     }
 

--- a/src/main/java/org/cactoos/func/IoCheckedFunc.java
+++ b/src/main/java/org/cactoos/func/IoCheckedFunc.java
@@ -24,8 +24,8 @@
 package org.cactoos.func;
 
 import java.io.IOException;
-import org.cactoos.BiFunc;
 import org.cactoos.Func;
+import org.cactoos.scalar.IoCheckedScalar;
 
 /**
  * Func that doesn't throw checked {@link Exception}, but throws
@@ -56,9 +56,7 @@ public final class IoCheckedFunc<X, Y> implements Func<X, Y> {
 
     @Override
     public Y apply(final X input) throws IOException {
-        return new IoCheckedBiFunc<>(
-            (BiFunc<X, Boolean, Y>) (first, second) -> this.func.apply(first)
-        ).apply(input, true);
+        return new IoCheckedScalar<>(() -> this.func.apply(input)).value();
     }
 
 }

--- a/src/main/java/org/cactoos/func/IoCheckedProc.java
+++ b/src/main/java/org/cactoos/func/IoCheckedProc.java
@@ -24,7 +24,6 @@
 package org.cactoos.func;
 
 import java.io.IOException;
-import org.cactoos.Func;
 import org.cactoos.Proc;
 
 /**
@@ -55,12 +54,7 @@ public final class IoCheckedProc<X> implements Proc<X> {
 
     @Override
     public void exec(final X input) throws IOException {
-        new IoCheckedFunc<>(
-            (Func<X, Boolean>) arg -> {
-                this.proc.exec(arg);
-                return true;
-            }
-        ).apply(input);
+        new IoCheckedFunc<>(new FuncOf<>(this.proc)).apply(input);
     }
 
 }

--- a/src/main/java/org/cactoos/func/UncheckedBiFunc.java
+++ b/src/main/java/org/cactoos/func/UncheckedBiFunc.java
@@ -23,9 +23,8 @@
  */
 package org.cactoos.func;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import org.cactoos.BiFunc;
+import org.cactoos.scalar.UncheckedScalar;
 
 /**
  * BiFunc that doesn't throw checked {@link Exception}.
@@ -56,10 +55,8 @@ public final class UncheckedBiFunc<X, Y, Z> implements BiFunc<X, Y, Z> {
 
     @Override
     public Z apply(final X first, final Y second) {
-        try {
-            return new IoCheckedBiFunc<>(this.func).apply(first, second);
-        } catch (final IOException ex) {
-            throw new UncheckedIOException(ex);
-        }
+        return new UncheckedScalar<>(
+            () -> this.func.apply(first, second)
+        ).value();
     }
 }

--- a/src/main/java/org/cactoos/func/UncheckedBiProc.java
+++ b/src/main/java/org/cactoos/func/UncheckedBiProc.java
@@ -23,7 +23,6 @@
  */
 package org.cactoos.func;
 
-import org.cactoos.BiFunc;
 import org.cactoos.BiProc;
 
 /**
@@ -55,10 +54,7 @@ public final class UncheckedBiProc<X, Y> implements BiProc<X, Y> {
     @Override
     public void exec(final X first, final Y second) {
         new UncheckedBiFunc<>(
-            (BiFunc<X, Y, Boolean>) (fst, snd) -> {
-                this.proc.exec(fst, snd);
-                return true;
-            }
+            new BiFuncOf<>(this.proc, null)
         ).apply(first, second);
     }
 }

--- a/src/main/java/org/cactoos/func/UncheckedFunc.java
+++ b/src/main/java/org/cactoos/func/UncheckedFunc.java
@@ -23,8 +23,8 @@
  */
 package org.cactoos.func;
 
-import org.cactoos.BiFunc;
 import org.cactoos.Func;
+import org.cactoos.scalar.UncheckedScalar;
 
 /**
  * Func that doesn't throw checked {@link Exception}.
@@ -54,9 +54,9 @@ public final class UncheckedFunc<X, Y> implements Func<X, Y> {
 
     @Override
     public Y apply(final X input) {
-        return new UncheckedBiFunc<>(
-            (BiFunc<X, Boolean, Y>) (first, second) -> this.func.apply(first)
-        ).apply(input, true);
+        return new UncheckedScalar<>(
+            () -> this.func.apply(input)
+        ).value();
     }
 
 }

--- a/src/main/java/org/cactoos/scalar/IoCheckedScalar.java
+++ b/src/main/java/org/cactoos/scalar/IoCheckedScalar.java
@@ -25,7 +25,6 @@ package org.cactoos.scalar;
 
 import java.io.IOException;
 import org.cactoos.Scalar;
-import org.cactoos.func.IoCheckedFunc;
 
 /**
  * Scalar that doesn't throw checked {@link Exception}, but throws
@@ -59,10 +58,26 @@ public final class IoCheckedScalar<T> implements Scalar<T> {
     }
 
     @Override
+    @SuppressWarnings
+        (
+            {
+                "PMD.AvoidCatchingGenericException",
+                "PMD.AvoidRethrowingException"
+            }
+        )
     public T value() throws IOException {
-        return new IoCheckedFunc<Scalar<T>, T>(
-            Scalar::value
-        ).apply(this.origin);
+        try {
+            return this.origin.value();
+            // @checkstyle IllegalCatchCheck (1 line)
+        } catch (final IOException | RuntimeException ex) {
+            throw ex;
+        } catch (final InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new IOException(ex);
+            // @checkstyle IllegalCatchCheck (1 line)
+        } catch (final Exception ex) {
+            throw new IOException(ex);
+        }
     }
 
 }

--- a/src/main/java/org/cactoos/scalar/UncheckedScalar.java
+++ b/src/main/java/org/cactoos/scalar/UncheckedScalar.java
@@ -23,9 +23,9 @@
  */
 package org.cactoos.scalar;
 
-import org.cactoos.Func;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import org.cactoos.Scalar;
-import org.cactoos.func.UncheckedFunc;
 
 /**
  * Scalar that doesn't throw checked {@link Exception}.
@@ -54,9 +54,11 @@ public final class UncheckedScalar<T> implements Scalar<T> {
 
     @Override
     public T value() {
-        return new UncheckedFunc<>(
-            (Func<Boolean, T>) input -> this.origin.value()
-        ).apply(true);
+        try {
+            return new IoCheckedScalar<>(this.origin::value).value();
+        } catch (final IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
     }
 
 }

--- a/src/test/java/org/cactoos/func/IoCheckedBiFuncTest.java
+++ b/src/test/java/org/cactoos/func/IoCheckedBiFuncTest.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 public final class IoCheckedBiFuncTest {
 
     @Test
-    public void rethrowsCheckedToUncheckedException() {
+    public void rethrowsIoException() {
         final IOException exception = new IOException("intended");
         try {
             new IoCheckedBiFunc<>(
@@ -54,7 +54,7 @@ public final class IoCheckedBiFuncTest {
     }
 
     @Test(expected = IOException.class)
-    public void throwsException() throws Exception {
+    public void rethrowsCheckedToIoException() throws Exception {
         new IoCheckedBiFunc<>(
             (fst, scd) -> {
                 throw new Exception("intended to fail");

--- a/src/test/java/org/cactoos/func/IoCheckedFuncTest.java
+++ b/src/test/java/org/cactoos/func/IoCheckedFuncTest.java
@@ -40,7 +40,7 @@ import org.junit.Test;
 public final class IoCheckedFuncTest {
 
     @Test
-    public void rethrowsCheckedToUncheckedException() {
+    public void rethrowsIoException() {
         final IOException exception = new IOException("intended");
         try {
             new IoCheckedFunc<>(
@@ -53,6 +53,24 @@ public final class IoCheckedFuncTest {
                 ex, Matchers.is(exception)
             );
         }
+    }
+
+    @Test(expected = IOException.class)
+    public void rethrowsCheckedToIoException() throws Exception {
+        new IoCheckedFunc<>(
+            i -> {
+                throw new Exception("intended to fail");
+            }
+        ).apply(1);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void runtimeExceptionGoesOut() throws IOException {
+        new IoCheckedFunc<>(
+            i -> {
+                throw new IllegalStateException("intended to fail here");
+            }
+        ).apply(1);
     }
 
 }

--- a/src/test/java/org/cactoos/func/IoCheckedProcTest.java
+++ b/src/test/java/org/cactoos/func/IoCheckedProcTest.java
@@ -38,9 +38,8 @@ import org.junit.Test;
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 public final class IoCheckedProcTest {
-
     @Test
-    public void rethrowsCheckedToUncheckedException() {
+    public void rethrowsIoException() {
         final IOException exception = new IOException("intended");
         try {
             new IoCheckedProc<>(
@@ -53,6 +52,24 @@ public final class IoCheckedProcTest {
                 ex, Matchers.is(exception)
             );
         }
+    }
+
+    @Test(expected = IOException.class)
+    public void rethrowsCheckedToIoException() throws Exception {
+        new IoCheckedProc<>(
+            i -> {
+                throw new Exception("intended to fail");
+            }
+        ).exec(1);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void runtimeExceptionGoesOut() throws IOException {
+        new IoCheckedProc<>(
+            i -> {
+                throw new IllegalStateException("intended to fail here");
+            }
+        ).exec(1);
     }
 
 }

--- a/src/test/java/org/cactoos/func/UncheckedFuncTest.java
+++ b/src/test/java/org/cactoos/func/UncheckedFuncTest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
  * Test case for {@link UncheckedFunc}.
  *
  * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id: c6da6ab1708d13ee64fe35d89fe217387d703e17 $
+ * @version $Id$
  * @since 0.2
  * @checkstyle JavadocMethodCheck (500 lines)
  */

--- a/src/test/java/org/cactoos/func/UncheckedFuncTest.java
+++ b/src/test/java/org/cactoos/func/UncheckedFuncTest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
  * Test case for {@link UncheckedFunc}.
  *
  * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
+ * @version $Id: c6da6ab1708d13ee64fe35d89fe217387d703e17 $
  * @since 0.2
  * @checkstyle JavadocMethodCheck (500 lines)
  */
@@ -43,6 +43,15 @@ public final class UncheckedFuncTest {
         new UncheckedFunc<>(
             (Func<Integer, String>) i -> {
                 throw new IOException("intended");
+            }
+        ).apply(1);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void runtimeExceptionGoesOut() {
+        new UncheckedFunc<>(
+            i -> {
+                throw new IllegalStateException("intended to fail");
             }
         ).apply(1);
     }

--- a/src/test/java/org/cactoos/func/UncheckedProcTest.java
+++ b/src/test/java/org/cactoos/func/UncheckedProcTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
  * Test case for {@link UncheckedProc}.
  *
  * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id: 59361df323d11d09fefce8e88269d4021d4d0dfe $
+ * @version $Id$
  * @since 0.2
  * @checkstyle JavadocMethodCheck (500 lines)
  */

--- a/src/test/java/org/cactoos/func/UncheckedProcTest.java
+++ b/src/test/java/org/cactoos/func/UncheckedProcTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
  * Test case for {@link UncheckedProc}.
  *
  * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
+ * @version $Id: 59361df323d11d09fefce8e88269d4021d4d0dfe $
  * @since 0.2
  * @checkstyle JavadocMethodCheck (500 lines)
  */
@@ -42,6 +42,15 @@ public final class UncheckedProcTest {
         new UncheckedProc<>(
             input -> {
                 throw new IOException("intended");
+            }
+        ).exec(1);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void runtimeExceptionGoesOut() {
+        new UncheckedProc<>(
+            i -> {
+                throw new IllegalStateException("intended to fail");
             }
         ).exec(1);
     }

--- a/src/test/java/org/cactoos/scalar/IoCheckedScalarTest.java
+++ b/src/test/java/org/cactoos/scalar/IoCheckedScalarTest.java
@@ -24,7 +24,6 @@
 package org.cactoos.scalar;
 
 import java.io.IOException;
-import org.cactoos.Scalar;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -40,11 +39,11 @@ import org.junit.Test;
 public final class IoCheckedScalarTest {
 
     @Test
-    public void rethrowsCheckedToUncheckedException() {
+    public void rethrowsIoException() {
         final IOException exception = new IOException("intended");
         try {
             new IoCheckedScalar<>(
-                (Scalar<Integer>) () -> {
+                () -> {
                     throw exception;
                 }
             ).value();
@@ -53,6 +52,24 @@ public final class IoCheckedScalarTest {
                 ex, Matchers.is(exception)
             );
         }
+    }
+
+    @Test(expected = IOException.class)
+    public void throwsException() throws Exception {
+        new IoCheckedScalar<>(
+            () -> {
+                throw new Exception("intended to fail");
+            }
+        ).value();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void runtimeExceptionGoesOut() throws IOException {
+        new IoCheckedScalar<>(
+            () -> {
+                throw new IllegalStateException("intended to fail here");
+            }
+        ).value();
     }
 
 }


### PR DESCRIPTION
Currently, the following chain of objects triggered when a single `UncheckedScalar`'s value evaluated:
`UncheckedScalar` -> `UncheckedFunc` -> `UncheckedBiFunc` -> `IoCheckedBiFunc` excluding Intermediate lambdas. I found this calls too expensive and fixed dependencies hell. In my version `UncheckedScalar` and `IoCncheckedScalar` do all the work themselves and other unchecked classes call them directly.

Additional tests which were missing for some reason added.