### PR TITLE
(#666) Added unit tests for CallableOf

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Note: [Checkstyle](https://en.wikipedia.org/wiki/Checkstyle) is used as a static
   - [@alex-semenyuk](https://github.com/alex-semenyuk) as Alexey Semenyuk
   - [@smallcreep](https://github.com/smallcreep) as Ilia Rogozhin
   - [@memoyil](https://github.com/memoyil) as Mehmet Yildirim
+  - [@llorllale](https://github.com/llorllale) as George Aristy
 
 
 ## License (MIT)

--- a/src/test/java/org/cactoos/func/CallableOfTest.java
+++ b/src/test/java/org/cactoos/func/CallableOfTest.java
@@ -60,11 +60,10 @@ public final class CallableOfTest {
         );
     }
 
-    @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
     @Test(expected = Exception.class)
     public void wrapsRuntimeErrorFromRunnable() throws Exception {
         new CallableOf<>(
-            () -> { throw new RuntimeException(); }
+            () -> { throw new IllegalStateException(); }
         ).call();
     }
 

--- a/src/test/java/org/cactoos/func/CallableOfTest.java
+++ b/src/test/java/org/cactoos/func/CallableOfTest.java
@@ -23,6 +23,9 @@
  */
 package org.cactoos.func;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.cactoos.Func;
+import org.cactoos.Proc;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -44,6 +47,41 @@ public final class CallableOfTest {
                 input -> 1
             ).call(),
             Matchers.equalTo(1)
+        );
+    }
+
+    @Test
+    public void convertsRunnableIntoCallable() throws Exception {
+        final AtomicBoolean flag = new AtomicBoolean(false);
+        new CallableOf<>(
+            (Runnable) () -> { flag.set(true); }
+        ).call();
+        MatcherAssert.assertThat(
+            flag.get(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    public void convertsProcIntoCallable() throws Exception {
+        final AtomicBoolean flag = new AtomicBoolean(false);
+        new CallableOf<>(
+            (Proc<AtomicBoolean>) (unused) -> { flag.set(true); }
+        ).call();
+        MatcherAssert.assertThat(
+            flag.get(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    public void convertsFuncWithInputIntoCallable() throws Exception {
+        MatcherAssert.assertThat(
+            new CallableOf<>(
+                (Func<Integer, Integer>) num -> num + 1,
+                1
+            ).call(),
+            Matchers.equalTo(2)
         );
     }
 

--- a/src/test/java/org/cactoos/func/CallableOfTest.java
+++ b/src/test/java/org/cactoos/func/CallableOfTest.java
@@ -24,8 +24,6 @@
 package org.cactoos.func;
 
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.cactoos.Func;
-import org.cactoos.Proc;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -54,7 +52,7 @@ public final class CallableOfTest {
     public void convertsRunnableIntoCallable() throws Exception {
         final AtomicBoolean flag = new AtomicBoolean(false);
         new CallableOf<>(
-            (Runnable) () -> { flag.set(true); }
+            () -> { flag.set(true); }
         ).call();
         MatcherAssert.assertThat(
             flag.get(),
@@ -62,11 +60,19 @@ public final class CallableOfTest {
         );
     }
 
+    @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
+    @Test(expected = Exception.class)
+    public void wrapsRuntimeErrorFromRunnable() throws Exception {
+        new CallableOf<>(
+            () -> { throw new RuntimeException(); }
+        ).call();
+    }
+
     @Test
     public void convertsProcIntoCallable() throws Exception {
         final AtomicBoolean flag = new AtomicBoolean(false);
         new CallableOf<>(
-            (Proc<AtomicBoolean>) (unused) -> { flag.set(true); }
+            unused -> { flag.set(true); }
         ).call();
         MatcherAssert.assertThat(
             flag.get(),
@@ -78,7 +84,7 @@ public final class CallableOfTest {
     public void convertsFuncWithInputIntoCallable() throws Exception {
         MatcherAssert.assertThat(
             new CallableOf<>(
-                (Func<Integer, Integer>) num -> num + 1,
+                num -> num + 1,
                 1
             ).call(),
             Matchers.equalTo(2)


### PR DESCRIPTION
As per #666:

Added missing tests for these ctors:
* `CallableOf(final Runnable runnable)`
* `CallableOf(final Proc<X> proc)`
* `CallableOf(final Func<X, T> fnc, final X ipt)`
