### PR TITLE
#585 - Multi-threaded tests for SyncIterator class

### DIFF
--- a/src/test/java/org/cactoos/iterator/SyncIteratorTest.java
+++ b/src/test/java/org/cactoos/iterator/SyncIteratorTest.java
@@ -32,7 +32,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import junit.framework.TestCase;
 import org.cactoos.list.ListOf;
 import org.cactoos.list.StickyList;
 import org.hamcrest.MatcherAssert;
@@ -246,7 +245,7 @@ public final class SyncIteratorTest {
                             }
                         });
                 }
-                TestCase.assertTrue(
+                MatcherAssert.assertThat(
                     "Timeout initializing threads! Perform longer thread init.",
                     this.ready.await(
                         this.runnables.size() * 50,
@@ -254,7 +253,7 @@ public final class SyncIteratorTest {
                     )
                 );
                 this.init.countDown();
-                TestCase.assertTrue(
+                MatcherAssert.assertThat(
                     String.format(
                         "Timeout! More than %d seconds",
                         10
@@ -264,7 +263,7 @@ public final class SyncIteratorTest {
             } finally {
                 this.pool.shutdownNow();
             }
-            TestCase.assertTrue(
+            MatcherAssert.assertThat(
                 String.format(
                     "%s failed with exception(s) %s",
                     "Error",

--- a/src/test/java/org/cactoos/iterator/SyncIteratorTest.java
+++ b/src/test/java/org/cactoos/iterator/SyncIteratorTest.java
@@ -256,7 +256,7 @@ public final class SyncIteratorTest {
                 TestCase.assertTrue(
                     "Timeout initializing threads! Perform longer thread init.",
                     this.ready.await(
-                        this.runnables.size() * 20,
+                        this.runnables.size() * 50,
                         TimeUnit.MILLISECONDS
                     )
                 );


### PR DESCRIPTION
As per #585

I have written three multi-threaded tests for the `SyncIterator` class.
The first test deals with two concurrent `iterator.next()` method calls and tests that the calls are able to produce the correct output even when they are accessed concurrently.
The second test deals with two concurrent methods calls (`iterator.next()` and `iterator.hasNext()`).
The last added test has two concurrent `iterator.hasNext()` calls.

I have also added the `Concurrent` inner class that tests the supplied `Runnable`s for concurrency problems. I have constructed this class based on the information found [here](https://www.planetgeek.ch/2009/08/25/how-to-find-a-concurrency-bug-with-java/).