### PR TITLE
#622 Fix javadoc for all Sync... classes

### DIFF
--- a/src/main/java/org/cactoos/io/SyncInput.java
+++ b/src/main/java/org/cactoos/io/SyncInput.java
@@ -30,7 +30,7 @@ import org.cactoos.Input;
 /**
  * Thread-safe {@link Input}.
  *
- * <p>This class is thread-safe.
+ * <p>Objects of this class are thread safe.</p>
  *
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$

--- a/src/main/java/org/cactoos/io/SyncOutput.java
+++ b/src/main/java/org/cactoos/io/SyncOutput.java
@@ -30,7 +30,7 @@ import org.cactoos.Output;
 /**
  * Thread-safe {@link Output}.
  *
- * <p>There is no thread-safety guarantee.
+ * <p>Objects of this class are thread safe.</p>
  *
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$

--- a/src/main/java/org/cactoos/iterator/SyncIterator.java
+++ b/src/main/java/org/cactoos/iterator/SyncIterator.java
@@ -31,10 +31,14 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * Synchronized {@link Iterator} implementation using a {@link ReadWriteLock}
  * either provided to the constructor or an internally created
  * {@link ReentrantReadWriteLock}.
- * The {@link ReadWriteLock} is used to synchronize read calls to
+ *
+ * <p>The {@link ReadWriteLock} is used to synchronize read calls to
  * {@link SyncIterator#hasNext()} against write calls to
  * {@link SyncIterator#next()} and write calls to any other read or write
- * calls.
+ * calls.</p>
+ *
+ * <p>Objects of this class are thread-safe.</p>
+ *
  * @author Sven Diedrichsen (sven.diedrichsen@gmail.com)
  * @version $Id$
  * @param <T> The type of the iterator.

--- a/src/main/java/org/cactoos/scalar/SyncScalar.java
+++ b/src/main/java/org/cactoos/scalar/SyncScalar.java
@@ -41,6 +41,8 @@ import org.cactoos.Scalar;
  * ); // list.size() will be equal to threads value
  * </pre>
  *
+ * <p>Objects of this class are thread-safe.</p>
+ *
  * @author Tim Hinkes (timmeey@timmeey.de)
  * @version $Id$
  * @param <T> Type of result

--- a/src/main/java/org/cactoos/text/SyncText.java
+++ b/src/main/java/org/cactoos/text/SyncText.java
@@ -29,7 +29,7 @@ import org.cactoos.Text;
 /**
  * Text that is thread-safe.
  *
- * <p>There is no thread-safety guarantee.
+ * <p>Objects of this class are thread safe.</p>
  *
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$


### PR DESCRIPTION
This is fix of wrong javadocs in Sync... classes (see Issue #622).