### PR TITLE
#454 TeeInput class should not close the OutputStream

### DIFF
--- a/src/main/java/org/cactoos/io/TeeInputStream.java
+++ b/src/main/java/org/cactoos/io/TeeInputStream.java
@@ -96,7 +96,7 @@ public final class TeeInputStream extends InputStream {
     @Override
     public void close() throws IOException {
         this.input.close();
-        this.output.close();
+        this.output.flush();
     }
 
     @Override

--- a/src/test/java/org/cactoos/io/GzipOutputTest.java
+++ b/src/test/java/org/cactoos/io/GzipOutputTest.java
@@ -63,12 +63,17 @@ public final class GzipOutputTest {
             (byte) 0x00, (byte) 0x00, (byte) 0x00,
         };
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        new LengthOf(
-            new TeeInput(
-                "Hello!",
-                new GzipOutput(new OutputTo(baos))
-            )
-        ).value();
+        try (final OutputStream output = new GzipOutput(
+            new OutputTo(baos)
+        ).stream()
+        ) {
+            new LengthOf(
+                new TeeInput(
+                    "Hello!",
+                    new OutputTo(output)
+                )
+            ).value();
+        }
         MatcherAssert.assertThat(
             "Can't write to a gzip output",
             baos.toByteArray(),

--- a/src/test/java/org/cactoos/io/LoggingOutputTest.java
+++ b/src/test/java/org/cactoos/io/LoggingOutputTest.java
@@ -120,16 +120,19 @@ public final class LoggingOutputTest {
         final Logger logger = new FakeLogger();
         final Path temp = this.folder.newFolder("ccts-1").toPath();
         final Path path = temp.resolve("x/y/z/file.txt");
-        new LengthOf(
-            new TeeInput(
-                new ResourceOf("org/cactoos/large-text.txt"),
-                new LoggingOutput(
-                    new OutputTo(path),
-                    "text file",
-                    logger
+        try (OutputStream output = new LoggingOutput(
+            new OutputTo(path),
+            "text file",
+            logger
+        ).stream()
+        ) {
+            new LengthOf(
+                new TeeInput(
+                    new ResourceOf("org/cactoos/large-text.txt"),
+                    new OutputTo(output)
                 )
-            )
-        ).intValue();
+            ).intValue();
+        }
         MatcherAssert.assertThat(
             "Can't log write and close operations to text file",
             logger.toString(),
@@ -150,16 +153,19 @@ public final class LoggingOutputTest {
         final Logger logger = new FakeLogger(Level.WARNING);
         final Path temp = this.folder.newFolder("ccts-2").toPath();
         final Path path = temp.resolve("a/b/c/file.txt");
-        new LengthOf(
-            new TeeInput(
-                new ResourceOf("org/cactoos/large-text.txt"),
-                new LoggingOutput(
-                    new OutputTo(path),
-                    "text file",
-                    logger
+        try (final OutputStream output = new LoggingOutput(
+            new OutputTo(path),
+            "text file",
+            logger
+        ).stream()
+        ) {
+            new LengthOf(
+                new TeeInput(
+                    new ResourceOf("org/cactoos/large-text.txt"),
+                    new OutputTo(output)
                 )
-            )
-        ).intValue();
+            ).intValue();
+        }
         MatcherAssert.assertThat(
             "Can't log all write and close operations to text file",
             logger.toString(),

--- a/src/test/java/org/cactoos/io/TeeInputStreamTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputStreamTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 
 /**
@@ -79,9 +80,9 @@ public final class TeeInputStreamTest {
                 )
             ).intValue();
             MatcherAssert.assertThat(
-                "Can''t use output after usage from TeeInput",
+                "Can't use output after usage from TeeInput",
                 write.isClosed(),
-                Matchers.equalTo(false)
+                new IsEqual<>(false)
             );
         }
     }

--- a/src/test/java/org/cactoos/io/TeeInputStreamTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputStreamTest.java
@@ -26,7 +26,9 @@ package org.cactoos.io;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -67,4 +69,39 @@ public final class TeeInputStreamTest {
         );
     }
 
+    @Test
+    public void leftInputUnclosed() {
+        try (StringWriterMock write = new StringWriterMock()) {
+            new LengthOf(
+                new TeeInput(
+                    "foo",
+                    new OutputTo(write)
+                )
+            ).intValue();
+            MatcherAssert.assertThat(
+                "Can''t use output after usage from TeeInput",
+                write.isClosed(),
+                Matchers.equalTo(false)
+            );
+        }
+    }
+
+    /**
+     * Mock object around StringWriter for checking closing state.
+     */
+    private static final class StringWriterMock extends StringWriter {
+        /**
+         * Closing state.
+         */
+        private final AtomicBoolean closed = new AtomicBoolean(false);
+
+        @Override
+        public void close() {
+            this.closed.set(true);
+        }
+
+        public boolean isClosed() {
+            return this.closed.get();
+        }
+    }
 }

--- a/src/test/java/org/cactoos/io/WriterAsOutputStreamTest.java
+++ b/src/test/java/org/cactoos/io/WriterAsOutputStreamTest.java
@@ -93,54 +93,56 @@ public final class WriterAsOutputStreamTest {
     public void writesLargeContentToFile() throws IOException {
         final Path temp = this.folder.newFile("cactoos-1.txt-1")
             .toPath();
-        MatcherAssert.assertThat(
-            "Can't copy Input to Output and return Input",
-            new TextOf(
-                new TeeInput(
-                    new ResourceOf("org/cactoos/large-text.txt"),
-                    new OutputTo(
-                        new WriterAsOutputStream(
-                            new OutputStreamWriter(
-                                new FileOutputStream(temp.toFile()),
-                                StandardCharsets.UTF_8
-                            ),
-                            StandardCharsets.UTF_8,
-                            // @checkstyle MagicNumber (1 line)
-                            345
+        try (final OutputStreamWriter writer = new OutputStreamWriter(
+            new FileOutputStream(temp.toFile()), StandardCharsets.UTF_8
+        )) {
+            MatcherAssert.assertThat(
+                "Can't copy Input to Output and return Input",
+                new TextOf(
+                    new TeeInput(
+                        new ResourceOf("org/cactoos/large-text.txt"),
+                        new OutputTo(
+                            new WriterAsOutputStream(
+                                writer,
+                                StandardCharsets.UTF_8,
+                                // @checkstyle MagicNumber (1 line)
+                                345
+                            )
                         )
                     )
+                ),
+                new TextHasString(
+                    new MatcherOf<>(
+                        str -> {
+                            return new TextOf(temp).asString().equals(str);
+                        }
+                    )
                 )
-            ),
-            new TextHasString(
-                new MatcherOf<>(
-                    str -> {
-                        return new TextOf(temp).asString().equals(str);
-                    }
-                )
-            )
-        );
+            );
+        }
     }
 
     @Test
     public void writesToFileAndRemovesIt() throws Exception {
         final Path temp = this.folder.newFile().toPath();
         final String content = "Hello, товарищ! How are you?";
-        new LengthOf(
-            new TeeInput(
-                new InputOf(content),
-                new OutputTo(
-                    new WriterAsOutputStream(
-                        new OutputStreamWriter(
-                            new FileOutputStream(temp.toFile()),
-                            StandardCharsets.UTF_8
-                        ),
-                        StandardCharsets.UTF_8,
-                        // @checkstyle MagicNumber (1 line)
-                        345
+        try (final OutputStreamWriter writer = new OutputStreamWriter(
+            new FileOutputStream(temp.toFile()), StandardCharsets.UTF_8
+        )) {
+            new LengthOf(
+                new TeeInput(
+                    new InputOf(content),
+                    new OutputTo(
+                        new WriterAsOutputStream(
+                            writer,
+                            StandardCharsets.UTF_8,
+                            // @checkstyle MagicNumber (1 line)
+                            345
+                        )
                     )
                 )
-            )
-        ).value();
+            ).value();
+        }
         Files.delete(temp);
         MatcherAssert.assertThat(
             () -> Files.exists(temp),

--- a/src/test/java/org/cactoos/io/WriterAsOutputTest.java
+++ b/src/test/java/org/cactoos/io/WriterAsOutputTest.java
@@ -56,27 +56,26 @@ public final class WriterAsOutputTest {
     public void writesLargeContentToFile() throws IOException {
         final Path temp = this.folder.newFile("cactoos-1.txt-1")
             .toPath();
-        MatcherAssert.assertThat(
-            "Can't copy Input to Output and return Input",
-            new TextOf(
-                new TeeInput(
-                    new ResourceOf("org/cactoos/large-text.txt"),
-                    new WriterAsOutput(
-                        new OutputStreamWriter(
-                            new FileOutputStream(temp.toFile()),
-                            StandardCharsets.UTF_8
-                        )
+        try (final OutputStreamWriter writer = new OutputStreamWriter(
+            new FileOutputStream(temp.toFile()), StandardCharsets.UTF_8
+        )) {
+            MatcherAssert.assertThat(
+                "Can't copy Input to Output and return Input",
+                new TextOf(
+                    new TeeInput(
+                        new ResourceOf("org/cactoos/large-text.txt"),
+                        new WriterAsOutput(writer)
+                    )
+                ),
+                new TextHasString(
+                    new MatcherOf<>(
+                        str -> {
+                            return new TextOf(temp).asString().equals(str);
+                        }
                     )
                 )
-            ),
-            new TextHasString(
-                new MatcherOf<>(
-                    str -> {
-                        return new TextOf(temp).asString().equals(str);
-                    }
-                )
-            )
-        );
+            );
+        }
     }
 
 }


### PR DESCRIPTION
For #454 
**Problem**
`TeeInput` closes output stream after work.

**Solution**
I have replaced `close` with `flush` for output stream in `TeeInputStream.close()`

Valuable changes only in files: `TeeInputStream` and `TeeInputStreamTest`.
All other files just tests which had broken after the fix because they didn't close output stream explicitly.