### PR TITLE
#659 remove ctor

### DIFF
--- a/src/main/java/org/cactoos/map/MapOf.java
+++ b/src/main/java/org/cactoos/map/MapOf.java
@@ -25,7 +25,6 @@ package org.cactoos.map;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import org.cactoos.Func;
 import org.cactoos.iterable.IterableOf;
@@ -144,14 +143,6 @@ public final class MapOf<X, Y> extends MapEnvelope<X, Y> {
                 src.entrySet(), list
             )
         );
-    }
-
-    /**
-     * Ctor.
-     * @param entries List of the entries
-     */
-    public MapOf(final Iterator<Map.Entry<X, Y>> entries) {
-        this(() -> entries);
     }
 
     /**


### PR DESCRIPTION
For #659 

**Problem**
Following code is failing:
```Java
@Test
    public void createsMapFromIterator() {
        MatcherAssert.assertThat(
            "Can't create a map from Iterator with Entries.",
            new MapOf<Integer, Integer>(
                new ListOf<Map.Entry<Integer, Integer>>(
                    new MapEntry<Integer, Integer>(0, 0),
                    new MapEntry<Integer, Integer>(1, 1)
                ).iterator()
            ),
            Matchers.allOf(
                Matchers.hasEntry(0, 0),
                Matchers.hasEntry(1, 1)
            )
        );
    }
```

**Reason**
In Java we can use iterator only once.

**Solution**
Remove ctor with iterator according to #677 
