### PR TITLE
#811: InheritanceLevel for unrelated classes should be negative

### DIFF
--- a/src/main/java/org/cactoos/scalar/CheckedScalar.java
+++ b/src/main/java/org/cactoos/scalar/CheckedScalar.java
@@ -111,8 +111,7 @@ public final class CheckedScalar<T, E extends Exception> implements Scalar<T> {
         ).value();
         final String message = wrapped.getMessage()
             .replaceFirst(String.format("%s: ", exp.getClass().getName()), "");
-        if ((level == 0 || level < Integer.MAX_VALUE)
-            && message.equals(exp.getMessage())) {
+        if (level >= 0 && message.equals(exp.getMessage())) {
             wrapped = (E) exp;
         }
         return wrapped;

--- a/src/main/java/org/cactoos/scalar/FallbackFrom.java
+++ b/src/main/java/org/cactoos/scalar/FallbackFrom.java
@@ -68,8 +68,8 @@ public final class FallbackFrom<T> implements Func<Throwable, T> {
     /**
      * Calculate level of support of the given exception type.
      * @param target Exception type
-     * @return Level of support between 0 (that is fully support) and
-     *  {@link Integer#MAX_VALUE} (that is not supported)
+     * @return Level of support: greater or equals to 0 if the target
+     *  is supported and {@link Integer#MIN_VALUE} otherwise
      * @see InheritanceLevel
      */
     public Integer support(final Class<? extends Throwable> target) {

--- a/src/main/java/org/cactoos/scalar/InheritanceLevel.java
+++ b/src/main/java/org/cactoos/scalar/InheritanceLevel.java
@@ -30,18 +30,16 @@ import org.cactoos.Scalar;
  *
  *  <p>This class is thread safe.
  *
- *  <p>
- *  Result interpretation:
- *
- *   0 -> classes are identical. (ex. matching IOException with IOException)
- *   1 -> single level inheritance. (ex. matching FileNotFoundException with
- *        IOException)
- *   2 -> two inheritance levels. (ex. matching FileNotFoundException with
- *        Exception)
- *   ...
- *   Integer.MAX_VALUE -> classes are not related.
- *      (ex. matching FileNotFoundException with RuntimeException)
- *  </p>
+ *  <ul>Result interpretation:
+ *      <li>Integer.MIN_VALUE -> classes are not related. (ex. matching
+ *      FileNotFoundException with RuntimeException)</li>
+ *      <li>0 -> classes are identical. (ex. matching IOException with
+ *      IOException)</li>
+ *      <li>1 -> single level inheritance. (ex. matching
+ *      FileNotFoundException with IOException)</li>
+ *      <li>2 -> two inheritance levels. (ex. matching
+ *      FileNotFoundException with Exception)</li>
+ *  </ul>
  *
  * @author Vedran Vatavuk (123vgv@gmail.com)
  * @version $Id$
@@ -85,7 +83,7 @@ public final class InheritanceLevel implements Scalar<Integer> {
      * @return Integer Level
      */
     private int calculateLevel() {
-        int level = Integer.MAX_VALUE;
+        int level = Integer.MIN_VALUE;
         Class<?> sclass = this.derived.getSuperclass();
         int idx = 0;
         while (!sclass.equals(Object.class)) {

--- a/src/main/java/org/cactoos/scalar/InheritanceLevel.java
+++ b/src/main/java/org/cactoos/scalar/InheritanceLevel.java
@@ -28,18 +28,19 @@ import org.cactoos.Scalar;
 /**
  * Calculates number of superclasses between base and derived class.
  *
- *  <p>This class is thread safe.
+ * <p>This class is thread safe.
  *
- *  <ul>Result interpretation:
- *      <li>Integer.MIN_VALUE -> classes are not related. (ex. matching
- *      FileNotFoundException with RuntimeException)</li>
- *      <li>0 -> classes are identical. (ex. matching IOException with
- *      IOException)</li>
- *      <li>1 -> single level inheritance. (ex. matching
- *      FileNotFoundException with IOException)</li>
- *      <li>2 -> two inheritance levels. (ex. matching
- *      FileNotFoundException with Exception)</li>
- *  </ul>
+ * <p>Result interpretation:
+ * <ul>
+ *     <li>{@link Integer#MIN_VALUE} -&gt; classes are not related.
+ *     (ex. matching FileNotFoundException with RuntimeException);
+ *     <li>0 -&gt; classes are identical. (ex. matching IOException with
+ *     IOException);
+ *     <li>1 -&gt; single level inheritance. (ex. matching
+ *     FileNotFoundException with IOException);
+ *     <li>2 -&gt; two inheritance levels. (ex. matching
+ *     FileNotFoundException with Exception).
+ * </ul>
  *
  * @author Vedran Vatavuk (123vgv@gmail.com)
  * @version $Id$

--- a/src/main/java/org/cactoos/scalar/ScalarWithFallback.java
+++ b/src/main/java/org/cactoos/scalar/ScalarWithFallback.java
@@ -101,12 +101,7 @@ public final class ScalarWithFallback<T> implements Scalar<T> {
             new Sorted<>(
                 Comparator.comparing(Map.Entry::getValue),
                 new Filtered<>(
-                    entry -> new Not(
-                        new Equals<>(
-                            entry::getValue,
-                            () -> Integer.MAX_VALUE
-                        )
-                    ).value(),
+                    entry -> entry.getValue() >= 0,
                     new MapOf<>(
                         fbk -> fbk,
                         fbk -> fbk.support(exp.getClass()),

--- a/src/main/java/org/cactoos/scalar/ScalarWithFallback.java
+++ b/src/main/java/org/cactoos/scalar/ScalarWithFallback.java
@@ -101,7 +101,12 @@ public final class ScalarWithFallback<T> implements Scalar<T> {
             new Sorted<>(
                 Comparator.comparing(Map.Entry::getValue),
                 new Filtered<>(
-                    entry -> entry.getValue() >= 0,
+                    entry -> new Not(
+                        new Equals<>(
+                            entry::getValue,
+                            () -> Integer.MIN_VALUE
+                        )
+                    ).value(),
                     new MapOf<>(
                         fbk -> fbk,
                         fbk -> fbk.support(exp.getClass()),

--- a/src/test/java/org/cactoos/scalar/FallbackFromTest.java
+++ b/src/test/java/org/cactoos/scalar/FallbackFromTest.java
@@ -73,7 +73,7 @@ public final class FallbackFromTest {
                 new IterableOf<>(RuntimeException.class),
                 exp -> "RuntimeException fallback #2"
             ).support(ClassNotFoundException.class),
-            new IsEqual<>(Integer.MAX_VALUE)
+            new IsEqual<>(Integer.MIN_VALUE)
         );
     }
 }

--- a/src/test/java/org/cactoos/scalar/InheritanceLevelTest.java
+++ b/src/test/java/org/cactoos/scalar/InheritanceLevelTest.java
@@ -25,7 +25,7 @@ package org.cactoos.scalar;
 
 import java.io.FileNotFoundException;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 
 /**
@@ -40,12 +40,12 @@ public final class InheritanceLevelTest {
 
     @Test
     public void twoInheritanceLevelsBetweenClasses() {
-        final int expected = 2;
         MatcherAssert.assertThat(
             new InheritanceLevel(
-                FileNotFoundException.class, Exception.class
+                FileNotFoundException.class,
+                Exception.class
             ).value(),
-            Matchers.equalTo(expected)
+            new IsEqual<>(2)
         );
     }
 
@@ -53,21 +53,21 @@ public final class InheritanceLevelTest {
     public void classesAreNotRelated() {
         MatcherAssert.assertThat(
             new InheritanceLevel(
-                FileNotFoundException.class, RuntimeException.class
+                FileNotFoundException.class,
+                RuntimeException.class
             ).value(),
-            Matchers.equalTo(Integer.MAX_VALUE)
+            new IsEqual<>(Integer.MIN_VALUE)
         );
     }
 
     @Test
     public void classesAreIdentical() {
-        final int expected = 0;
         MatcherAssert.assertThat(
             new InheritanceLevel(
-                FileNotFoundException.class, FileNotFoundException.class
+                FileNotFoundException.class,
+                FileNotFoundException.class
             ).value(),
-            Matchers.equalTo(expected)
+            new IsEqual<>(0)
         );
     }
-
 }


### PR DESCRIPTION
Pull request for #811.

I've changed the logic of InheritanceLevel.java so that it returns Integer.MIN_VALUE (instead of MAX_VALUE) when the classes are not related. As well I've fixed all dependencies which rely on this logic. And finally, I've fixed affected tests.