### PR TITLE
#849 Makeing Text classes extend TextEnvelope

### DIFF
--- a/src/main/java/org/cactoos/text/JoinedText.java
+++ b/src/main/java/org/cactoos/text/JoinedText.java
@@ -24,6 +24,7 @@
 package org.cactoos.text;
 
 import java.util.StringJoiner;
+import org.cactoos.Scalar;
 import org.cactoos.Text;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.Mapped;
@@ -34,18 +35,11 @@ import org.cactoos.iterable.Mapped;
  * <p>There is no thread-safety guarantee.
  *
  * @since 0.9
+ * @todo #849:30min Continue refactoring all classes implementing Text to extend
+ *  TextEnvelope - in most cases asString should be removed and implementation
+ *  from TextEnvelope should be used.
  */
-public final class JoinedText implements Text {
-
-    /**
-     * The texts.
-     */
-    private final Iterable<Text> texts;
-
-    /**
-     * The delimiter.
-     */
-    private final Text delimiter;
+public final class JoinedText extends TextEnvelope {
 
     /**
      * Ctor.
@@ -64,9 +58,7 @@ public final class JoinedText implements Text {
     public JoinedText(final String delimit, final Iterable<String> strs) {
         this(
             new TextOf(delimit),
-            new Mapped<>(
-                text -> new TextOf(text), strs
-            )
+            new Mapped<>(TextOf::new, strs)
         );
     }
 
@@ -85,17 +77,14 @@ public final class JoinedText implements Text {
      * @param txts Texts to be joined
      */
     public JoinedText(final Text delimit, final Iterable<Text> txts) {
-        this.delimiter = delimit;
-        this.texts = txts;
-    }
-
-    @Override
-    public String asString() throws Exception {
-        final StringJoiner joint = new StringJoiner(this.delimiter.asString());
-        for (final Text text : this.texts) {
-            joint.add(text.asString());
-        }
-        return joint.toString();
+        super((Scalar<String>) () -> {
+            final StringJoiner joint =
+                new StringJoiner(delimit.asString());
+            for (final Text text : txts) {
+                joint.add(text.asString());
+            }
+            return joint.toString();
+        });
     }
 
 }

--- a/src/main/java/org/cactoos/text/LowerText.java
+++ b/src/main/java/org/cactoos/text/LowerText.java
@@ -24,6 +24,7 @@
 package org.cactoos.text;
 
 import java.util.Locale;
+import org.cactoos.Scalar;
 import org.cactoos.Text;
 
 /**
@@ -33,17 +34,7 @@ import org.cactoos.Text;
  *
  * @since 0.1
  */
-public final class LowerText implements Text {
-
-    /**
-     * The text.
-     */
-    private final Text origin;
-
-    /**
-     * The locale.
-     */
-    private final Locale locale;
+public final class LowerText extends TextEnvelope {
 
     /**
      * Ctor.
@@ -59,13 +50,7 @@ public final class LowerText implements Text {
      * @param lang Locale
      */
     public LowerText(final Text text, final Locale lang) {
-        this.origin = text;
-        this.locale = lang;
-    }
-
-    @Override
-    public String asString() throws Exception {
-        return this.origin.asString().toLowerCase(this.locale);
+        super((Scalar<String>) () -> text.asString().toLowerCase(lang));
     }
 
 }

--- a/src/main/java/org/cactoos/text/NormalizedText.java
+++ b/src/main/java/org/cactoos/text/NormalizedText.java
@@ -23,6 +23,7 @@
  */
 package org.cactoos.text;
 
+import org.cactoos.Scalar;
 import org.cactoos.Text;
 
 /**
@@ -31,12 +32,7 @@ import org.cactoos.Text;
  *
  * @since 0.9
  */
-public final class NormalizedText implements Text {
-
-    /**
-     * The text.
-     */
-    private final Text origin;
+public final class NormalizedText extends TextEnvelope {
 
     /**
      * Ctor.
@@ -51,17 +47,13 @@ public final class NormalizedText implements Text {
      * @param text A Text
      */
     public NormalizedText(final Text text) {
-        this.origin = text;
+        super(
+            (Scalar<String>) () -> new ReplacedText(
+                new TrimmedText(text),
+                "\\s+",
+                " "
+            ).asString()
+        );
     }
-
-    @Override
-    public String asString() throws Exception {
-        return new ReplacedText(
-            new TrimmedText(this.origin),
-            "\\s+",
-            " "
-        ).asString();
-    }
-
 }
 

--- a/src/main/java/org/cactoos/text/RepeatedText.java
+++ b/src/main/java/org/cactoos/text/RepeatedText.java
@@ -23,6 +23,7 @@
  */
 package org.cactoos.text;
 
+import org.cactoos.Scalar;
 import org.cactoos.Text;
 
 /**
@@ -32,17 +33,7 @@ import org.cactoos.Text;
  *
  * @since 0.9
  */
-public final class RepeatedText implements Text {
-
-    /**
-     * The text.
-     */
-    private final Text origin;
-
-    /**
-     * How many times repeat the Text.
-     */
-    private final int count;
+public final class RepeatedText extends TextEnvelope {
 
     /**
      * Ctor.
@@ -59,17 +50,12 @@ public final class RepeatedText implements Text {
      * @param count How many times repeat the Text
      */
     public RepeatedText(final Text text, final int count) {
-        this.origin = text;
-        this.count = count;
+        super((Scalar<String>) () -> {
+            final StringBuilder out = new StringBuilder();
+            for (int cnt = 0; cnt < count; ++cnt) {
+                out.append(text.asString());
+            }
+            return out.toString();
+        });
     }
-
-    @Override
-    public String asString() throws Exception {
-        final StringBuilder out = new StringBuilder();
-        for (int cnt = 0; cnt < this.count; ++cnt) {
-            out.append(this.origin.asString());
-        }
-        return out.toString();
-    }
-
 }

--- a/src/main/java/org/cactoos/text/TextEnvelope.java
+++ b/src/main/java/org/cactoos/text/TextEnvelope.java
@@ -38,7 +38,6 @@ import org.cactoos.scalar.UncheckedScalar;
  *  and equals methods.
  * @checkstyle AbstractClassNameCheck (500 lines)
  */
-@SuppressWarnings("PMD.AbstractNaming")
 public abstract class TextEnvelope implements Text {
 
     /**
@@ -51,7 +50,7 @@ public abstract class TextEnvelope implements Text {
      * @param text Text representing the text value.
      */
     public TextEnvelope(final Text text) {
-        this(new IoCheckedScalar<>(() -> text.asString()));
+        this(new IoCheckedScalar<>(text::asString));
     }
 
     /**
@@ -65,6 +64,11 @@ public abstract class TextEnvelope implements Text {
     @Override
     public final String asString() throws IOException {
         return this.origin.value();
+    }
+
+    @Override
+    public final String toString() {
+        return new UncheckedText(this).asString();
     }
 
     @Override

--- a/src/main/java/org/cactoos/text/TextOf.java
+++ b/src/main/java/org/cactoos/text/TextOf.java
@@ -35,11 +35,9 @@ import java.nio.file.Path;
 import org.cactoos.Bytes;
 import org.cactoos.Input;
 import org.cactoos.Scalar;
-import org.cactoos.Text;
 import org.cactoos.io.BytesOf;
 import org.cactoos.io.InputOf;
 import org.cactoos.iterable.Mapped;
-import org.cactoos.scalar.IoCheckedScalar;
 
 /**
  * TextOf
@@ -48,12 +46,7 @@ import org.cactoos.scalar.IoCheckedScalar;
  *
  * @since 0.12
  */
-public final class TextOf implements Text {
-
-    /**
-     * The origin.
-     */
-    private final Scalar<String> origin;
+public final class TextOf extends TextEnvelope {
 
     /**
      * Ctor.
@@ -354,17 +347,7 @@ public final class TextOf implements Text {
      * @param scalar The Scalar of String
      */
     private TextOf(final Scalar<String> scalar) {
-        this.origin = scalar;
-    }
-
-    @Override
-    public String asString() throws Exception {
-        return new IoCheckedScalar<>(this.origin).value();
-    }
-
-    @Override
-    public String toString() {
-        return new UncheckedText(this).asString();
+        super(scalar);
     }
 
 }


### PR DESCRIPTION
#849 
* made `JoinedText`, `TextOf`, `LowerText`, `NormalizedText`, `RepeatedText` extend TextEvelope (and tuned the code in those to work correctly)