### PR TITLE
#683 add unit tests to reach full coverage

### DIFF
--- a/src/test/java/org/cactoos/io/TeeOutputTest.java
+++ b/src/test/java/org/cactoos/io/TeeOutputTest.java
@@ -41,26 +41,15 @@ import org.junit.Test;
  */
 public final class TeeOutputTest {
 
-    /**
-     * The CONTENT for copying of TeeOutput.
-     */
-    private static final String CONTENT = "Hello, товарищ!";
-
-    /**
-     * The TeeOutputTest.DESCRIPTION of failure test.
-     */
-    private static final String
-        DESCRIPTION = "Can't copy Output to Output and return Input";
-
     @Test
     public void copiesContent() {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final ByteArrayOutputStream copy = new ByteArrayOutputStream();
         MatcherAssert.assertThat(
-            TeeOutputTest.DESCRIPTION,
+            "Can't copy Output to Output and return Input",
             new TextOf(
                 new TeeInput(
-                    new InputOf(TeeOutputTest.CONTENT),
+                    new InputOf("Hello, товарищ!"),
                     new TeeOutput(
                         new OutputTo(baos),
                         new OutputTo(copy)
@@ -84,10 +73,10 @@ public final class TeeOutputTest {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final ByteArrayOutputStream copy = new ByteArrayOutputStream();
         MatcherAssert.assertThat(
-            TeeOutputTest.DESCRIPTION,
+            "Can't copy Output with writer",
             new TextOf(
                 new TeeInput(
-                    new InputOf(TeeOutputTest.CONTENT),
+                    new InputOf("Hello, товарищ! writer"),
                     new TeeOutput(
                         new OutputTo(baos),
                         new WriterTo(copy)
@@ -111,10 +100,10 @@ public final class TeeOutputTest {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final ByteArrayOutputStream copy = new ByteArrayOutputStream();
         MatcherAssert.assertThat(
-            TeeOutputTest.DESCRIPTION,
+            "Can't copy Output with writer and charset",
             new TextOf(
                 new TeeInput(
-                    new InputOf(TeeOutputTest.CONTENT),
+                    new InputOf("Hello, товарищ! writer and charset"),
                     new TeeOutput(
                         new OutputTo(baos),
                         new WriterTo(copy),
@@ -139,10 +128,10 @@ public final class TeeOutputTest {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final TempFile file = new TempFile();
         MatcherAssert.assertThat(
-            TeeOutputTest.DESCRIPTION,
+            "Can't copy Output with path",
             new TextOf(
                 new TeeInput(
-                    new InputOf(TeeOutputTest.CONTENT),
+                    new InputOf("Hello, товарищ! with path"),
                     new TeeOutput(
                         new OutputTo(baos),
                         file.value()
@@ -166,10 +155,10 @@ public final class TeeOutputTest {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final TempFile file = new TempFile();
         MatcherAssert.assertThat(
-            TeeOutputTest.DESCRIPTION,
+            "Can't copy Output with file",
             new TextOf(
                 new TeeInput(
-                    new InputOf(TeeOutputTest.CONTENT),
+                    new InputOf("Hello, товарищ! with file"),
                     new TeeOutput(
                         new OutputTo(baos),
                         file.value().toFile()
@@ -193,10 +182,10 @@ public final class TeeOutputTest {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final ByteArrayOutputStream copy = new ByteArrayOutputStream();
         MatcherAssert.assertThat(
-            TeeOutputTest.DESCRIPTION,
+            "Can't copy Output with output stream",
             new TextOf(
                 new TeeInput(
-                    new InputOf(TeeOutputTest.CONTENT),
+                    new InputOf("Hello, товарищ! with output stream"),
                     new TeeOutput(
                         new OutputTo(baos),
                         copy

--- a/src/test/java/org/cactoos/io/TeeOutputTest.java
+++ b/src/test/java/org/cactoos/io/TeeOutputTest.java
@@ -41,19 +41,165 @@ import org.junit.Test;
  */
 public final class TeeOutputTest {
 
+    /**
+     * The CONTENT for copying of TeeOutput.
+     */
+    private static final String CONTENT = "Hello, товарищ!";
+
+    /**
+     * The TeeOutputTest.DESCRIPTION of failure test.
+     */
+    private static final String
+        DESCRIPTION = "Can't copy Output to Output and return Input";
+
     @Test
     public void copiesContent() {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final ByteArrayOutputStream copy = new ByteArrayOutputStream();
-        final String content = "Hello, товарищ!";
         MatcherAssert.assertThat(
-            "Can't copy Output to Output and return Input",
+            TeeOutputTest.DESCRIPTION,
             new TextOf(
                 new TeeInput(
-                    new InputOf(content),
+                    new InputOf(TeeOutputTest.CONTENT),
                     new TeeOutput(
                         new OutputTo(baos),
                         new OutputTo(copy)
+                    )
+                )
+            ),
+            new TextHasString(
+                new MatcherOf<>(
+                    str -> {
+                        return new String(
+                            copy.toByteArray(), StandardCharsets.UTF_8
+                        ).equals(str);
+                    }
+                )
+            )
+        );
+    }
+
+    @Test
+    public void copiesWithWriter() {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final ByteArrayOutputStream copy = new ByteArrayOutputStream();
+        MatcherAssert.assertThat(
+            TeeOutputTest.DESCRIPTION,
+            new TextOf(
+                new TeeInput(
+                    new InputOf(TeeOutputTest.CONTENT),
+                    new TeeOutput(
+                        new OutputTo(baos),
+                        new WriterTo(copy)
+                    )
+                )
+            ),
+            new TextHasString(
+                new MatcherOf<>(
+                    str -> {
+                        return new String(
+                            copy.toByteArray(), StandardCharsets.UTF_8
+                        ).equals(str);
+                    }
+                )
+            )
+        );
+    }
+
+    @Test
+    public void copiesWithWriterAndCharset() {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final ByteArrayOutputStream copy = new ByteArrayOutputStream();
+        MatcherAssert.assertThat(
+            TeeOutputTest.DESCRIPTION,
+            new TextOf(
+                new TeeInput(
+                    new InputOf(TeeOutputTest.CONTENT),
+                    new TeeOutput(
+                        new OutputTo(baos),
+                        new WriterTo(copy),
+                        StandardCharsets.UTF_8
+                    )
+                )
+            ),
+            new TextHasString(
+                new MatcherOf<>(
+                    str -> {
+                        return new String(
+                            copy.toByteArray(), StandardCharsets.UTF_8
+                        ).equals(str);
+                    }
+                )
+            )
+        );
+    }
+
+    @Test
+    public void copiesWithPath() throws Exception {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final TempFile file = new TempFile();
+        MatcherAssert.assertThat(
+            TeeOutputTest.DESCRIPTION,
+            new TextOf(
+                new TeeInput(
+                    new InputOf(TeeOutputTest.CONTENT),
+                    new TeeOutput(
+                        new OutputTo(baos),
+                        file.value()
+                    )
+                )
+            ),
+            new TextHasString(
+                new MatcherOf<>(
+                    str -> {
+                        return new String(
+                            new TextOf(file.value()).asString()
+                        ).equals(str);
+                    }
+                )
+            )
+        );
+    }
+
+    @Test
+    public void copiesWithFile() throws Exception {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final TempFile file = new TempFile();
+        MatcherAssert.assertThat(
+            TeeOutputTest.DESCRIPTION,
+            new TextOf(
+                new TeeInput(
+                    new InputOf(TeeOutputTest.CONTENT),
+                    new TeeOutput(
+                        new OutputTo(baos),
+                        file.value().toFile()
+                    )
+                )
+            ),
+            new TextHasString(
+                new MatcherOf<>(
+                    str -> {
+                        return new String(
+                            new TextOf(file.value()).asString()
+                        ).equals(str);
+                    }
+                )
+            )
+        );
+    }
+
+    @Test
+    public void copiesWithOutputStream() {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final ByteArrayOutputStream copy = new ByteArrayOutputStream();
+        MatcherAssert.assertThat(
+            TeeOutputTest.DESCRIPTION,
+            new TextOf(
+                new TeeInput(
+                    new InputOf(TeeOutputTest.CONTENT),
+                    new TeeOutput(
+                        new OutputTo(baos),
+                        copy
                     )
                 )
             ),


### PR DESCRIPTION
The problem in #683:
small coverage of `TeeOutput` class.

The solution:
added few unit tests to reach full coverage.