### PR TITLE
#532 AvgOf() bug on Double edge values fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ new LengthOf(
     "Hello, world!",
     new File("/code/a.txt")
   )
-).value();
+).intValue();
 ```
 
 To read a binary file from classpath:
@@ -170,7 +170,7 @@ To count elements in an iterable:
 ```java
 int total = new LengthOf(
   "how", "are", "you"
-).value();
+).intValue();
 ```
 
 ## Funcs and Procs

--- a/src/main/java/org/cactoos/scalar/AvgOf.java
+++ b/src/main/java/org/cactoos/scalar/AvgOf.java
@@ -23,7 +23,9 @@
  */
 package org.cactoos.scalar;
 
-import java.util.Iterator;
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.util.stream.StreamSupport;
 import org.cactoos.Scalar;
 import org.cactoos.iterable.IterableOf;
 
@@ -71,48 +73,19 @@ public final class AvgOf extends NumberEnvelope {
      * @param src Numbers
      */
     public AvgOf(final Integer... src) {
-        super(() -> {
-            long sum = 0L;
-            long total = 0L;
-            for (final int val : src) {
-                sum += (long) val;
-                ++total;
-            }
-            if (total == 0L) {
-                total = 1L;
-            }
-            return sum / total;
-        }, () -> {
-            double sum = 0;
-            double total = 1;
-            for (final double val : src) {
-                sum += (val - sum) / total;
-                ++total;
-            }
-            return (int) sum;
-        }, () -> {
-            float sum = 0.0f;
-            float total = 0.0f;
-            for (final int val : src) {
-                sum += (float) val;
-                total += 1.0f;
-            }
-            if (total == 0.0f) {
-                total = 1.0f;
-            }
-            return sum / total;
-        }, () -> {
-            double sum = 0.0d;
-            double total = 0.0d;
-            for (final int val : src) {
-                sum += (double) val;
-                total += 1.0d;
-            }
-            if (total == 0.0d) {
-                total = 1.0d;
-            }
-            return sum / total;
-        });
+        super(() -> avgArray(
+            number -> BigDecimal.valueOf(number.intValue()), src
+            ).longValue(),
+            () -> avgArray(
+                number -> BigDecimal.valueOf(number.intValue()), src
+            ).intValue(),
+            () -> avgArray(
+                number -> BigDecimal.valueOf(number.intValue()), src
+            ).floatValue(),
+            () -> avgArray(
+                number -> BigDecimal.valueOf(number.intValue()), src
+            ).doubleValue()
+        );
     }
 
     /**
@@ -120,48 +93,19 @@ public final class AvgOf extends NumberEnvelope {
      * @param src Numbers
      */
     public AvgOf(final Long... src) {
-        super(() -> {
-            double sum = 0d;
-            double total = 1d;
-            for (final double val : src) {
-                sum += (val - sum) / total;
-                ++total;
-            }
-            return (long) sum;
-        }, () -> {
-            int sum = 0;
-            int total = 0;
-            for (final long val : src) {
-                sum += (int) val;
-                ++total;
-            }
-            if (total == 0) {
-                total = 1;
-            }
-            return sum / total;
-        }, () -> {
-            float sum = 0.0f;
-            float total = 0.0f;
-            for (final long val : src) {
-                sum += (float) val;
-                total += 1.0f;
-            }
-            if (total == 0.0f) {
-                total = 1.0f;
-            }
-            return sum / total;
-        }, () -> {
-            double sum = 0.0d;
-            double total = 0.0d;
-            for (final long val : src) {
-                sum += (double) val;
-                total += 1.0d;
-            }
-            if (total == 0.0d) {
-                total = 1.0d;
-            }
-            return sum / total;
-        });
+        super(() -> avgArray(
+            number -> BigDecimal.valueOf(number.longValue()), src
+            ).longValue(),
+            () -> avgArray(
+                number -> BigDecimal.valueOf(number.longValue()), src
+            ).intValue(),
+            () -> avgArray(
+                number -> BigDecimal.valueOf(number.longValue()), src
+            ).floatValue(),
+            () -> avgArray(
+                number -> BigDecimal.valueOf(number.longValue()), src
+            ).doubleValue()
+        );
     }
 
     /**
@@ -169,48 +113,19 @@ public final class AvgOf extends NumberEnvelope {
      * @param src Numbers
      */
     public AvgOf(final Double... src) {
-        super(() -> {
-            long sum = 0L;
-            long total = 0L;
-            for (final double val : src) {
-                sum += (long) val;
-                ++total;
-            }
-            if (total == 0L) {
-                total = 1L;
-            }
-            return sum / total;
-        }, () -> {
-            int sum = 0;
-            int total = 0;
-            for (final double val : src) {
-                sum += (int) val;
-                ++total;
-            }
-            if (total == 0) {
-                total = 1;
-            }
-            return sum / total;
-        }, () -> {
-            float sum = 0.0f;
-            float total = 0.0f;
-            for (final double val : src) {
-                sum += (float) val;
-                total += 1.0f;
-            }
-            if (total == 0.0f) {
-                total = 1.0f;
-            }
-            return sum / total;
-        }, () -> {
-            double sum = 0.0d;
-            double total = 1.0d;
-            for (final double val : src) {
-                sum += (val - sum) / total;
-                total += 1.0d;
-            }
-            return sum;
-        });
+        super(() -> avgArray(
+            number -> BigDecimal.valueOf(number), src
+            ).longValue(),
+            () -> avgArray(
+                number -> BigDecimal.valueOf(number), src
+            ).intValue(),
+            () -> avgArray(
+                number -> BigDecimal.valueOf(number), src
+            ).floatValue(),
+            () -> avgArray(
+                number -> new BigDecimal(number), src
+            ).doubleValue()
+        );
     }
 
     /**
@@ -218,48 +133,19 @@ public final class AvgOf extends NumberEnvelope {
      * @param src Numbers
      */
     public AvgOf(final Float... src) {
-        super(() -> {
-            long sum = 0L;
-            long total = 0L;
-            for (final float val : src) {
-                sum += (long) val;
-                ++total;
-            }
-            if (total == 0L) {
-                total = 1L;
-            }
-            return sum / total;
-        }, () -> {
-            int sum = 0;
-            int total = 0;
-            for (final float val : src) {
-                sum += (int) val;
-                ++total;
-            }
-            if (total == 0) {
-                total = 1;
-            }
-            return sum / total;
-        }, () -> {
-            double sum = 0.0d;
-            double total = 1.0d;
-            for (final double val : src) {
-                sum += (val - sum) / total;
-                total += 1.0f;
-            }
-            return (float) sum;
-        }, () -> {
-            double sum = 0.0d;
-            double total = 0.0d;
-            for (final float val : src) {
-                sum += (double) val;
-                total += 1.0d;
-            }
-            if (total == 0.0d) {
-                total = 1.0d;
-            }
-            return sum / total;
-        });
+        super(() -> avgArray(
+            number -> BigDecimal.valueOf(number.floatValue()), src
+            ).longValue(),
+            () -> avgArray(
+                number -> BigDecimal.valueOf(number.floatValue()), src
+            ).intValue(),
+            () -> avgArray(
+                number -> BigDecimal.valueOf(number.floatValue()), src
+            ).floatValue(),
+            () -> avgArray(
+                number -> BigDecimal.valueOf(number.floatValue()), src
+            ).doubleValue()
+        );
     }
 
     /**
@@ -277,58 +163,76 @@ public final class AvgOf extends NumberEnvelope {
      * @checkstyle ExecutableStatementCountCheck (150 lines)
      */
     public AvgOf(final Iterable<Scalar<Number>> src) {
-        super(() -> {
-            final Iterator<Scalar<Number>> numbers = src.iterator();
-            long sum = 0L;
-            long total = 0L;
-            while (numbers.hasNext()) {
-                final Number next = numbers.next().value();
-                sum += next.longValue();
-                ++total;
-            }
-            if (total == 0L) {
-                total = 1L;
-            }
-            return sum / total;
-        }, () -> {
-            final Iterator<Scalar<Number>> numbers = src.iterator();
-            int sum = 0;
-            int total = 0;
-            while (numbers.hasNext()) {
-                final Number next = numbers.next().value();
-                sum += next.intValue();
-                ++total;
-            }
-            if (total == 0) {
-                total = 1;
-            }
-            return sum / total;
-        }, () -> {
-            final Iterator<Scalar<Number>> numbers = src.iterator();
-            float sum = 0.0f;
-            float total = 0.0f;
-            while (numbers.hasNext()) {
-                final Number next = numbers.next().value();
-                sum += next.floatValue();
-                total += 1.0f;
-            }
-            if (total == 0.0f) {
-                total = 1.0f;
-            }
-            return sum / total;
-        }, () -> {
-            final Iterator<Scalar<Number>> numbers = src.iterator();
-            double sum = 0.0d;
-            double total = 0.0d;
-            while (numbers.hasNext()) {
-                final Number next = numbers.next().value();
-                sum += next.doubleValue();
-                total += 1.0d;
-            }
-            if (total == 0.0d) {
-                total = 1.0d;
-            }
-            return sum / total;
-        });
+        super(() -> avgIterator(
+            number -> BigDecimal.valueOf(number.longValue()), src
+            ).longValue(),
+            () -> avgIterator(
+                number -> BigDecimal.valueOf(number.intValue()), src
+            ).intValue(),
+            () -> avgIterator(
+                number -> BigDecimal.valueOf(number.floatValue()), src
+            ).floatValue(),
+            () -> avgIterator(
+                number -> BigDecimal.valueOf(number.doubleValue()), src
+            ).doubleValue()
+        );
+    }
+
+    /**
+     * Calculates average from the provided numbers and uses {@link Converter}
+     * to create {@link BigDecimal}.
+     * @param converter The {@link Converter} to create {@link BigDecimal}
+     * @param src The numbers to calculate average.
+     * @return The average.
+     */
+    private static BigDecimal avgIterator(
+        final Converter<Number> converter, final Iterable<Scalar<Number>> src
+    ) {
+        return avgArray(
+            converter,
+            StreamSupport.stream(src.spliterator(), false)
+                .map(scalar -> new UncheckedScalar<>(scalar).value())
+                .toArray(Number[]::new)
+        );
+    }
+
+    /**
+     * Calculates average from the provided numbers and uses {@link Converter}
+     * to create {@link BigDecimal}.
+     * @param converter The {@link Converter} to create {@link BigDecimal}
+     * @param src The numbers to calculate average.
+     * @param <T> The type of numbers.
+     * @return The average.
+     */
+    @SafeVarargs
+    private static <T extends Number> BigDecimal avgArray(
+        final Converter<T> converter, final T... src
+    ) {
+        BigDecimal sum = BigDecimal.ZERO;
+        long count = 0;
+        for (final T value : src) {
+            sum = sum.add(converter.convert(value));
+            ++count;
+        }
+        if (count == 0) {
+            count = 1;
+        }
+        return sum.divide(
+            BigDecimal.valueOf(count), MathContext.DECIMAL128
+        );
+    }
+
+    /**
+     * The converter interface to provide {@link BigDecimal}.
+     * @param <T> The type of number.
+     */
+    @FunctionalInterface
+    private interface Converter<T extends Number> {
+        /**
+         * Converts the number to {@link BigDecimal}.
+         * @param number The number to convert.
+         * @return A {@link BigDecimal}.
+         */
+        BigDecimal convert(final T number);
     }
 }

--- a/src/main/java/org/cactoos/scalar/AvgOf.java
+++ b/src/main/java/org/cactoos/scalar/AvgOf.java
@@ -83,16 +83,16 @@ public final class AvgOf extends NumberEnvelope {
             }
             return sum / total;
         }, () -> {
-            int sum = 0;
-            int total = 0;
-            for (final int val : src) {
-                sum += val;
+            double sum = 0;
+            double total = 1;
+            for (final double val : src) {
+                sum += (val - sum) / total;
                 ++total;
             }
             if (total == 0) {
                 total = 1;
             }
-            return sum / total;
+            return (int) sum;
         }, () -> {
             float sum = 0.0f;
             float total = 0.0f;
@@ -124,16 +124,16 @@ public final class AvgOf extends NumberEnvelope {
      */
     public AvgOf(final Long... src) {
         super(() -> {
-            long sum = 0L;
-            long total = 0L;
-            for (final long val : src) {
-                sum += val;
+            double sum = 0d;
+            double total = 1d;
+            for (final double val : src) {
+                sum += (val - sum) / total;
                 ++total;
             }
             if (total == 0L) {
                 total = 1L;
             }
-            return sum / total;
+            return (long) sum;
         }, () -> {
             int sum = 0;
             int total = 0;
@@ -250,16 +250,16 @@ public final class AvgOf extends NumberEnvelope {
             }
             return sum / total;
         }, () -> {
-            float sum = 0.0f;
-            float total = 0.0f;
-            for (final float val : src) {
-                sum += val;
+            double sum = 0.0d;
+            double total = 1.0d;
+            for (final double val : src) {
+                sum += (val - sum) / total;
                 total += 1.0f;
             }
             if (total == 0.0f) {
                 total = 1.0f;
             }
-            return sum / total;
+            return (float) sum;
         }, () -> {
             double sum = 0.0d;
             double total = 0.0d;
@@ -343,5 +343,4 @@ public final class AvgOf extends NumberEnvelope {
             return sum / total;
         });
     }
-
 }

--- a/src/main/java/org/cactoos/scalar/AvgOf.java
+++ b/src/main/java/org/cactoos/scalar/AvgOf.java
@@ -210,15 +210,15 @@ public final class AvgOf extends NumberEnvelope {
             return sum / total;
         }, () -> {
             double sum = 0.0d;
-            double total = 0.0d;
+            double total = 1.0d;
             for (final double val : src) {
-                sum += val;
+                sum += (val - sum) / total;
                 total += 1.0d;
             }
             if (total == 0.0d) {
                 total = 1.0d;
             }
-            return sum / total;
+            return sum;
         });
     }
 

--- a/src/main/java/org/cactoos/scalar/AvgOf.java
+++ b/src/main/java/org/cactoos/scalar/AvgOf.java
@@ -89,9 +89,6 @@ public final class AvgOf extends NumberEnvelope {
                 sum += (val - sum) / total;
                 ++total;
             }
-            if (total == 0) {
-                total = 1;
-            }
             return (int) sum;
         }, () -> {
             float sum = 0.0f;
@@ -129,9 +126,6 @@ public final class AvgOf extends NumberEnvelope {
             for (final double val : src) {
                 sum += (val - sum) / total;
                 ++total;
-            }
-            if (total == 0L) {
-                total = 1L;
             }
             return (long) sum;
         }, () -> {
@@ -215,9 +209,6 @@ public final class AvgOf extends NumberEnvelope {
                 sum += (val - sum) / total;
                 total += 1.0d;
             }
-            if (total == 0.0d) {
-                total = 1.0d;
-            }
             return sum;
         });
     }
@@ -255,9 +246,6 @@ public final class AvgOf extends NumberEnvelope {
             for (final double val : src) {
                 sum += (val - sum) / total;
                 total += 1.0f;
-            }
-            if (total == 0.0f) {
-                total = 1.0f;
             }
             return (float) sum;
         }, () -> {

--- a/src/test/java/org/cactoos/scalar/AvgOfTest.java
+++ b/src/test/java/org/cactoos/scalar/AvgOfTest.java
@@ -179,7 +179,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withDoubleMaxValue() {
+    public void withMaxValueCollections() {
         MatcherAssert.assertThat(
             new AvgOf(
                 new ListOf<>(Double.MAX_VALUE, Double.MAX_VALUE)
@@ -187,27 +187,26 @@ public final class AvgOfTest {
                         ).doubleValue(),
                 Matchers.equalTo(Double.MAX_VALUE)
         );
-    }
-
-    @Test
-    public void withDoubleMinValue() {
         MatcherAssert.assertThat(
             new AvgOf(
-                new ListOf<>(Double.MIN_VALUE, Double.MIN_VALUE)
-                    .toArray(new Double[2])
-                        ).doubleValue(),
-                Matchers.equalTo(Double.MIN_VALUE)
+                new ListOf<>(Integer.MAX_VALUE, Integer.MAX_VALUE)
+                    .toArray(new Integer[2])
+                        ).intValue(),
+                Matchers.equalTo(Integer.MAX_VALUE)
         );
-    }
-
-    @Test
-    public void withDoublePositiveInfinity() {
         MatcherAssert.assertThat(
             new AvgOf(
-                new ListOf<>(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY)
-                    .toArray(new Double[2])
-                        ).doubleValue(),
-                Matchers.equalTo(Double.NaN)
+                new ListOf<>(Long.MAX_VALUE, Long.MAX_VALUE)
+                    .toArray(new Long[2])
+                        ).longValue(),
+                Matchers.equalTo(Long.MAX_VALUE)
+        );
+        MatcherAssert.assertThat(
+            new AvgOf(
+                new ListOf<>(Float.MAX_VALUE, Float.MAX_VALUE)
+                    .toArray(new Float[2])
+                        ).floatValue(),
+                Matchers.equalTo(Float.MAX_VALUE)
         );
     }
 }

--- a/src/test/java/org/cactoos/scalar/AvgOfTest.java
+++ b/src/test/java/org/cactoos/scalar/AvgOfTest.java
@@ -179,35 +179,35 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withDoubleMAX_VALUE() {       
-        ListOf<Double> listOf = new ListOf<>(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
-        
+    public void withDoubleMaxValue() {
         MatcherAssert.assertThat(
             new AvgOf(
-                listOf.toArray(new Double[listOf.size()])
-                        ).doubleValue(), 
-                Matchers.equalTo(Double.MAX_VALUE));
+                new ListOf<>(Double.MAX_VALUE, Double.MAX_VALUE)
+                    .toArray(new Double[2])
+                        ).doubleValue(),
+                Matchers.equalTo(Double.MAX_VALUE)
+        );
     }
-    
+
     @Test
-    public void withDoubleMIN_VALUE() {       
-        ListOf<Double> listOf = new ListOf<>(Double.MIN_VALUE, Double.MIN_VALUE, Double.MIN_VALUE);
-        
+    public void withDoubleMinValue() {
         MatcherAssert.assertThat(
             new AvgOf(
-                    listOf.toArray(new Double[listOf.size()])
-                        ).doubleValue(), 
-                Matchers.equalTo(Double.MIN_VALUE));
+                new ListOf<>(Double.MIN_VALUE, Double.MIN_VALUE)
+                    .toArray(new Double[2])
+                        ).doubleValue(),
+                Matchers.equalTo(Double.MIN_VALUE)
+        );
     }
-    
+
     @Test
-    public void withDoublePOSITIVE_INFINITY() {       
-        ListOf<Double> listOf = new ListOf<>(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
-        
+    public void withDoublePositiveInfinity() {
         MatcherAssert.assertThat(
             new AvgOf(
-                    listOf.toArray(new Double[listOf.size()])
-                        ).doubleValue(), 
-                Matchers.equalTo(Double.NaN));
+                new ListOf<>(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY)
+                    .toArray(new Double[2])
+                        ).doubleValue(),
+                Matchers.equalTo(Double.NaN)
+        );
     }
 }

--- a/src/test/java/org/cactoos/scalar/AvgOfTest.java
+++ b/src/test/java/org/cactoos/scalar/AvgOfTest.java
@@ -178,4 +178,36 @@ public final class AvgOfTest {
         );
     }
 
+    @Test
+    public void withDoubleMAX_VALUE() {       
+        ListOf<Double> listOf = new ListOf<>(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
+        
+        MatcherAssert.assertThat(
+            new AvgOf(
+                listOf.toArray(new Double[listOf.size()])
+                        ).doubleValue(), 
+                Matchers.equalTo(Double.MAX_VALUE));
+    }
+    
+    @Test
+    public void withDoubleMIN_VALUE() {       
+        ListOf<Double> listOf = new ListOf<>(Double.MIN_VALUE, Double.MIN_VALUE, Double.MIN_VALUE);
+        
+        MatcherAssert.assertThat(
+            new AvgOf(
+                    listOf.toArray(new Double[listOf.size()])
+                        ).doubleValue(), 
+                Matchers.equalTo(Double.MIN_VALUE));
+    }
+    
+    @Test
+    public void withDoublePOSITIVE_INFINITY() {       
+        ListOf<Double> listOf = new ListOf<>(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
+        
+        MatcherAssert.assertThat(
+            new AvgOf(
+                    listOf.toArray(new Double[listOf.size()])
+                        ).doubleValue(), 
+                Matchers.equalTo(Double.NaN));
+    }
 }

--- a/src/test/java/org/cactoos/scalar/AvgOfTest.java
+++ b/src/test/java/org/cactoos/scalar/AvgOfTest.java
@@ -209,4 +209,55 @@ public final class AvgOfTest {
                 Matchers.equalTo(Float.MAX_VALUE)
         );
     }
+
+    @Test
+    public void withMinValueCollections() {
+        MatcherAssert.assertThat(
+            new AvgOf(
+                new ListOf<>(Double.MIN_VALUE, Double.MIN_VALUE)
+                    .toArray(new Double[2])
+                        ).doubleValue(),
+                Matchers.equalTo(Double.MIN_VALUE)
+        );
+        MatcherAssert.assertThat(
+            new AvgOf(
+                new ListOf<>(Integer.MIN_VALUE, Integer.MIN_VALUE)
+                    .toArray(new Integer[2])
+                        ).intValue(),
+                Matchers.equalTo(Integer.MIN_VALUE)
+        );
+        MatcherAssert.assertThat(
+            new AvgOf(
+                new ListOf<>(Long.MIN_VALUE, Long.MIN_VALUE)
+                    .toArray(new Long[2])
+                        ).longValue(),
+                Matchers.equalTo(Long.MIN_VALUE)
+        );
+        MatcherAssert.assertThat(
+            new AvgOf(
+                new ListOf<>(Float.MIN_VALUE, Float.MIN_VALUE)
+                    .toArray(new Float[2])
+                        ).floatValue(),
+                Matchers.equalTo(Float.MIN_VALUE)
+        );
+    }
+
+    @Test
+    public void withEvenOddValues() {
+        final Float[] array = new ListOf<>(12345.0f, -12345.0f)
+            .toArray(new Float[2]);
+        final int expected = 0;
+        MatcherAssert.assertThat(
+            new AvgOf(array).intValue(), Matchers.equalTo(expected)
+        );
+        MatcherAssert.assertThat(
+            new AvgOf(array).longValue(), Matchers.equalTo((long) expected)
+        );
+        MatcherAssert.assertThat(
+            new AvgOf(array).doubleValue(), Matchers.equalTo((double) expected)
+        );
+        MatcherAssert.assertThat(
+            new AvgOf(array).floatValue(), Matchers.equalTo((float) expected)
+        );
+    }
 }

--- a/src/test/java/org/cactoos/scalar/AvgOfTest.java
+++ b/src/test/java/org/cactoos/scalar/AvgOfTest.java
@@ -26,7 +26,6 @@ package org.cactoos.scalar;
 import java.util.Collections;
 import org.cactoos.Scalar;
 import org.cactoos.iterable.IterableOf;
-import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -52,7 +51,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withIntegerCollectionIntValue() {
+    public void withIntCollectionIntValue() {
         MatcherAssert.assertThat(
             new AvgOf(
                 1, 2, 3, 4
@@ -62,7 +61,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withIntegerCollectionIntValueMaxValues() {
+    public void withIntCollectionIntValueMaxValues() {
         MatcherAssert.assertThat(
             new AvgOf(
                 Integer.MAX_VALUE, Integer.MAX_VALUE
@@ -72,7 +71,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withIntegerCollectionLongValue() {
+    public void withIntCollectionLongValue() {
         MatcherAssert.assertThat(
             new AvgOf(
                 1, 2, 3, 4
@@ -82,7 +81,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withIntegerCollectionDoubleValue() {
+    public void withIntCollectionDoubleValue() {
         MatcherAssert.assertThat(
             new AvgOf(
                 1, 2, 3, 4
@@ -92,7 +91,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withIntegerCollectionFloatValue() {
+    public void withIntCollectionFloatValue() {
         MatcherAssert.assertThat(
             new AvgOf(
                 1, 2, 3, 4
@@ -192,22 +191,63 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withDoubleCollectionFloatValue() {
+    public void withDoubleCollectionMinValue() {
         MatcherAssert.assertThat(
             new AvgOf(
-                1.0d, 2.0d, 3.0d, 4.0d
-            ).floatValue(),
-            Matchers.equalTo(2.5f)
+                Double.MIN_VALUE, Double.MIN_VALUE
+            ).doubleValue(),
+            Matchers.equalTo(Double.MIN_VALUE)
+        );
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void withDoubleCollectionPositiveInfinity() {
+        new AvgOf(
+            Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY
+        ).doubleValue();
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void withDoubleCollectionNegativeInfinity() {
+        new AvgOf(
+            Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY
+        ).doubleValue();
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void withDoubleCollectionNaN() {
+        new AvgOf(
+            Double.NaN, Double.NaN
+        ).doubleValue();
+    }
+
+    @Test
+    public void withDoubleCollectionNegativeNumbersDoubleValue() {
+        MatcherAssert.assertThat(
+            new AvgOf(
+                -1.0d, -2.0d, -3.0d, -4.0d
+            ).doubleValue(),
+            Matchers.equalTo(-2.5d)
         );
     }
 
     @Test
-    public void withDoubleCollectionPrecisionProblem() {
+    public void withDecimalCollectionPrecisionProblem() {
         MatcherAssert.assertThat(
             new AvgOf(
-                100.0, 100.266
-            ).doubleValue(),
-            Matchers.equalTo(100.133d)
+                100.0, 100.666, 100.0
+            ).floatValue(),
+            Matchers.equalTo(100.222f)
+        );
+    }
+
+    @Test
+    public void withDecimalCollectionPrecisionProblemExtraDecimalRange() {
+        MatcherAssert.assertThat(
+            new AvgOf(
+                100.266, 100.267
+            ).floatValue(),
+            Matchers.equalTo(100.2665f)
         );
     }
 
@@ -262,12 +302,52 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withScalars() {
+    public void withFloatCollectionMinValue() {
+        MatcherAssert.assertThat(
+            new AvgOf(
+                Float.MIN_VALUE, Float.MIN_VALUE
+            ).floatValue(),
+            Matchers.equalTo(Float.MIN_VALUE)
+        );
+    }
+
+    @Test
+    public void withIntScalarsIntValue() {
+        MatcherAssert.assertThat(
+            new AvgOf(
+                () -> 1, () -> 2, () -> 10
+            ).intValue(),
+            Matchers.equalTo(4)
+        );
+    }
+
+    @Test
+    public void withLongScalarsIntValue() {
         MatcherAssert.assertThat(
             new AvgOf(
                 () -> 1L, () -> 2L, () -> 10L
+            ).intValue(),
+            Matchers.equalTo(4)
+        );
+    }
+
+    @Test
+    public void withFloatScalarsIntValue() {
+        MatcherAssert.assertThat(
+            new AvgOf(
+                () -> 1f, () -> 2f, () -> 10f
             ).longValue(),
             Matchers.equalTo(4L)
+        );
+    }
+
+    @Test
+    public void withDoubleScalarsIntValue() {
+        MatcherAssert.assertThat(
+            new AvgOf(
+                () -> 1.0d, () -> 2.0d, () -> 10.0d
+            ).intValue(),
+            Matchers.equalTo(4)
         );
     }
 
@@ -278,89 +358,6 @@ public final class AvgOfTest {
                 new IterableOf<Scalar<Number>>(() -> 1L, () -> 2L, () -> 10L)
             ).longValue(),
             Matchers.equalTo(4L)
-        );
-    }
-
-    @Test
-    public void withMaxValueCollections() {
-        MatcherAssert.assertThat(
-            new AvgOf(
-                new ListOf<>(Double.MAX_VALUE, Double.MAX_VALUE)
-                    .toArray(new Double[2])
-                        ).doubleValue(),
-                Matchers.equalTo(Double.MAX_VALUE)
-        );
-        MatcherAssert.assertThat(
-            new AvgOf(
-                new ListOf<>(Integer.MAX_VALUE, Integer.MAX_VALUE)
-                    .toArray(new Integer[2])
-                        ).intValue(),
-                Matchers.equalTo(Integer.MAX_VALUE)
-        );
-        MatcherAssert.assertThat(
-            new AvgOf(
-                new ListOf<>(Long.MAX_VALUE, Long.MAX_VALUE)
-                    .toArray(new Long[2])
-                        ).longValue(),
-                Matchers.equalTo(Long.MAX_VALUE)
-        );
-        MatcherAssert.assertThat(
-            new AvgOf(
-                new ListOf<>(Float.MAX_VALUE, Float.MAX_VALUE)
-                    .toArray(new Float[2])
-                        ).floatValue(),
-                Matchers.equalTo(Float.MAX_VALUE)
-        );
-    }
-
-    @Test
-    public void withMinValueCollections() {
-        MatcherAssert.assertThat(
-            new AvgOf(
-                new ListOf<>(Double.MIN_VALUE, Double.MIN_VALUE)
-                    .toArray(new Double[2])
-                        ).doubleValue(),
-                Matchers.equalTo(Double.MIN_VALUE)
-        );
-        MatcherAssert.assertThat(
-            new AvgOf(
-                new ListOf<>(Integer.MIN_VALUE, Integer.MIN_VALUE)
-                    .toArray(new Integer[2])
-                        ).intValue(),
-                Matchers.equalTo(Integer.MIN_VALUE)
-        );
-        MatcherAssert.assertThat(
-            new AvgOf(
-                new ListOf<>(Long.MIN_VALUE, Long.MIN_VALUE)
-                    .toArray(new Long[2])
-                        ).longValue(),
-                Matchers.equalTo(Long.MIN_VALUE)
-        );
-        MatcherAssert.assertThat(
-            new AvgOf(
-                new ListOf<>(Float.MIN_VALUE, Float.MIN_VALUE)
-                    .toArray(new Float[2])
-                        ).floatValue(),
-                Matchers.equalTo(Float.MIN_VALUE)
-        );
-    }
-
-    @Test
-    public void withEvenOddValues() {
-        final Float[] array = new ListOf<>(12345.0f, -12345.0f)
-            .toArray(new Float[2]);
-        final int expected = 0;
-        MatcherAssert.assertThat(
-            new AvgOf(array).intValue(), Matchers.equalTo(expected)
-        );
-        MatcherAssert.assertThat(
-            new AvgOf(array).longValue(), Matchers.equalTo((long) expected)
-        );
-        MatcherAssert.assertThat(
-            new AvgOf(array).doubleValue(), Matchers.equalTo((double) expected)
-        );
-        MatcherAssert.assertThat(
-            new AvgOf(array).floatValue(), Matchers.equalTo((float) expected)
         );
     }
 }


### PR DESCRIPTION
Fixing Issue #532 

After reading @vmotsak comments and also considering @svendiedrichsen input and reading a few more things on the theme, like [here](https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html), [here](https://en.wikipedia.org/wiki/IEEE_754-1985) and [here](https://en.wikipedia.org/wiki/Average), I decided to go on the simplest solution for now, implementing what @vmotsak suggested.

Maybe in the future we can consider adding more number types of avg. calculation (as @svendiedrichsen suggested).
  