### PR TITLE
Fix LoggingInputTest errors in appveyor

### DIFF
--- a/src/test/java/org/cactoos/io/LoggingInputTest.java
+++ b/src/test/java/org/cactoos/io/LoggingInputTest.java
@@ -219,13 +219,14 @@ public final class LoggingInputTest {
     @Test
     public void logIntoCreatedLogger() {
         final FakeHandler handler = new FakeHandler();
-        final String logger = "my source";
-        Logger.getLogger(logger).addHandler(handler);
+        final String src = "my source";
+        final Logger logger = Logger.getLogger(src);
+        logger.addHandler(handler);
         try {
             new LengthOf(
                 new LoggingInput(
                     new InputOf("Hi there"),
-                    logger
+                    src
                 )
             ).intValue();
             MatcherAssert.assertThat(
@@ -234,7 +235,7 @@ public final class LoggingInputTest {
                 Matchers.containsString("Read 8 byte(s)")
             );
         } finally {
-            Logger.getGlobal().removeHandler(handler);
+            logger.removeHandler(handler);
         }
     }
 


### PR DESCRIPTION
This is for #776.

Basically, as the `Logger.getLogger()` method warns, if you don't retain a strong reference to a logger retrieved from this method, nothing prevent its garbage collection.
In this case, it meant the `Handler` we added was lost and so the test failed sometimes.

The solution:
- keep a (strong) reference to the logger during the whole test.
- use this reference to remove the handler.
- do NOT rely on the logger itself to create `LoggingInput` though (as this is the purpose of the test).