### PR TITLE
#702 Remove temporary files in tests

### DIFF
--- a/src/test/java/org/cactoos/io/InputOfTest.java
+++ b/src/test/java/org/cactoos/io/InputOfTest.java
@@ -31,7 +31,6 @@ import java.io.StringReader;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.cactoos.matchers.InputHasContent;
 import org.cactoos.matchers.MatcherOf;
@@ -39,7 +38,9 @@ import org.cactoos.matchers.TextHasString;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.takes.http.FtRemote;
 import org.takes.tk.TkHtml;
 
@@ -56,6 +57,12 @@ import org.takes.tk.TkHtml;
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public final class InputOfTest {
+
+    /**
+     * Temporary files generator.
+     */
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
 
     @Test
     public void readsAlternativeInputForFileCase() throws IOException {
@@ -75,12 +82,12 @@ public final class InputOfTest {
 
     @Test
     public void readsSimpleFileContent() throws IOException {
-        final Path temp = Files.createTempFile("cactoos-1", "txt-1");
+        final File file = this.folder.newFile();
         final String content = "Hello, товарищ!";
-        Files.write(temp, content.getBytes(StandardCharsets.UTF_8));
+        Files.write(file.toPath(), content.getBytes(StandardCharsets.UTF_8));
         MatcherAssert.assertThat(
             "Can't read file content",
-            new InputOf(temp),
+            new InputOf(file),
             new InputHasContent(content)
         );
     }

--- a/src/test/java/org/cactoos/io/InputStreamOfTest.java
+++ b/src/test/java/org/cactoos/io/InputStreamOfTest.java
@@ -23,15 +23,17 @@
  */
 package org.cactoos.io;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import org.cactoos.matchers.InputHasContent;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * Test case for {@link InputStreamOf}.
@@ -44,14 +46,20 @@ import org.junit.Test;
  */
 public final class InputStreamOfTest {
 
+    /**
+     * Temporary files generator.
+     */
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
     @Test
     public void readsSimpleFileContent() throws IOException {
-        final Path temp = Files.createTempFile("cactoos-1", "txt-1");
+        final File file = this.folder.newFile();
         final String content = "Hello, товарищ!";
-        Files.write(temp, content.getBytes(StandardCharsets.UTF_8));
+        Files.write(file.toPath(), content.getBytes(StandardCharsets.UTF_8));
         MatcherAssert.assertThat(
             "Can't read file content",
-            new InputOf(new InputStreamOf(temp)),
+            new InputOf(new InputStreamOf(file)),
             new InputHasContent(content)
         );
     }

--- a/src/test/java/org/cactoos/io/OutputStreamToTest.java
+++ b/src/test/java/org/cactoos/io/OutputStreamToTest.java
@@ -23,14 +23,15 @@
  */
 package org.cactoos.io;
 
+import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import org.cactoos.matchers.MatcherOf;
 import org.cactoos.matchers.TextHasString;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * Test case for {@link OutputStreamTo}.
@@ -43,21 +44,27 @@ import org.junit.Test;
  */
 public final class OutputStreamToTest {
 
+    /**
+     * Temporary files generator.
+     */
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
     @Test
     public void writesLargeContentToFile() throws IOException {
-        final Path temp = Files.createTempFile("cactoos-1", "txt-1");
+        final File file = this.folder.newFile();
         MatcherAssert.assertThat(
             "Can't copy Input to Output and return Input",
             new TextOf(
                 new TeeInput(
                     new ResourceOf("org/cactoos/large-text.txt"),
-                    new OutputTo(new OutputStreamTo(temp))
+                    new OutputTo(new OutputStreamTo(file))
                 )
             ),
             new TextHasString(
                 new MatcherOf<>(
                     str -> {
-                        return new TextOf(temp).asString().equals(str);
+                        return new TextOf(file).asString().equals(str);
                     }
                 )
             )

--- a/src/test/java/org/cactoos/io/WriterAsOutputStreamTest.java
+++ b/src/test/java/org/cactoos/io/WriterAsOutputStreamTest.java
@@ -24,6 +24,7 @@
 package org.cactoos.io;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
@@ -35,7 +36,9 @@ import org.cactoos.matchers.ScalarHasValue;
 import org.cactoos.matchers.TextHasString;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * Test case for {@link WriterAsOutputStream}.
@@ -48,6 +51,12 @@ import org.junit.Test;
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class WriterAsOutputStreamTest {
+
+    /**
+     * Temporary files generator.
+     */
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
 
     @Test
     public void writesToByteArray() {
@@ -84,7 +93,7 @@ public final class WriterAsOutputStreamTest {
 
     @Test
     public void writesLargeContentToFile() throws IOException {
-        final Path temp = Files.createTempFile("cactoos-1", "txt-1");
+        final File file = this.folder.newFile();
         MatcherAssert.assertThat(
             "Can't copy Input to Output and return Input",
             new TextOf(
@@ -93,7 +102,7 @@ public final class WriterAsOutputStreamTest {
                     new OutputTo(
                         new WriterAsOutputStream(
                             new OutputStreamWriter(
-                                new FileOutputStream(temp.toFile()),
+                                new FileOutputStream(file),
                                 StandardCharsets.UTF_8
                             ),
                             StandardCharsets.UTF_8,
@@ -106,7 +115,7 @@ public final class WriterAsOutputStreamTest {
             new TextHasString(
                 new MatcherOf<>(
                     str -> {
-                        return new TextOf(temp).asString().equals(str);
+                        return new TextOf(file).asString().equals(str);
                     }
                 )
             )

--- a/src/test/java/org/cactoos/io/WriterAsOutputTest.java
+++ b/src/test/java/org/cactoos/io/WriterAsOutputTest.java
@@ -23,17 +23,18 @@
  */
 package org.cactoos.io;
 
+import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import org.cactoos.matchers.MatcherOf;
 import org.cactoos.matchers.TextHasString;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * Test case for {@link WriterAsOutput}.
@@ -46,9 +47,15 @@ import org.junit.Test;
  */
 public final class WriterAsOutputTest {
 
+    /**
+     * Temporary files generator.
+     */
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
     @Test
     public void writesLargeContentToFile() throws IOException {
-        final Path temp = Files.createTempFile("cactoos-1", "txt-1");
+        final File file = this.folder.newFile();
         MatcherAssert.assertThat(
             "Can't copy Input to Output and return Input",
             new TextOf(
@@ -56,7 +63,7 @@ public final class WriterAsOutputTest {
                     new ResourceOf("org/cactoos/large-text.txt"),
                     new WriterAsOutput(
                         new OutputStreamWriter(
-                            new FileOutputStream(temp.toFile()),
+                            new FileOutputStream(file),
                             StandardCharsets.UTF_8
                         )
                     )
@@ -65,7 +72,7 @@ public final class WriterAsOutputTest {
             new TextHasString(
                 new MatcherOf<>(
                     str -> {
-                        return new TextOf(temp).asString().equals(str);
+                        return new TextOf(file).asString().equals(str);
                     }
                 )
             )

--- a/src/test/java/org/cactoos/io/WriterToTest.java
+++ b/src/test/java/org/cactoos/io/WriterToTest.java
@@ -23,14 +23,15 @@
  */
 package org.cactoos.io;
 
+import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import org.cactoos.matchers.MatcherOf;
 import org.cactoos.matchers.TextHasString;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * Test case for {@link WriterTo}.
@@ -43,21 +44,27 @@ import org.junit.Test;
  */
 public final class WriterToTest {
 
+    /**
+     * Temporary files generator.
+     */
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
     @Test
     public void writesLargeContentToFile() throws IOException {
-        final Path temp = Files.createTempFile("cactoos-1", "txt-1");
+        final File file = this.folder.newFile();
         MatcherAssert.assertThat(
             "Can't copy Input to Output and return Input",
             new TextOf(
                 new TeeInput(
                     new ResourceOf("org/cactoos/large-text.txt"),
-                    new WriterAsOutput(new WriterTo(temp))
+                    new WriterAsOutput(new WriterTo(file))
                 )
             ),
             new TextHasString(
                 new MatcherOf<>(
                     str -> {
-                        return new TextOf(temp).asString().equals(str);
+                        return new TextOf(file).asString().equals(str);
                     }
                 )
             )


### PR DESCRIPTION
Issue https://github.com/yegor256/cactoos/issues/702.
Replace Files#createTempFile with TemporaryFolder to ensure that all temporary files will be removed after unit tests are complete.