### PR TITLE
#692 And/Or javadoc

### DIFF
--- a/src/main/java/org/cactoos/scalar/And.java
+++ b/src/main/java/org/cactoos/scalar/And.java
@@ -38,7 +38,6 @@ import org.cactoos.iterable.Mapped;
  * {@link java.util.stream.Stream#forEach(java.util.function.Consumer)}
  * works:</p>
  *
- * <pre>
  * {@code
  * new And(
  *    new ProcOf<>(input -> System.out.printf("\'%s\' ", input) ),
@@ -46,12 +45,10 @@ import org.cactoos.iterable.Mapped;
  * ).value(); // will print 'Mary' 'John' 'William' 'Napkin' to standard output
  *            // the result of this operation is always true
  * }
- * </pre>
  *
  * <p>This class could be also used for matching multiple boolean
  * expressions:</p>
  *
- * <pre>
  * {@code
  * new And(
  *    new True(),
@@ -65,7 +62,6 @@ import org.cactoos.iterable.Mapped;
  *    new True()
  * ).value(); // the result is false
  * }
- * </pre>
  *
  * <p>This class implements {@link Scalar}, which throws a checked
  * {@link Exception}. This may not be convenient in many cases. To make

--- a/src/main/java/org/cactoos/scalar/And.java
+++ b/src/main/java/org/cactoos/scalar/And.java
@@ -43,6 +43,24 @@ import org.cactoos.iterable.Mapped;
  *    new ProcOf<>(input -> System.out.printf("\'%s\' ", input) ),
  *    new IterableOf<>("Mary", "John", "William", "Napkin")
  * ).value(); // will print 'Mary' 'John' 'William' 'Napkin' to standard output
+ *            // the result of this operation is always true
+ * </pre>
+ *
+ * <p>This class could be also used for matching multiple boolean
+ * expressions:</p>
+ *
+ * <pre>
+ * new And(
+ *    new True(),
+ *    new True(),
+ *    new True()
+ * ).value(); // the result is true
+ *
+ * new And(
+ *    new True(),
+ *    new False(),
+ *    new True()
+ * ).value(); // the result is false
  * </pre>
  *
  * <p>This class implements {@link Scalar}, which throws a checked

--- a/src/main/java/org/cactoos/scalar/And.java
+++ b/src/main/java/org/cactoos/scalar/And.java
@@ -39,17 +39,20 @@ import org.cactoos.iterable.Mapped;
  * works:</p>
  *
  * <pre>
+ * {@code
  * new And(
  *    new ProcOf<>(input -> System.out.printf("\'%s\' ", input) ),
  *    new IterableOf<>("Mary", "John", "William", "Napkin")
  * ).value(); // will print 'Mary' 'John' 'William' 'Napkin' to standard output
  *            // the result of this operation is always true
+ * }
  * </pre>
  *
  * <p>This class could be also used for matching multiple boolean
  * expressions:</p>
  *
  * <pre>
+ * {@code
  * new And(
  *    new True(),
  *    new True(),
@@ -61,6 +64,7 @@ import org.cactoos.iterable.Mapped;
  *    new False(),
  *    new True()
  * ).value(); // the result is false
+ * }
  * </pre>
  *
  * <p>This class implements {@link Scalar}, which throws a checked

--- a/src/main/java/org/cactoos/scalar/And.java
+++ b/src/main/java/org/cactoos/scalar/And.java
@@ -32,6 +32,9 @@ import org.cactoos.iterable.Mapped;
 
 /**
  * Logical conjunction.
+ * This class performs short-circuit evaluation in which arguments are
+ * executed only if the preceding argument does not suffice to determine
+ * the value of the expression.
  *
  * <p>This class can be effectively used to iterate through
  * a collection, just like

--- a/src/main/java/org/cactoos/scalar/And.java
+++ b/src/main/java/org/cactoos/scalar/And.java
@@ -40,7 +40,7 @@ import org.cactoos.iterable.Mapped;
  *
  * {@code
  * new And(
- *    new ProcOf<>(input -> System.out.printf("\'%s\' ", input) ),
+ *    new ProcOf<>(input -> System.out.printf("\'%s\' ", input)),
  *    new IterableOf<>("Mary", "John", "William", "Napkin")
  * ).value(); // will print 'Mary' 'John' 'William' 'Napkin' to standard output
  *            // the result of this operation is always true

--- a/src/main/java/org/cactoos/scalar/AndInThreads.java
+++ b/src/main/java/org/cactoos/scalar/AndInThreads.java
@@ -39,15 +39,7 @@ import org.cactoos.iterable.Mapped;
 /**
  * Logical conjunction, in multiple threads.
  *
- * <p>This class can be effectively used to iterate through
- * a collection, just like
- * {@link java.util.stream.Stream#forEach(java.util.function.Consumer)}
- * works:</p>
- *
- * <pre> new AndInThreads(
- *   name -> System.out.println("The name: %s\n", name),
- *   new IterableOf&lt;&gt;("Mary", "John", "William", "Napkin")
- * ).value();</pre>
+ * <p>The usage is same as for {@link And}</p>
  *
  * <p>This class implements {@link Scalar}, which throws a checked
  * {@link Exception}. This may not be convenient in many cases. To make

--- a/src/main/java/org/cactoos/scalar/Or.java
+++ b/src/main/java/org/cactoos/scalar/Or.java
@@ -40,17 +40,20 @@ import org.cactoos.iterable.Mapped;
  * works:</p>
  *
  * <pre>
+ * {@code
  * new Or(
  *    new ProcOf<>(input -> System.out.printf("\'%s\' ", input) ),
  *    new IterableOf<>("Mary", "John", "William", "Napkin")
  * ).value(); // will print 'Mary' 'John' 'William' 'Napkin' to standard output
  *            // the result of this operation is always false
+ * }
  * </pre>
  *
  * <p>This class could be also used for matching multiple boolean
  * expressions:</p>
  *
  * <pre>
+ * {@code
  * new Or(
  *    new False(),
  *    new True(),
@@ -62,6 +65,7 @@ import org.cactoos.iterable.Mapped;
  *    new False(),
  *    new False()
  * ).value(); // the result is false
+ * }
  * </pre>
  *
  * <p>There is no thread-safety guarantee.

--- a/src/main/java/org/cactoos/scalar/Or.java
+++ b/src/main/java/org/cactoos/scalar/Or.java
@@ -34,6 +34,36 @@ import org.cactoos.iterable.Mapped;
 /**
  * Logical disjunction.
  *
+ * <p>This class can be effectively used to iterate through
+ * a collection, just like
+ * {@link java.util.stream.Stream#forEach(java.util.function.Consumer)}
+ * works:</p>
+ *
+ * <pre>
+ * new Or(
+ *    new ProcOf<>(input -> System.out.printf("\'%s\' ", input) ),
+ *    new IterableOf<>("Mary", "John", "William", "Napkin")
+ * ).value(); // will print 'Mary' 'John' 'William' 'Napkin' to standard output
+ *            // the result of this operation is always false
+ * </pre>
+ *
+ * <p>This class could be also used for matching multiple boolean
+ * expressions:</p>
+ *
+ * <pre>
+ * new Or(
+ *    new False(),
+ *    new True(),
+ *    new True()
+ * ).value(); // the result is true
+ *
+ * new Or(
+ *    new False(),
+ *    new False(),
+ *    new False()
+ * ).value(); // the result is false
+ * </pre>
+ *
  * <p>There is no thread-safety guarantee.
  *
  * <p>This class implements {@link Scalar}, which throws a checked

--- a/src/main/java/org/cactoos/scalar/Or.java
+++ b/src/main/java/org/cactoos/scalar/Or.java
@@ -39,7 +39,6 @@ import org.cactoos.iterable.Mapped;
  * {@link java.util.stream.Stream#forEach(java.util.function.Consumer)}
  * works:</p>
  *
- * <pre>
  * {@code
  * new Or(
  *    new ProcOf<>(input -> System.out.printf("\'%s\' ", input) ),
@@ -47,12 +46,10 @@ import org.cactoos.iterable.Mapped;
  * ).value(); // will print 'Mary' 'John' 'William' 'Napkin' to standard output
  *            // the result of this operation is always false
  * }
- * </pre>
  *
  * <p>This class could be also used for matching multiple boolean
  * expressions:</p>
  *
- * <pre>
  * {@code
  * new Or(
  *    new False(),
@@ -66,7 +63,6 @@ import org.cactoos.iterable.Mapped;
  *    new False()
  * ).value(); // the result is false
  * }
- * </pre>
  *
  * <p>There is no thread-safety guarantee.
  *

--- a/src/main/java/org/cactoos/scalar/Or.java
+++ b/src/main/java/org/cactoos/scalar/Or.java
@@ -33,6 +33,9 @@ import org.cactoos.iterable.Mapped;
 
 /**
  * Logical disjunction.
+ * This class performs short-circuit evaluation in which arguments are
+ * executed only if the preceding argument does not suffice to determine
+ * the value of the expression.
  *
  * <p>This class can be effectively used to iterate through
  * a collection, just like


### PR DESCRIPTION
Expanded javadoc for And/Or/AndInThreads for #692 

I've updated `And` and `Or` javadoc and added a link to `AndInThreads` which refers to `And` javadoc examples.