### PR TITLE
#655 - Added toString() method to CollectionEnvelope class.

### DIFF
--- a/src/main/java/org/cactoos/collection/CollectionEnvelope.java
+++ b/src/main/java/org/cactoos/collection/CollectionEnvelope.java
@@ -137,4 +137,10 @@ public abstract class CollectionEnvelope<X> implements Collection<X> {
             "#clear(): the collection is ready only"
         );
     }
+
+    @Override
+    public String toString() {
+        return col.value().toString();
+    }
+
 }


### PR DESCRIPTION
As per #655 
I have added the `toString()` method to the parent class (`CollectionEnvelope`).
There is no need to add it to the `CollectionOf` class.