### PR TITLE
#766 Make IoCheckedScalar use CheckedScalar

### DIFF
--- a/src/main/java/org/cactoos/scalar/IoCheckedScalar.java
+++ b/src/main/java/org/cactoos/scalar/IoCheckedScalar.java
@@ -24,6 +24,7 @@
 package org.cactoos.scalar;
 
 import java.io.IOException;
+import org.cactoos.Func;
 import org.cactoos.Scalar;
 
 /**
@@ -66,18 +67,16 @@ public final class IoCheckedScalar<T> implements Scalar<T> {
             }
         )
     public T value() throws IOException {
-        try {
-            return this.origin.value();
-            // @checkstyle IllegalCatchCheck (1 line)
-        } catch (final IOException | RuntimeException ex) {
-            throw ex;
-        } catch (final InterruptedException ex) {
-            Thread.currentThread().interrupt();
-            throw new IOException(ex);
-            // @checkstyle IllegalCatchCheck (1 line)
-        } catch (final Exception ex) {
-            throw new IOException(ex);
-        }
+        return new CheckedScalar<T, IOException>(
+            this.origin,
+            new  Func<Exception, IOException>() {
+                @Override
+                public IOException apply(final Exception input) throws
+                Exception {
+                    return new IOException(input);
+                }
+            }
+        ).value();
     }
 
 }

--- a/src/main/java/org/cactoos/scalar/IoCheckedScalar.java
+++ b/src/main/java/org/cactoos/scalar/IoCheckedScalar.java
@@ -24,7 +24,6 @@
 package org.cactoos.scalar;
 
 import java.io.IOException;
-import org.cactoos.Func;
 import org.cactoos.Scalar;
 
 /**
@@ -59,23 +58,10 @@ public final class IoCheckedScalar<T> implements Scalar<T> {
     }
 
     @Override
-    @SuppressWarnings
-        (
-            {
-                "PMD.AvoidCatchingGenericException",
-                "PMD.AvoidRethrowingException"
-            }
-        )
     public T value() throws IOException {
-        return new CheckedScalar<T, IOException>(
+        return new CheckedScalar<>(
             this.origin,
-            new  Func<Exception, IOException>() {
-                @Override
-                public IOException apply(final Exception input) throws
-                Exception {
-                    return new IOException(input);
-                }
-            }
+            IOException::new
         ).value();
     }
 


### PR DESCRIPTION
As asked in #766, `IoCheckedScalar` now uses `CheckedScalar` logic to return `IOException`.