### PR TITLE
removed list.Mapped's constructor that accepts a Collection

### DIFF
--- a/src/main/java/org/cactoos/list/Mapped.java
+++ b/src/main/java/org/cactoos/list/Mapped.java
@@ -23,9 +23,9 @@
  */
 package org.cactoos.list;
 
-import java.util.Collection;
 import java.util.Iterator;
 import org.cactoos.Func;
+import org.cactoos.iterable.IterableOf;
 
 /**
  * Mapped list.
@@ -47,26 +47,17 @@ public final class Mapped<X, Y> extends ListEnvelope<Y> {
      * @since 0.21
      */
     public Mapped(final Func<X, Y> fnc, final Iterator<X> src) {
-        this(fnc, new ListOf<>(src));
+        this(fnc, new IterableOf<>(src));
     }
 
     /**
      * Ctor.
-     * @param src Source list
+     * @param src Source iterable
      * @param fnc Func
      */
     public Mapped(final Func<X, Y> fnc, final Iterable<X> src) {
-        this(fnc, new ListOf<>(src));
-    }
-
-    /**
-     * Ctor.
-     * @param src Source list
-     * @param fnc Func
-     */
-    public Mapped(final Func<X, Y> fnc, final Collection<X> src) {
         super(() -> new ListOf<Y>(
-            new org.cactoos.collection.Mapped<>(fnc, src)
+            new org.cactoos.iterable.Mapped<>(fnc, src)
         ));
     }
 


### PR DESCRIPTION
`org.cactoos.list.Mapped(Collection)` constructor is absolutely redundant because there is already a constructor accepting an `Iterable` which is less resource-consumable. Replacement of `ListOf` to `IterableOf` allows to spend fewer resources too.