### PR TITLE
#721: Add matcher for TeeInput class

### DIFF
--- a/src/main/java/org/cactoos/matchers/TeeInputHasResult.java
+++ b/src/main/java/org/cactoos/matchers/TeeInputHasResult.java
@@ -26,6 +26,9 @@ package org.cactoos.matchers;
 import java.io.File;
 import org.cactoos.Text;
 import org.cactoos.io.TeeInput;
+import org.cactoos.scalar.And;
+import org.cactoos.scalar.Equals;
+import org.cactoos.scalar.UncheckedScalar;
 import org.cactoos.text.ComparableText;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.TextOf;
@@ -42,11 +45,6 @@ import org.hamcrest.TypeSafeMatcher;
  */
 public final class TeeInputHasResult extends TypeSafeMatcher<TeeInput> {
 
-    /**
-     * Format for matcher description.
-     */
-    private static final String DESCRIPTION =
-        "TeeInput with result \"%s\" and copied value \"%s\"";
     /**
      * Value that is expected to be returned from the given TeeInput.
      */
@@ -68,8 +66,7 @@ public final class TeeInputHasResult extends TypeSafeMatcher<TeeInput> {
      */
     public TeeInputHasResult(
         final String expected,
-        final File file
-    ) {
+        final File file) {
         this(
             new TextOf(expected),
             new TextOf(file)
@@ -110,8 +107,18 @@ public final class TeeInputHasResult extends TypeSafeMatcher<TeeInput> {
     public boolean matchesSafely(final TeeInput item) {
         this.actual = new ComparableText(new TextOf(item));
         return
-            this.expected.compareTo(this.actual) == 0
-                && this.expected.compareTo(this.copied) == 0;
+            new UncheckedScalar<>(
+                new And(
+                    new Equals<>(
+                        this.expected::asString,
+                        this.actual::asString
+                    ),
+                    new Equals<>(
+                        this.expected::asString,
+                        this.copied::asString
+                    )
+                )
+            ).value();
     }
 
     @Override
@@ -119,8 +126,7 @@ public final class TeeInputHasResult extends TypeSafeMatcher<TeeInput> {
         description.appendText(
             new UncheckedText(
                 new FormattedText(
-                    TeeInputHasResult.DESCRIPTION,
-                    new UncheckedText(this.expected).asString(),
+                    "TeeInput with result \"%1$s\" and copied value \"%1$s\"",
                     new UncheckedText(this.expected).asString()
                 )
             ).asString()

--- a/src/main/java/org/cactoos/matchers/TeeInputHasResult.java
+++ b/src/main/java/org/cactoos/matchers/TeeInputHasResult.java
@@ -1,0 +1,136 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.matchers;
+
+import java.io.File;
+import org.cactoos.Text;
+import org.cactoos.io.TeeInput;
+import org.cactoos.text.ComparableText;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.TextOf;
+import org.cactoos.text.UncheckedText;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Matcher for the {@link TeeInput}'s results.
+ *
+ * @author Roman Proshin (roman@proshin.org)
+ * @version $Id$
+ * @since 1.0
+ */
+public final class TeeInputHasResult extends TypeSafeMatcher<TeeInput> {
+
+    /**
+     * Format for matcher description.
+     */
+    private static final String DESCRIPTION =
+        "TeeInput with result \"%s\" and copied value \"%s\"";
+    /**
+     * Value that is expected to be returned from the given TeeInput.
+     */
+    private final ComparableText expected;
+    /**
+     * Value that is expected to be copied into the output of TeeInput.
+     */
+    private final ComparableText copied;
+    /**
+     * Actual value returned from the given TeeInput.
+     */
+    private ComparableText actual;
+
+    /**
+     * Ctor.
+     * @param expected Value that is expected to be returned from the TeeInput
+     * @param file Value that is expected to be copied into the output of
+     *  the TeeInput
+     */
+    public TeeInputHasResult(
+        final String expected,
+        final File file
+    ) {
+        this(
+            new TextOf(expected),
+            new TextOf(file)
+        );
+    }
+
+    /**
+     * Ctor.
+     * @param expected Value that is expected to be returned from the TeeInput
+     * @param copied Value that is expected to be copied into the output of
+     *  the TeeInput
+     */
+    public TeeInputHasResult(
+        final String expected,
+        final Text copied) {
+        this(
+            new TextOf(expected),
+            copied
+        );
+    }
+
+    /**
+     * Ctor.
+     * @param expected Value that is expected to be returned from the TeeInput
+     * @param copied Value that is expected to be copied into the output of
+     *  the TeeInput
+     */
+    public TeeInputHasResult(
+        final Text expected,
+        final Text copied) {
+        super();
+        this.expected = new ComparableText(expected);
+        this.copied = new ComparableText(copied);
+        this.actual = new ComparableText(new TextOf(""));
+    }
+
+    @Override
+    public boolean matchesSafely(final TeeInput item) {
+        this.actual = new ComparableText(new TextOf(item));
+        return
+            this.expected.compareTo(this.actual) == 0
+                && this.expected.compareTo(this.copied) == 0;
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+        description.appendText(
+            new UncheckedText(
+                new FormattedText(
+                    TeeInputHasResult.DESCRIPTION,
+                    new UncheckedText(this.expected).asString(),
+                    new UncheckedText(this.expected).asString()
+                )
+            ).asString()
+        );
+    }
+
+    @Override
+    public void describeMismatchSafely(
+        final TeeInput item,
+        final Description description) {
+        this.describeTo(description);
+    }
+}

--- a/src/test/java/org/cactoos/io/TeeInputFromByteArrayTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputFromByteArrayTest.java
@@ -25,9 +25,8 @@ package org.cactoos.io;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
-import org.cactoos.text.TextOf;
+import org.cactoos.matchers.TeeInputHasResult;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsEqual;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -54,17 +53,15 @@ public final class TeeInputFromByteArrayTest {
         final String message =
             "Hello, товарищ path äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        final TeeInput input = new TeeInput(
-            message.getBytes(StandardCharsets.UTF_8),
-            output.toPath()
-        );
         MatcherAssert.assertThat(
-            new TextOf(input).asString(),
-            new IsEqual<>(message)
-        );
-        MatcherAssert.assertThat(
-            new TextOf(output).asString(),
-            new IsEqual<>(message)
+            new TeeInput(
+                message.getBytes(StandardCharsets.UTF_8),
+                output.toPath()
+            ),
+            new TeeInputHasResult(
+                message,
+                output
+            )
         );
     }
 
@@ -73,17 +70,15 @@ public final class TeeInputFromByteArrayTest {
         final String message =
             "Hello, товарищ file äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        final TeeInput input = new TeeInput(
-            message.getBytes(StandardCharsets.UTF_8),
-            output
-        );
         MatcherAssert.assertThat(
-            new TextOf(input).asString(),
-            new IsEqual<>(message)
-        );
-        MatcherAssert.assertThat(
-            new TextOf(output).asString(),
-            new IsEqual<>(message)
+            new TeeInput(
+                message.getBytes(StandardCharsets.UTF_8),
+                output
+            ),
+            new TeeInputHasResult(
+                message,
+                output
+            )
         );
     }
 
@@ -92,17 +87,15 @@ public final class TeeInputFromByteArrayTest {
         final String message =
             "Hello, товарищ output äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        final TeeInput input = new TeeInput(
-            message.getBytes(StandardCharsets.UTF_8),
-            new OutputTo(output)
-        );
         MatcherAssert.assertThat(
-            new TextOf(input).asString(),
-            new IsEqual<>(message)
-        );
-        MatcherAssert.assertThat(
-            new TextOf(output).asString(),
-            new IsEqual<>(message)
+            new TeeInput(
+                message.getBytes(StandardCharsets.UTF_8),
+                new OutputTo(output)
+            ),
+            new TeeInputHasResult(
+                message,
+                output
+            )
         );
     }
 }

--- a/src/test/java/org/cactoos/io/TeeInputFromBytesTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputFromBytesTest.java
@@ -25,9 +25,8 @@ package org.cactoos.io;
 
 import java.io.File;
 import java.io.IOException;
-import org.cactoos.text.TextOf;
+import org.cactoos.matchers.TeeInputHasResult;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsEqual;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -38,9 +37,6 @@ import org.junit.rules.TemporaryFolder;
  * @author Roman Proshin (roman@proshin.org)
  * @version $Id$
  * @since 1.0
- * @todo #631:30min Create a new Matcher that will compare results of TeeInput
- *  as well as copied content to the original message. Apply this new matcher
- *  for this test and for {@link TeeInputFromByteArrayTest}.
  * @checkstyle JavadocMethodCheck (100 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (100 lines)
  */
@@ -57,17 +53,15 @@ public final class TeeInputFromBytesTest {
         final String message =
             "Hello, товарищ path äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        final TeeInput input = new TeeInput(
-            new BytesOf(message),
-            output.toPath()
-        );
         MatcherAssert.assertThat(
-            new TextOf(input).asString(),
-            new IsEqual<>(message)
-        );
-        MatcherAssert.assertThat(
-            new TextOf(output).asString(),
-            new IsEqual<>(message)
+            new TeeInput(
+                new BytesOf(message),
+                output.toPath()
+            ),
+            new TeeInputHasResult(
+                message,
+                output
+            )
         );
     }
 
@@ -76,17 +70,15 @@ public final class TeeInputFromBytesTest {
         final String message =
             "Hello, товарищ file äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        final TeeInput input = new TeeInput(
-            new BytesOf(message),
-            output
-        );
         MatcherAssert.assertThat(
-            new TextOf(input).asString(),
-            new IsEqual<>(message)
-        );
-        MatcherAssert.assertThat(
-            new TextOf(output).asString(),
-            new IsEqual<>(message)
+            new TeeInput(
+                new BytesOf(message),
+                output
+            ),
+            new TeeInputHasResult(
+                message,
+                output
+            )
         );
     }
 
@@ -95,17 +87,15 @@ public final class TeeInputFromBytesTest {
         final String message =
             "Hello, товарищ output äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        final TeeInput input = new TeeInput(
-            new BytesOf(message),
-            new OutputTo(output)
-        );
         MatcherAssert.assertThat(
-            new TextOf(input).asString(),
-            new IsEqual<>(message)
-        );
-        MatcherAssert.assertThat(
-            new TextOf(output).asString(),
-            new IsEqual<>(message)
+            new TeeInput(
+                new BytesOf(message),
+                new OutputTo(output)
+            ),
+            new TeeInputHasResult(
+                message,
+                output
+            )
         );
     }
 }

--- a/src/test/java/org/cactoos/matchers/TeeInputHasResultTest.java
+++ b/src/test/java/org/cactoos/matchers/TeeInputHasResultTest.java
@@ -1,0 +1,124 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.matchers;
+
+import java.io.ByteArrayOutputStream;
+import org.cactoos.io.OutputTo;
+import org.cactoos.io.TeeInput;
+import org.cactoos.text.TextOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.StringDescription;
+import org.hamcrest.core.IsEqual;
+import org.junit.Test;
+
+/**
+ * Test case for {@link TeeInputHasResult}.
+ *
+ * @author Roman Proshin (roman@proshin.org)
+ * @version $Id$
+ * @since 1.0
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class TeeInputHasResultTest {
+
+    @Test
+    public void failsIfInputDoesNotMatchExpectedValue() {
+        final TeeInput matchable = new TeeInput(
+            new TextOf("input"),
+            new OutputTo(new ByteArrayOutputStream())
+        );
+        final String expected = "expected-1";
+        final TeeInputHasResult matcher = new TeeInputHasResult(
+            expected,
+            new TextOf(expected)
+        );
+        MatcherAssert.assertThat(
+            "Matcher does not compare input and expected values",
+            matcher.matchesSafely(matchable),
+            new IsEqual<>(false)
+        );
+    }
+
+    @Test
+    public void describesMismatchOfInputAndExpected() {
+        final TeeInput matchable = new TeeInput(
+            new TextOf("i"),
+            new OutputTo(new ByteArrayOutputStream())
+        );
+        final TeeInputHasResult matcher = new TeeInputHasResult(
+            "e",
+            new TextOf("e")
+        );
+        final StringDescription description = new StringDescription();
+        matcher.matchesSafely(matchable);
+        matcher.describeMismatchSafely(matchable, description);
+        MatcherAssert.assertThat(
+            "Description of mismatch of input and expected incorrect",
+            description.toString(),
+            new IsEqual<>(
+                "TeeInput with result \"e\" and copied value \"e\""
+            )
+        );
+    }
+
+    @Test
+    public void failsIfCopiedValueDoesNotMatchExpectedValue() {
+        final String expected = "expected-2";
+        final TeeInput matchable = new TeeInput(
+            new TextOf(expected),
+            new OutputTo(new ByteArrayOutputStream())
+        );
+        final TeeInputHasResult matcher = new TeeInputHasResult(
+            expected,
+            new TextOf("incorrect")
+        );
+        MatcherAssert.assertThat(
+            "Matcher does not compare copied and expected values",
+            matcher.matchesSafely(matchable),
+            new IsEqual<>(false)
+        );
+    }
+
+    @Test
+    public void describesMismatchOfCopiedAndExpected() {
+        final TeeInput matchable = new TeeInput(
+            new TextOf("i"),
+            new OutputTo(new ByteArrayOutputStream())
+        );
+        final TeeInputHasResult matcher = new TeeInputHasResult(
+            "i",
+            new TextOf("wrong")
+        );
+        final StringDescription description = new StringDescription();
+        matcher.matchesSafely(matchable);
+        matcher.describeMismatchSafely(matchable, description);
+        MatcherAssert.assertThat(
+            "Description of mismatch of copied and expected incorrect",
+            description.toString(),
+            new IsEqual<>(
+                "TeeInput with result \"i\" and copied value \"i\""
+            )
+        );
+    }
+}


### PR DESCRIPTION
It is for issue #721: adds a new matcher that checks result of TeeInput class: compares both TeeInput's results (direct and copied) to the expected value. As well this new matcher has been applied to existing tests of TeeInput class.