### PR TITLE
#643 - ItemAt object now returns correct value when used again

### DIFF
--- a/src/test/java/org/cactoos/scalar/ItemAtTest.java
+++ b/src/test/java/org/cactoos/scalar/ItemAtTest.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.matchers.ScalarHasValue;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
@@ -37,6 +38,7 @@ import org.junit.Test;
  * @since 0.7
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.TooManyMethods")
 public final class ItemAtTest {
 
     @Test
@@ -139,5 +141,21 @@ public final class ItemAtTest {
             new IterableOf<>(1, 2, 3).iterator(),
             3
         ).value();
+    }
+
+    @Test
+    public void sameValueTest() throws Exception {
+        final ItemAt<Integer> item = new ItemAt<>(
+            // @checkstyle MagicNumberCheck (2 lines)
+            new IterableOf<>(1, 2, 3).iterator(),
+            1
+        );
+        MatcherAssert.assertThat(
+            "Not the same value",
+            item.value(),
+            Matchers.equalTo(
+                item.value()
+            )
+        );
     }
 }


### PR DESCRIPTION
As per #643 

I have refactored the class, so that it saves the value at the position specified in the constructor in a private property. When the `value()` method is called again, it simply returns the saved value.

Since we need to save the value inside the object, our class cannot be fully immutable (internally, it is still immutable from outside) as we need to return the value of type T on each method call. I think that using a list with a capacity of 1 element will suffice, although I do agree that this is a compromise. 
