### PR TITLE
#580 Fix failed tests of digest invelope.

### DIFF
--- a/src/main/java/org/cactoos/matchers/TextHasString.java
+++ b/src/main/java/org/cactoos/matchers/TextHasString.java
@@ -80,7 +80,7 @@ public final class TextHasString extends TypeSafeMatcher<Text> {
 
     @Override
     public void describeTo(final Description description) {
-        description.appendText(this.PREFIX);
+        description.appendText(TextHasString.PREFIX);
         description.appendDescriptionOf(this.matcher);
     }
 
@@ -88,7 +88,7 @@ public final class TextHasString extends TypeSafeMatcher<Text> {
     public void describeMismatchSafely(
         final Text item,
         final Description description) {
-        description.appendText(this.PREFIX);
+        description.appendText(TextHasString.PREFIX);
         description.appendValue(this.result);
     }
 }

--- a/src/main/java/org/cactoos/matchers/TextHasString.java
+++ b/src/main/java/org/cactoos/matchers/TextHasString.java
@@ -40,9 +40,19 @@ import org.hamcrest.core.IsEqual;
 public final class TextHasString extends TypeSafeMatcher<Text> {
 
     /**
+     * Prefix for description.
+     */
+    private static final String PREFIX = "Text with ";
+
+    /**
      * Matcher of the text.
      */
     private final Matcher<String> matcher;
+
+    /**
+     * Actual result for comparison.
+     */
+    private String result;
 
     /**
      * Ctor.
@@ -59,17 +69,26 @@ public final class TextHasString extends TypeSafeMatcher<Text> {
     public TextHasString(final Matcher<String> mtr) {
         super();
         this.matcher = mtr;
+        this.result = "";
     }
 
     @Override
     public boolean matchesSafely(final Text item) {
-        return this.matcher.matches(new UncheckedText(item).asString());
+        this.result = new UncheckedText(item).asString();
+        return this.matcher.matches(this.result);
     }
 
     @Override
     public void describeTo(final Description description) {
-        description.appendText("Text with ");
+        description.appendText(this.PREFIX);
         description.appendDescriptionOf(this.matcher);
     }
 
+    @Override
+    public void describeMismatchSafely(
+        final Text item,
+        final Description description) {
+        description.appendText(this.PREFIX);
+        description.appendValue(this.result);
+    }
 }

--- a/src/test/java/org/cactoos/io/Md5DigestOfTest.java
+++ b/src/test/java/org/cactoos/io/Md5DigestOfTest.java
@@ -77,13 +77,13 @@ public final class Md5DigestOfTest {
                 new Md5DigestOf(
                     new InputOf(
                         new ResourceOf(
-                            "org/cactoos/io/DigestEnvelope.class"
+                            "org/cactoos/digest-calculation.txt"
                         ).stream()
                     )
                 )
             ),
             new TextHasString(
-                "842a5e7012d76e1df96c3d92e5c661df"
+                "dbb9828164fa7d30c8a17c5cc8dadc2a"
             )
         );
     }

--- a/src/test/java/org/cactoos/io/Md5DigestOfTest.java
+++ b/src/test/java/org/cactoos/io/Md5DigestOfTest.java
@@ -83,7 +83,7 @@ public final class Md5DigestOfTest {
                 )
             ),
             new TextHasString(
-                "dbb9828164fa7d30c8a17c5cc8dadc2a"
+                "162665ab3d58424724f83f28e7a147d6"
             )
         );
     }

--- a/src/test/java/org/cactoos/io/Sha1DigestOfTest.java
+++ b/src/test/java/org/cactoos/io/Sha1DigestOfTest.java
@@ -77,13 +77,13 @@ public final class Sha1DigestOfTest {
                 new Sha1DigestOf(
                     new InputOf(
                         new ResourceOf(
-                            "org/cactoos/io/DigestEnvelope.class"
+                            "org/cactoos/digest-calculation.txt"
                         ).stream()
                     )
                 )
             ),
             new TextHasString(
-                "9d47e35afdcbf845aa9f05f15b4d936b97e55f0e"
+                "c0792fe7892c705443bf68844559e077d230bccd"
             )
         );
     }

--- a/src/test/java/org/cactoos/io/Sha1DigestOfTest.java
+++ b/src/test/java/org/cactoos/io/Sha1DigestOfTest.java
@@ -83,7 +83,7 @@ public final class Sha1DigestOfTest {
                 )
             ),
             new TextHasString(
-                "c0792fe7892c705443bf68844559e077d230bccd"
+                "34f80bdab9b93af514004f127e440139aad63e2d"
             )
         );
     }

--- a/src/test/java/org/cactoos/io/Sha256DigestOfTest.java
+++ b/src/test/java/org/cactoos/io/Sha256DigestOfTest.java
@@ -86,7 +86,7 @@ public final class Sha256DigestOfTest {
             ),
             new TextHasString(
                 // @checkstyle LineLengthCheck (1 lines)
-                "7eac7a6e680f020b240b5353c1038a630e03a75b2a011401eca312558b949654"
+                "c94451bd1476a3728669de11e22c645906d806e63a95c5797de1f3e84f126a3e"
             )
         );
     }

--- a/src/test/java/org/cactoos/io/Sha256DigestOfTest.java
+++ b/src/test/java/org/cactoos/io/Sha256DigestOfTest.java
@@ -79,14 +79,14 @@ public final class Sha256DigestOfTest {
                 new Sha256DigestOf(
                     new InputOf(
                         new ResourceOf(
-                            "org/cactoos/io/DigestEnvelope.class"
+                            "org/cactoos/digest-calculation.txt"
                         ).stream()
                     )
                 )
             ),
             new TextHasString(
                 // @checkstyle LineLengthCheck (1 lines)
-                "a56c3be45f9be8dda0653e33ae7ef3abf2939f926eda801f329e0830b6e7cc22"
+                "7eac7a6e680f020b240b5353c1038a630e03a75b2a011401eca312558b949654"
             )
         );
     }

--- a/src/test/java/org/cactoos/matchers/TextHasStringTest.java
+++ b/src/test/java/org/cactoos/matchers/TextHasStringTest.java
@@ -1,0 +1,66 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.matchers;
+
+import org.cactoos.io.InputOf;
+import org.cactoos.io.Md5DigestOf;
+import org.cactoos.text.HexOf;
+import org.hamcrest.Description;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.StringDescription;
+import org.hamcrest.core.StringContains;
+import org.junit.Test;
+
+/**
+ * Test case for {@link TextHasString}.
+ *
+ * @author Nikita Salomatin (nsalomatin@hotmail.com)
+ * @version $Id$
+ * @since 0.29
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class TextHasStringTest {
+
+    @Test
+    public void hasClearDescriptionForFailedTest() throws Exception {
+        final HexOf hex = new HexOf(
+            new Md5DigestOf(
+                new InputOf("Hello World!")
+            )
+        );
+        final Description description = new StringDescription();
+        final TextHasString matcher = new TextHasString(
+            "ed076287532e86365e841e92bfc50d8c6"
+        );
+        matcher.matchesSafely(hex);
+        matcher.describeMismatchSafely(hex, description);
+        MatcherAssert.assertThat(
+            "Description is not clear ",
+            description.toString(),
+            new StringContains(
+                "Text with \"ed076287532e86365e841e92bfc50d8c\""
+            )
+        );
+    }
+}

--- a/src/test/java/org/cactoos/matchers/package-info.java
+++ b/src/test/java/org/cactoos/matchers/package-info.java
@@ -1,0 +1,32 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Matcher's tests.
+ *
+ * @author Nikita Salomatin (nsalomatin@hotmail.com)
+ * @version $Id$
+ * @since 0.1
+ */
+package org.cactoos.matchers;

--- a/src/test/resources/org/cactoos/digest-calculation.txt
+++ b/src/test/resources/org/cactoos/digest-calculation.txt
@@ -1,0 +1,2 @@
+That file is used for digest calculation with different algorithms, so please DO NOT CHANGE IT.
+If you DO, then make sure all tests of DigestInvelope are passed.

--- a/src/test/resources/org/cactoos/digest-calculation.txt
+++ b/src/test/resources/org/cactoos/digest-calculation.txt
@@ -1,2 +1,1 @@
-That file is used for digest calculation with different algorithms, so please DO NOT CHANGE IT.
-If you DO, then make sure all tests of DigestInvelope are passed.
+That file is used for digest calculation with different algorithms, so please DO NOT CHANGE IT. If you DO, then make sure all tests of DigestInvelope are passed.


### PR DESCRIPTION
#580 Fix failed tests of digest invelope. Added clear description for TextHasString.
These tests were failed because Linux and Windows use different line spliterators, that is why they had different checksums in windows and linux that was the reason of failure. Moreover, the tests used DigestInvelope.class as a source of checking sum, which was the problem, because whenever you change that file, you should update new checksum in the tests, but as I said before different platforms have different checksum. More information [here](https://stackoverflow.com/questions/12289480/md5sum-different-on-linux-and-windows)