### PR TITLE
#640 Tests for SolidMap ctors

### DIFF
--- a/src/test/java/org/cactoos/map/SolidMapTest.java
+++ b/src/test/java/org/cactoos/map/SolidMapTest.java
@@ -26,6 +26,7 @@ package org.cactoos.map;
 import java.util.Map;
 import org.cactoos.Scalar;
 import org.cactoos.iterable.IterableOf;
+import org.cactoos.matchers.MatcherOf;
 import org.cactoos.matchers.RunsInThreads;
 import org.cactoos.text.SubText;
 import org.cactoos.text.TextOf;
@@ -42,6 +43,7 @@ import org.junit.Test;
  * @version $Id$
  * @since 0.24
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle MagicNumberCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class SolidMapTest {
@@ -88,35 +90,49 @@ public final class SolidMapTest {
     }
 
     @Test
-    @SuppressWarnings({"unchecked", "MismatchedQueryAndUpdateOfCollection"})
+    @SuppressWarnings("unchecked")
     public void extendsExistingMapWithArrayOfEntries() {
         final SolidMap<Integer, Integer> map = new SolidMap<>(
             new MapEntry<>(0, 10),
             new MapEntry<>(1, 11)
         );
-        final SolidMap<Integer, Integer> toadd = new SolidMap<>(
-            new MapEntry<>(2, 12),
-            new MapEntry<>(3, 13)
-        );
-        final Map.Entry<Integer, Integer>[] array =
-            (Map.Entry<Integer, Integer>[]) new Map.Entry<?, ?>[toadd.size()];
-        toadd.entrySet().toArray(array);
         MatcherAssert.assertThat(
             "Does not extends existing map with array of entries",
-            new SolidMap<Integer, Integer>(map, array).size(),
-            Matchers.equalTo(map.size() + toadd.size())
+            new SolidMap<>(
+                map,
+                new MapEntry<>(2, 12),
+                new MapEntry<>(3, 13)
+            ).size(),
+            Matchers.equalTo(4)
+        );
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void acceptsEmptyArray() {
+        MatcherAssert.assertThat(
+            "Accepts empty array of entries",
+            new SolidMap<>(
+                new SolidMap<>(
+                    new MapEntry<>(0, 10),
+                    new MapEntry<>(1, 11)
+                ),
+                (Map.Entry<Integer, Integer>[]) new Map.Entry<?, ?>[0]
+            ).size(),
+            Matchers.equalTo(2)
         );
     }
 
     @Test
     public void mapsIterableWithKeyFuncAndValueFunc() {
+        final SolidMap<String, String> map = new SolidMap<>(
+            key -> new SubText(new TextOf(key), 0, 1).asString(),
+            value -> new UpperText(new TextOf(value)).asString(),
+            new IterableOf<>("aa", "bb")
+        );
         MatcherAssert.assertThat(
             "Functions are not applied to key and value",
-            new SolidMap<>(
-                key -> new SubText(new TextOf(key), 0, 1).asString(),
-                value -> new UpperText(new TextOf(value)).asString(),
-                new IterableOf<>("aa", "bb")
-            ),
+            map,
             Matchers.allOf(
                 Matchers.hasEntry(
                     Matchers.equalTo("a"),
@@ -125,8 +141,23 @@ public final class SolidMapTest {
                 Matchers.hasEntry(
                     Matchers.equalTo("b"),
                     Matchers.equalTo("BB")
-                )
+                ),
+                new MatcherOf<>(m -> m.size() == 2)
             )
+        );
+    }
+
+    @Test
+    public void mapsEmptyIterableWithKeyFuncAndValueFunc() {
+        final SolidMap<String, String> map = new SolidMap<>(
+            key -> new SubText(new TextOf(key), 0, 1).asString(),
+            value -> new UpperText(new TextOf(value)).asString(),
+            new IterableOf<String>()
+        );
+        MatcherAssert.assertThat(
+            "Empty Iterable cannot be accepted for key and value mapping",
+            map,
+            new MatcherOf<>(m -> m.size() == 0)
         );
     }
 
@@ -149,8 +180,24 @@ public final class SolidMapTest {
                 Matchers.hasEntry(
                     Matchers.equalTo("b"),
                     Matchers.equalTo("BB")
-                )
+                ),
+                new MatcherOf<>(m -> m.size() == 2)
             )
+        );
+    }
+
+    @Test
+    public void mapsEmptyIterableWithMapEntryFunc() {
+        MatcherAssert.assertThat(
+            "Empty Iterable cannot be accepted for MapEntry mapping",
+            new SolidMap<>(
+                entry -> new MapEntry<>(
+                    new SubText(new TextOf(entry), 0, 1).asString(),
+                    new UpperText(new TextOf(entry)).asString()
+                ),
+                new IterableOf<String>()
+            ),
+            new MatcherOf<>(m -> m.size() == 0)
         );
     }
 }

--- a/src/test/java/org/cactoos/map/SolidMapTest.java
+++ b/src/test/java/org/cactoos/map/SolidMapTest.java
@@ -25,7 +25,11 @@ package org.cactoos.map;
 
 import java.util.Map;
 import org.cactoos.Scalar;
+import org.cactoos.iterable.IterableOf;
 import org.cactoos.matchers.RunsInThreads;
+import org.cactoos.text.SubText;
+import org.cactoos.text.TextOf;
+import org.cactoos.text.UpperText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -34,6 +38,7 @@ import org.junit.Test;
  * Test case for {@link SolidMap}.
  *
  * @author Yegor Bugayenko (yegor256@gmail.com)
+ * @author Stanislav Myachenkov (s.myachenkov@gmail.com)
  * @version $Id$
  * @since 0.24
  * @checkstyle JavadocMethodCheck (500 lines)
@@ -79,6 +84,73 @@ public final class SolidMapTest {
         MatcherAssert.assertThat(
             "Can't map only once",
             map.get(0), Matchers.equalTo(map.get(0))
+        );
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "MismatchedQueryAndUpdateOfCollection"})
+    public void extendsExistingMapWithArrayOfEntries() {
+        final SolidMap<Integer, Integer> map = new SolidMap<>(
+            new MapEntry<>(0, 10),
+            new MapEntry<>(1, 11)
+        );
+        final SolidMap<Integer, Integer> toadd = new SolidMap<>(
+            new MapEntry<>(2, 12),
+            new MapEntry<>(3, 13)
+        );
+        final Map.Entry<Integer, Integer>[] array =
+            (Map.Entry<Integer, Integer>[]) new Map.Entry<?, ?>[toadd.size()];
+        toadd.entrySet().toArray(array);
+        MatcherAssert.assertThat(
+            "Does not extends existing map with array of entries",
+            new SolidMap<Integer, Integer>(map, array).size(),
+            Matchers.equalTo(map.size() + toadd.size())
+        );
+    }
+
+    @Test
+    public void mapsIterableWithKeyFuncAndValueFunc() {
+        MatcherAssert.assertThat(
+            "Functions are not applied to key and value",
+            new SolidMap<>(
+                key -> new SubText(new TextOf(key), 0, 1).asString(),
+                value -> new UpperText(new TextOf(value)).asString(),
+                new IterableOf<>("aa", "bb")
+            ),
+            Matchers.allOf(
+                Matchers.hasEntry(
+                    Matchers.equalTo("a"),
+                    Matchers.equalTo("AA")
+                ),
+                Matchers.hasEntry(
+                    Matchers.equalTo("b"),
+                    Matchers.equalTo("BB")
+                )
+            )
+        );
+    }
+
+    @Test
+    public void mapsIterableWithMapEntryFunc() {
+        MatcherAssert.assertThat(
+            "Function are not applied to entry",
+            new SolidMap<>(
+                entry -> new MapEntry<>(
+                    new SubText(new TextOf(entry), 0, 1).asString(),
+                    new UpperText(new TextOf(entry)).asString()
+                ),
+                new IterableOf<>("aa", "bb")
+            ),
+            Matchers.allOf(
+                Matchers.hasEntry(
+                    Matchers.equalTo("a"),
+                    Matchers.equalTo("AA")
+                ),
+                Matchers.hasEntry(
+                    Matchers.equalTo("b"),
+                    Matchers.equalTo("BB")
+                )
+            )
         );
     }
 }


### PR DESCRIPTION
Issue #640. 
This pull request covers following SolidMap constructors with tests:
- `public SolidMap(final Map<X, Y> map, final Map.Entry<X, Y>... list)`
- `public <Z> SolidMap(final Func<Z, X> key, final Func<Z, Y> value, final Map<X, Y> map, final Iterable<Z> list)`
- `public <Z> SolidMap(final Func<Z, X> key, final Func<Z, Y> value, final Iterable<Z> list)`