### PR TITLE
#677 removed ctors with iterator for And's classes

### DIFF
--- a/src/main/java/org/cactoos/scalar/And.java
+++ b/src/main/java/org/cactoos/scalar/And.java
@@ -23,7 +23,6 @@
  */
 package org.cactoos.scalar;
 
-import java.util.Iterator;
 import org.cactoos.Func;
 import org.cactoos.Proc;
 import org.cactoos.Scalar;
@@ -95,30 +94,8 @@ public final class And implements Scalar<Boolean> {
      * @param <X> Type of items in the iterable
      * @since 0.24
      */
-    public <X> And(final Proc<X> proc, final Iterator<X> src) {
-        this(new FuncOf<>(proc, true), src);
-    }
-
-    /**
-     * Ctor.
-     * @param src The iterable
-     * @param proc Proc to use
-     * @param <X> Type of items in the iterable
-     * @since 0.24
-     */
     public <X> And(final Proc<X> proc, final Iterable<X> src) {
         this(new FuncOf<>(proc, true), src);
-    }
-
-    /**
-     * Ctor.
-     * @param src The iterable
-     * @param func Func to map
-     * @param <X> Type of items in the iterable
-     * @since 0.24
-     */
-    public <X> And(final Func<X, Boolean> func, final Iterator<X> src) {
-        this(func, new IterableOf<>(src));
     }
 
     /**
@@ -142,15 +119,6 @@ public final class And implements Scalar<Boolean> {
      */
     @SafeVarargs
     public And(final Scalar<Boolean>... src) {
-        this(new IterableOf<>(src));
-    }
-
-    /**
-     * Ctor.
-     * @param src The iterable
-     * @since 0.24
-     */
-    public And(final Iterator<Scalar<Boolean>> src) {
         this(new IterableOf<>(src));
     }
 

--- a/src/main/java/org/cactoos/scalar/AndInThreads.java
+++ b/src/main/java/org/cactoos/scalar/AndInThreads.java
@@ -24,7 +24,6 @@
 package org.cactoos.scalar;
 
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -108,29 +107,8 @@ public final class AndInThreads implements Scalar<Boolean> {
      * @param proc Proc to use
      * @param <X> Type of items in the iterable
      */
-    public <X> AndInThreads(final Proc<X> proc, final Iterator<X> src) {
-        this(new FuncOf<>(proc, true), src);
-    }
-
-    /**
-     * Ctor.
-     * @param src The iterable
-     * @param proc Proc to use
-     * @param <X> Type of items in the iterable
-     */
     public <X> AndInThreads(final Proc<X> proc, final Iterable<X> src) {
         this(new FuncOf<>(proc, true), src);
-    }
-
-    /**
-     * Ctor.
-     * @param src The iterable
-     * @param func Func to map
-     * @param <X> Type of items in the iterable
-     */
-    public <X> AndInThreads(final Func<X, Boolean> func,
-        final Iterator<X> src) {
-        this(func, new IterableOf<>(src));
     }
 
     /**
@@ -154,15 +132,6 @@ public final class AndInThreads implements Scalar<Boolean> {
      */
     @SafeVarargs
     public AndInThreads(final Scalar<Boolean>... src) {
-        this(new IterableOf<>(src));
-    }
-
-    /**
-     * Ctor.
-     * @param src The iterable
-     * @since 0.24
-     */
-    public AndInThreads(final Iterator<Scalar<Boolean>> src) {
         this(new IterableOf<>(src));
     }
 
@@ -208,32 +177,8 @@ public final class AndInThreads implements Scalar<Boolean> {
      * @param <X> Type of items in the iterable
      */
     public <X> AndInThreads(final ExecutorService svc,
-        final Proc<X> proc, final Iterator<X> src) {
-        this(svc, new FuncOf<>(proc, true), src);
-    }
-
-    /**
-     * Ctor.
-     * @param svc Executable service to run thread in
-     * @param src The iterable
-     * @param proc Proc to use
-     * @param <X> Type of items in the iterable
-     */
-    public <X> AndInThreads(final ExecutorService svc,
         final Proc<X> proc, final Iterable<X> src) {
         this(svc, new FuncOf<>(proc, true), src);
-    }
-
-    /**
-     * Ctor.
-     * @param svc Executable service to run thread in
-     * @param src The iterable
-     * @param func Func to map
-     * @param <X> Type of items in the iterable
-     */
-    public <X> AndInThreads(final ExecutorService svc,
-        final Func<X, Boolean> func, final Iterator<X> src) {
-        this(svc, func, new IterableOf<>(src));
     }
 
     /**
@@ -261,16 +206,6 @@ public final class AndInThreads implements Scalar<Boolean> {
     @SafeVarargs
     public AndInThreads(final ExecutorService svc,
         final Scalar<Boolean>... src) {
-        this(svc, new IterableOf<>(src));
-    }
-
-    /**
-     * Ctor.
-     * @param svc Executable service to run thread in
-     * @param src The iterable
-     */
-    public AndInThreads(final ExecutorService svc,
-        final Iterator<Scalar<Boolean>> src) {
         this(svc, new IterableOf<>(src));
     }
 

--- a/src/test/java/org/cactoos/scalar/AndInThreadsTest.java
+++ b/src/test/java/org/cactoos/scalar/AndInThreadsTest.java
@@ -170,21 +170,6 @@ public final class AndInThreadsTest {
     }
 
     @Test
-    public void worksWithProcIterator() throws Exception {
-        final List<Integer> list = Collections.synchronizedList(
-            new ArrayList<Integer>(2)
-        );
-        new AndInThreads(
-            new Proc.NoNulls<Integer>(list::add),
-            Arrays.asList(1, 2).iterator()
-        ).value();
-        MatcherAssert.assertThat(
-            list,
-            Matchers.containsInAnyOrder(1, 2)
-        );
-    }
-
-    @Test
     public void worksWithProcIterable() throws Exception {
         final List<Integer> list = Collections.synchronizedList(
             new ArrayList<Integer>(2)
@@ -196,19 +181,6 @@ public final class AndInThreadsTest {
         MatcherAssert.assertThat(
             list,
             Matchers.containsInAnyOrder(1, 2)
-        );
-    }
-
-    @Test
-    public void worksWithIteratorScalarBoolean() throws Exception {
-        MatcherAssert.assertThat(
-            new AndInThreads(
-                new ListOf<Scalar<Boolean>>(
-                    new Constant<Boolean>(true),
-                    new Constant<Boolean>(false)
-                ).iterator()
-            ).value(),
-            Matchers.equalTo(false)
         );
     }
 
@@ -235,22 +207,6 @@ public final class AndInThreadsTest {
             service,
             new Proc.NoNulls<Integer>(list::add),
             1, 2
-        ).value();
-        MatcherAssert.assertThat(
-            list,
-            Matchers.containsInAnyOrder(1, 2)
-        );
-    }
-
-    @Test
-    public void worksWithExecServiceProcIterator() throws Exception {
-        final List<Integer> list = Collections.synchronizedList(
-            new ArrayList<Integer>(2)
-        );
-        new AndInThreads(
-            Executors.newSingleThreadExecutor(),
-            new Proc.NoNulls<Integer>(list::add),
-            Arrays.asList(1, 2).iterator()
         ).value();
         MatcherAssert.assertThat(
             list,
@@ -298,20 +254,6 @@ public final class AndInThreadsTest {
                 )
             ).value(),
             Matchers.equalTo(false)
-        );
-    }
-
-    @Test
-    public void worksWithExecServiceIteratorScalarBoolean() throws Exception {
-        MatcherAssert.assertThat(
-            new AndInThreads(
-                Executors.newSingleThreadExecutor(),
-                new ListOf<Scalar<Boolean>>(
-                    new Constant<Boolean>(true),
-                    new Constant<Boolean>(true)
-                ).iterator()
-            ).value(),
-            Matchers.equalTo(true)
         );
     }
 


### PR DESCRIPTION
In the issue #677 explained why iterator as a parameter is a bad idea, so I just removed ctors with `Iterator` for `And`, `AndInThreads`