### PR TITLE
replaced all Arrays.asList with new ListOf<>()

### DIFF
--- a/src/test/java/org/cactoos/collection/MappedTest.java
+++ b/src/test/java/org/cactoos/collection/MappedTest.java
@@ -31,6 +31,7 @@ import java.util.Iterator;
 import org.cactoos.Text;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterator.Endless;
+import org.cactoos.list.ListOf;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UpperText;
 import org.hamcrest.MatcherAssert;
@@ -89,7 +90,7 @@ public final class MappedTest {
             "Can't convert to string",
             new Mapped<Integer, Integer>(
                 x -> x * 2,
-                Arrays.asList(1, 2, 3)
+                new ListOf<>(1, 2, 3)
             ).toString(),
             Matchers.equalTo("2, 4, 6")
         );

--- a/src/test/java/org/cactoos/collection/MappedTest.java
+++ b/src/test/java/org/cactoos/collection/MappedTest.java
@@ -23,6 +23,10 @@
  */
 package org.cactoos.collection;
 
+import java.io.IOException;
+import java.util.AbstractCollection;
+import java.util.Collections;
+import java.util.Iterator;
 import org.cactoos.Text;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterator.Endless;
@@ -32,11 +36,6 @@ import org.cactoos.text.UpperText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
-
-import java.io.IOException;
-import java.util.AbstractCollection;
-import java.util.Collections;
-import java.util.Iterator;
 
 /**
  * Test case for {@link Mapped}.

--- a/src/test/java/org/cactoos/collection/MappedTest.java
+++ b/src/test/java/org/cactoos/collection/MappedTest.java
@@ -23,11 +23,6 @@
  */
 package org.cactoos.collection;
 
-import java.io.IOException;
-import java.util.AbstractCollection;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Iterator;
 import org.cactoos.Text;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterator.Endless;
@@ -37,6 +32,11 @@ import org.cactoos.text.UpperText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.util.AbstractCollection;
+import java.util.Collections;
+import java.util.Iterator;
 
 /**
  * Test case for {@link Mapped}.

--- a/src/test/java/org/cactoos/collection/MappedTest.java
+++ b/src/test/java/org/cactoos/collection/MappedTest.java
@@ -44,6 +44,7 @@ import org.junit.Test;
  * @since 0.14
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle MagicNumberCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class MappedTest {
 

--- a/src/test/java/org/cactoos/collection/StickyCollectionTest.java
+++ b/src/test/java/org/cactoos/collection/StickyCollectionTest.java
@@ -23,15 +23,15 @@
  */
 package org.cactoos.collection;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Test case for {@link StickyCollection}.

--- a/src/test/java/org/cactoos/collection/StickyCollectionTest.java
+++ b/src/test/java/org/cactoos/collection/StickyCollectionTest.java
@@ -112,7 +112,7 @@ public final class StickyCollectionTest {
     @Test
     public void testContainsAll() {
         MatcherAssert.assertThat(
-            new StickyCollection<>(1, 2).containsAll(Arrays.asList(1, 2)),
+            new StickyCollection<>(1, 2).containsAll(new ListOf<>(1, 2)),
             Matchers.equalTo(true)
         );
     }

--- a/src/test/java/org/cactoos/collection/StickyCollectionTest.java
+++ b/src/test/java/org/cactoos/collection/StickyCollectionTest.java
@@ -23,15 +23,14 @@
  */
 package org.cactoos.collection;
 
-import org.cactoos.list.ListOf;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.cactoos.list.ListOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
 
 /**
  * Test case for {@link StickyCollection}.

--- a/src/test/java/org/cactoos/iterable/MappedTest.java
+++ b/src/test/java/org/cactoos/iterable/MappedTest.java
@@ -23,6 +23,8 @@
  */
 package org.cactoos.iterable;
 
+import java.io.IOException;
+import java.util.Collections;
 import org.cactoos.Text;
 import org.cactoos.list.ListOf;
 import org.cactoos.text.TextOf;
@@ -30,9 +32,6 @@ import org.cactoos.text.UpperText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
-
-import java.io.IOException;
-import java.util.Collections;
 
 /**
  * Test case for {@link Mapped}.

--- a/src/test/java/org/cactoos/iterable/MappedTest.java
+++ b/src/test/java/org/cactoos/iterable/MappedTest.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import org.cactoos.Text;
+import org.cactoos.list.ListOf;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UpperText;
 import org.hamcrest.MatcherAssert;
@@ -75,7 +76,7 @@ public final class MappedTest {
             "Can't convert to string",
             new Mapped<Integer, Integer>(
                 x -> x * 2,
-                Arrays.asList(1, 2, 3)
+                new ListOf<>(1, 2, 3)
             ).toString(),
             Matchers.equalTo("2, 4, 6")
         );

--- a/src/test/java/org/cactoos/iterable/MappedTest.java
+++ b/src/test/java/org/cactoos/iterable/MappedTest.java
@@ -23,9 +23,6 @@
  */
 package org.cactoos.iterable;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
 import org.cactoos.Text;
 import org.cactoos.list.ListOf;
 import org.cactoos.text.TextOf;
@@ -33,6 +30,9 @@ import org.cactoos.text.UpperText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
 
 /**
  * Test case for {@link Mapped}.

--- a/src/test/java/org/cactoos/iterator/PartitionedTest.java
+++ b/src/test/java/org/cactoos/iterator/PartitionedTest.java
@@ -88,6 +88,7 @@ public final class PartitionedTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void partitionedLastPartitionSmaller() {
         MatcherAssert.assertThat(
             "Can't generate a Partitioned of size 2 last partition smaller.",

--- a/src/test/java/org/cactoos/iterator/PartitionedTest.java
+++ b/src/test/java/org/cactoos/iterator/PartitionedTest.java
@@ -55,6 +55,7 @@ public final class PartitionedTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void partitionedOne() {
         MatcherAssert.assertThat(
             "Can't generate a Partitioned of partition size 1.",
@@ -73,6 +74,7 @@ public final class PartitionedTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void partitionedEqualSize() {
         MatcherAssert.assertThat(
             "Can't generate a Partitioned of partition size 2.",

--- a/src/test/java/org/cactoos/iterator/PartitionedTest.java
+++ b/src/test/java/org/cactoos/iterator/PartitionedTest.java
@@ -23,14 +23,13 @@
  */
 package org.cactoos.iterator;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.NoSuchElementException;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.NoSuchElementException;
 
 /**
  * Test case for {@link Partitioned}.
@@ -84,7 +83,7 @@ public final class PartitionedTest {
                 )
             ),
             Matchers.equalTo(
-                    new ListOf<>(new ListOf<>(1, 2), new ListOf<>(3, 4))
+                new ListOf<>(new ListOf<>(1, 2), new ListOf<>(3, 4))
             )
         );
     }

--- a/src/test/java/org/cactoos/iterator/PartitionedTest.java
+++ b/src/test/java/org/cactoos/iterator/PartitionedTest.java
@@ -23,14 +23,14 @@
  */
 package org.cactoos.iterator;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.NoSuchElementException;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.NoSuchElementException;
 
 /**
  * Test case for {@link Partitioned}.

--- a/src/test/java/org/cactoos/iterator/PartitionedTest.java
+++ b/src/test/java/org/cactoos/iterator/PartitionedTest.java
@@ -60,11 +60,11 @@ public final class PartitionedTest {
             "Can't generate a Partitioned of partition size 1.",
             new ArrayList<>(
                 new ListOf<>(
-                    new Partitioned<>(1, Arrays.asList(1, 2, 3).iterator())
+                    new Partitioned<>(1, new ListOf<>(1, 2, 3).iterator())
                 )
             ),
             Matchers.equalTo(
-                Arrays.asList(
+                new ListOf<>(
                     Collections.singletonList(1), Collections.singletonList(2),
                     Collections.singletonList(3)
                 )
@@ -82,7 +82,7 @@ public final class PartitionedTest {
                 )
             ),
             Matchers.equalTo(
-                Arrays.asList(Arrays.asList(1, 2), Arrays.asList(3, 4))
+                    new ListOf<>(new ListOf<>(1, 2), new ListOf<>(3, 4))
             )
         );
     }
@@ -97,8 +97,8 @@ public final class PartitionedTest {
                 )
             ),
             Matchers.equalTo(
-                Arrays.asList(
-                    Arrays.asList(1, 2),
+                new ListOf<>(
+                    new ListOf<>(1, 2),
                     Collections.singletonList(3)
                 )
             )

--- a/src/test/java/org/cactoos/iterator/SyncIteratorTest.java
+++ b/src/test/java/org/cactoos/iterator/SyncIteratorTest.java
@@ -23,13 +23,12 @@
  */
 package org.cactoos.iterator;
 
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.cactoos.list.ListOf;
 import org.cactoos.matchers.RunsInThreads;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
-
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Test for {@link SyncIterator}.
@@ -89,7 +88,7 @@ public final class SyncIteratorTest {
                 },
                 new RunsInThreads<>(
                     new SyncIterator<>(
-                            new ListOf<>("a", "b").iterator()
+                        new ListOf<>("a", "b").iterator()
                     ),
                     2
                 )

--- a/src/test/java/org/cactoos/iterator/SyncIteratorTest.java
+++ b/src/test/java/org/cactoos/iterator/SyncIteratorTest.java
@@ -23,13 +23,13 @@
  */
 package org.cactoos.iterator;
 
-import java.util.Arrays;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.cactoos.list.ListOf;
 import org.cactoos.matchers.RunsInThreads;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Test for {@link SyncIterator}.

--- a/src/test/java/org/cactoos/iterator/SyncIteratorTest.java
+++ b/src/test/java/org/cactoos/iterator/SyncIteratorTest.java
@@ -51,7 +51,7 @@ public final class SyncIteratorTest {
             "Unexpected value found.",
             new ListOf<>(
                 new SyncIterator<>(
-                    Arrays.asList("a", "b").iterator(), lock
+                    new ListOf<>("a", "b").iterator(), lock
                 )
             ).toArray(),
             Matchers.equalTo(new Object[]{"a", "b"})
@@ -64,7 +64,7 @@ public final class SyncIteratorTest {
             "Unexpected value found.",
             new ListOf<>(
                 new SyncIterator<>(
-                    Arrays.asList("a", "b").iterator()
+                    new ListOf<>("a", "b").iterator()
                 )
             ).toArray(),
             Matchers.equalTo(new Object[]{"a", "b"})
@@ -89,7 +89,7 @@ public final class SyncIteratorTest {
                 },
                 new RunsInThreads<>(
                     new SyncIterator<>(
-                        Arrays.asList("a", "b").iterator()
+                            new ListOf<>("a", "b").iterator()
                     ),
                     2
                 )
@@ -129,7 +129,7 @@ public final class SyncIteratorTest {
                 },
                 new RunsInThreads<>(
                     new SyncIterator<>(
-                        Arrays.asList("a", "b").iterator()
+                        new ListOf<>("a", "b").iterator()
                     ),
                     2
                 )

--- a/src/test/java/org/cactoos/list/ListOfTest.java
+++ b/src/test/java/org/cactoos/list/ListOfTest.java
@@ -148,7 +148,7 @@ public final class ListOfTest {
         MatcherAssert.assertThat(
             "Can't compare using equals.",
             new ListOf<>(1, 2),
-            new IsEqual<>(Arrays.asList(1, 2))
+            new IsEqual<>(new ListOf<>(1, 2))
         );
     }
 

--- a/src/test/java/org/cactoos/list/ListOfTest.java
+++ b/src/test/java/org/cactoos/list/ListOfTest.java
@@ -23,7 +23,6 @@
  */
 package org.cactoos.list;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/src/test/java/org/cactoos/list/MappedTest.java
+++ b/src/test/java/org/cactoos/list/MappedTest.java
@@ -86,7 +86,7 @@ public final class MappedTest {
             "Can't convert to string",
             new Mapped<Integer, Integer>(
                 x -> x * 2,
-                Arrays.asList(1, 2, 3)
+                new ListOf<>(1, 2, 3)
             ).toString(),
             Matchers.equalTo("2, 4, 6")
         );

--- a/src/test/java/org/cactoos/list/MappedTest.java
+++ b/src/test/java/org/cactoos/list/MappedTest.java
@@ -23,6 +23,8 @@
  */
 package org.cactoos.list;
 
+import java.io.IOException;
+import java.util.Collections;
 import org.cactoos.Text;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.text.TextOf;
@@ -30,9 +32,6 @@ import org.cactoos.text.UpperText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
-
-import java.io.IOException;
-import java.util.Collections;
 
 /**
  * Test case for {@link Mapped}.

--- a/src/test/java/org/cactoos/list/MappedTest.java
+++ b/src/test/java/org/cactoos/list/MappedTest.java
@@ -23,9 +23,6 @@
  */
 package org.cactoos.list;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
 import org.cactoos.Text;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.text.TextOf;
@@ -33,6 +30,9 @@ import org.cactoos.text.UpperText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
 
 /**
  * Test case for {@link Mapped}.

--- a/src/test/java/org/cactoos/list/StickyListTest.java
+++ b/src/test/java/org/cactoos/list/StickyListTest.java
@@ -23,16 +23,16 @@
  */
 package org.cactoos.list;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.cactoos.Scalar;
 import org.cactoos.iterable.IterableOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Test case for {@link StickyList}.

--- a/src/test/java/org/cactoos/list/StickyListTest.java
+++ b/src/test/java/org/cactoos/list/StickyListTest.java
@@ -115,7 +115,7 @@ public final class StickyListTest {
     @Test
     public void testContainsAll() {
         MatcherAssert.assertThat(
-            new StickyList<>(1, 2).containsAll(Arrays.asList(1, 2)),
+            new StickyList<>(1, 2).containsAll(new ListOf<>(1, 2)),
             Matchers.equalTo(true)
         );
     }

--- a/src/test/java/org/cactoos/list/StickyListTest.java
+++ b/src/test/java/org/cactoos/list/StickyListTest.java
@@ -23,16 +23,15 @@
  */
 package org.cactoos.list;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.cactoos.Scalar;
 import org.cactoos.iterable.IterableOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Test case for {@link StickyList}.

--- a/src/test/java/org/cactoos/scalar/AndInThreadsTest.java
+++ b/src/test/java/org/cactoos/scalar/AndInThreadsTest.java
@@ -23,13 +23,6 @@
  */
 package org.cactoos.scalar;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import org.cactoos.Proc;
 import org.cactoos.Scalar;
 import org.cactoos.func.FuncOf;
@@ -41,6 +34,13 @@ import org.cactoos.matchers.ScalarHasValue;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 /**
  * Test case for {@link AndInThreads}.

--- a/src/test/java/org/cactoos/scalar/AndInThreadsTest.java
+++ b/src/test/java/org/cactoos/scalar/AndInThreadsTest.java
@@ -176,7 +176,7 @@ public final class AndInThreadsTest {
         );
         new AndInThreads(
             new Proc.NoNulls<Integer>(list::add),
-            Arrays.asList(1, 2)
+                new ListOf<>(1, 2)
         ).value();
         MatcherAssert.assertThat(
             list,
@@ -223,7 +223,7 @@ public final class AndInThreadsTest {
         new AndInThreads(
             service,
             new Proc.NoNulls<Integer>(list::add),
-            Arrays.asList(1, 2)
+                new ListOf<>(1, 2)
         ).value();
         MatcherAssert.assertThat(
             list,

--- a/src/test/java/org/cactoos/scalar/AndInThreadsTest.java
+++ b/src/test/java/org/cactoos/scalar/AndInThreadsTest.java
@@ -23,6 +23,12 @@
  */
 package org.cactoos.scalar;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.cactoos.Proc;
 import org.cactoos.Scalar;
 import org.cactoos.func.FuncOf;
@@ -34,13 +40,6 @@ import org.cactoos.matchers.ScalarHasValue;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 /**
  * Test case for {@link AndInThreads}.


### PR DESCRIPTION
This is for this [issue](https://github.com/yegor256/cactoos/issues/769). There is still [one more](https://github.com/yegor256/cactoos/blob/b4223ce3e096424397e33058568b587844d93b24/src/main/java/org/cactoos/iterable/IterableOf.java#L50) left. I've created a [new issue](https://github.com/yegor256/cactoos/issues/773) for this one because it has a deeper problem that needs to be solved.