### PR TITLE
 FuncWithFallbacks uses ScalarWithFallbacks

### DIFF
--- a/src/main/java/org/cactoos/scalar/FallbackFrom.java
+++ b/src/main/java/org/cactoos/scalar/FallbackFrom.java
@@ -24,6 +24,7 @@
 package org.cactoos.scalar;
 
 import org.cactoos.Func;
+import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.Mapped;
 
 /**
@@ -45,6 +46,17 @@ public final class FallbackFrom<T> implements Func<Throwable, T> {
      * Function that converts exceptions to the required type.
      */
     private final Func<Throwable, T> func;
+
+    /**
+     * Ctor.
+     * @param exp Supported exception type
+     * @param func Function that converts the given exception into required one
+     */
+    @SuppressWarnings("unchecked")
+    public FallbackFrom(final Class<? extends Throwable> exp,
+        final Func<Throwable, T> func) {
+        this(new IterableOf<>(exp), func);
+    }
 
     /**
      * Ctor.


### PR DESCRIPTION
This is for #821.

This:
- Replace the ad-hoc implementation of `FuncWithFallbacks` with use of `ScalarWithFallbacks`.
- Add more tests to `FuncWithFallbackTest` in order to cover the new extra behaviours of `FuncWithFallbacks`
- Rework some of the tests of `FuncWithFallbackTest` to be more object-oriented (less calls to static methods) and more precise (test equality instead of contains of `String`s)
- Add some more constructors to `FuncWithFallback` and `FallbackFrom` to write clearer/simpler tests.


