### PR TITLE
#545 fixing SyncIterable thread-safety bug

### DIFF
--- a/src/main/java/org/cactoos/iterable/SyncIterable.java
+++ b/src/main/java/org/cactoos/iterable/SyncIterable.java
@@ -23,7 +23,8 @@
  */
 package org.cactoos.iterable;
 
-import org.cactoos.scalar.SyncScalar;
+import java.util.Iterator;
+import org.cactoos.scalar.UncheckedScalar;
 
 /**
  * Synchronized iterable.
@@ -42,7 +43,12 @@ import org.cactoos.scalar.SyncScalar;
  * @param <X> Type of item
  * @since 0.24
  */
-public final class SyncIterable<X> extends IterableEnvelope<X> {
+public final class SyncIterable<X> implements Iterable<X> {
+
+    /**
+     * The iterable.
+     */
+    private final UncheckedScalar<Iterable<X>> iterable;
 
     /**
      * Ctor.
@@ -58,7 +64,16 @@ public final class SyncIterable<X> extends IterableEnvelope<X> {
      * @param iterable The iterable
      */
     public SyncIterable(final Iterable<X> iterable) {
-        super(new SyncScalar<>(() -> iterable));
+        this.iterable = new UncheckedScalar<>(
+            () -> iterable
+        );
+    }
+
+    @Override
+    public Iterator<X> iterator() {
+        synchronized (this.iterable) {
+            return this.iterable.value().iterator();
+        }
     }
 
 }

--- a/src/main/java/org/cactoos/iterable/SyncIterable.java
+++ b/src/main/java/org/cactoos/iterable/SyncIterable.java
@@ -24,7 +24,6 @@
 package org.cactoos.iterable;
 
 import java.util.Iterator;
-import org.cactoos.scalar.UncheckedScalar;
 
 /**
  * Synchronized iterable.
@@ -48,7 +47,11 @@ public final class SyncIterable<X> implements Iterable<X> {
     /**
      * The iterable.
      */
-    private final UncheckedScalar<Iterable<X>> iterable;
+    private final Iterable<X> origin;
+    /**
+     * Sync lock.
+     */
+    private final Object lock;
 
     /**
      * Ctor.
@@ -61,18 +64,26 @@ public final class SyncIterable<X> implements Iterable<X> {
 
     /**
      * Ctor.
-     * @param iterable The iterable
+     * @param iterable The iterable synchronize access to.
      */
     public SyncIterable(final Iterable<X> iterable) {
-        this.iterable = new UncheckedScalar<>(
-            () -> iterable
-        );
+        this(iterable, new Object());
+    }
+
+    /**
+     * Ctor.
+     * @param iterable The iterable synchronize access to.
+     * @param lck The lock to synchronize with.
+     */
+    public SyncIterable(final Iterable<X> iterable, final Object lck) {
+        this.origin = iterable;
+        this.lock = lck;
     }
 
     @Override
     public Iterator<X> iterator() {
-        synchronized (this.iterable) {
-            return this.iterable.value().iterator();
+        synchronized (this.lock) {
+            return this.origin.iterator();
         }
     }
 

--- a/src/test/java/org/cactoos/iterable/SolidIterableTest.java
+++ b/src/test/java/org/cactoos/iterable/SolidIterableTest.java
@@ -40,7 +40,7 @@ import org.junit.Test;
 public final class SolidIterableTest {
 
     @Test
-    public void makesListFromMappedIterable() throws Exception {
+    public void makesListFromMappedIterable() {
         final Iterable<Integer> list = new SolidIterable<>(
             new org.cactoos.list.Mapped<>(
                 i -> i + 1,
@@ -58,7 +58,7 @@ public final class SolidIterableTest {
     }
 
     @Test
-    public void mapsToSameObjects() throws Exception {
+    public void mapsToSameObjects() {
         final Iterable<Scalar<Integer>> list = new SolidIterable<>(
             new org.cactoos.list.Mapped<>(
                 i -> (Scalar<Integer>) () -> i,
@@ -69,6 +69,13 @@ public final class SolidIterableTest {
             "Can't map only once",
             list.iterator().next(), Matchers.equalTo(list.iterator().next())
         );
+    }
+
+    @Test
+    public void worksInThreadsMultipleTimes() {
+        for (int count = 0; count < 100; ++count) {
+            this.worksInThreads();
+        }
     }
 
     @Test


### PR DESCRIPTION
Replaced SyncIterable extending IterableEnvelope with implementing Iterable<> interface and synchronized access to iterator method