### PR TITLE
#844: Implement equals and hashCode for MapEnvelope

### DIFF
--- a/src/main/java/org/cactoos/collection/CollectionEnvelope.java
+++ b/src/main/java/org/cactoos/collection/CollectionEnvelope.java
@@ -36,8 +36,10 @@ import org.cactoos.scalar.UncheckedScalar;
  *
  * @param <X> Element type
  * @since 0.23
- * @todo #844:30min Implement methods equals and hashCode for this class. Class
- *  {@link org.cactoos.map.MapEnvelope} can be used as an example.
+ * @todo #844:30min Implement methods equals and hashCode for this class.
+ *  Implementation should rely on the items of the nested collection, but not
+ *  on default JVM impl. Class {@link org.cactoos.map.MapEnvelope} can be used
+ *  as an example.
  * @checkstyle AbstractClassNameCheck (500 lines)
  */
 @SuppressWarnings(

--- a/src/main/java/org/cactoos/collection/CollectionEnvelope.java
+++ b/src/main/java/org/cactoos/collection/CollectionEnvelope.java
@@ -36,6 +36,8 @@ import org.cactoos.scalar.UncheckedScalar;
  *
  * @param <X> Element type
  * @since 0.23
+ * @todo #844:30min Implement methods equals and hashCode for this class. Class
+ *  {@link org.cactoos.map.MapEnvelope} can be used as an example.
  * @checkstyle AbstractClassNameCheck (500 lines)
  */
 @SuppressWarnings(

--- a/src/main/java/org/cactoos/map/MapEnvelope.java
+++ b/src/main/java/org/cactoos/map/MapEnvelope.java
@@ -24,9 +24,12 @@
 package org.cactoos.map;
 
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import org.cactoos.Scalar;
+import org.cactoos.scalar.Folded;
+import org.cactoos.scalar.SumOfIntScalar;
 import org.cactoos.scalar.UncheckedScalar;
 import org.cactoos.text.TextOf;
 
@@ -137,5 +140,53 @@ public abstract class MapEnvelope<X, Y> implements Map<X, Y> {
             .append(new TextOf(this.entrySet()).toString())
             .append('}')
             .toString();
+    }
+
+    @Override
+    @SuppressWarnings("PMD.OnlyOneReturn")
+    public final boolean equals(final Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (getClass() != other.getClass()) {
+            return false;
+        }
+        final MapEnvelope<?, ?> that = (MapEnvelope<?, ?>) other;
+        final Iterator<Entry<X, Y>> these =
+            this.map.value().entrySet().iterator();
+        final Iterator<? extends Entry<?, ?>> those =
+            that.map.value().entrySet().iterator();
+        while (these.hasNext() && those.hasNext()) {
+            final Entry<X, Y> first = these.next();
+            final Entry<?, ?> second = those.next();
+            if (!first.getKey().equals(second.getKey())) {
+                return false;
+            }
+            if (!first.getValue().equals(second.getValue())) {
+                return false;
+            }
+        }
+        return !these.hasNext() && !those.hasNext();
+    }
+
+    // @checkstyle MagicNumberCheck (30 lines)
+    @Override
+    public final int hashCode() {
+        return new UncheckedScalar<>(
+            new Folded<>(
+                42,
+                (hash, entry) -> {
+                    final int keys = new SumOfIntScalar(
+                        () -> 37 * hash,
+                        () -> entry.getKey().hashCode()
+                    ).value();
+                    return new SumOfIntScalar(
+                        () -> 37 * keys,
+                        () -> entry.getValue().hashCode()
+                    ).value();
+                },
+                this.map.value().entrySet()
+            )
+        ).value();
     }
 }

--- a/src/test/java/org/cactoos/map/MapEnvelopeTest.java
+++ b/src/test/java/org/cactoos/map/MapEnvelopeTest.java
@@ -233,12 +233,14 @@ public final class MapEnvelopeTest {
 
     @Test
     public void mapEqualsToMapWithSameEntries() {
-        final MapEntry<String, String> entry =
-            new MapEntry<>("key2", "value2");
+        final String key = "key2";
+        final String value = "value2";
+        final MapEntry<String, String> input = new MapEntry<>(key, value);
+        final MapEntry<String, String> expected = new MapEntry<>(key, value);
         MatcherAssert.assertThat(
             "Map doesn't equal to another map with same entries",
-            new MapOf<String, String>(entry),
-            new IsEqual<>(new MapOf<String, String>(entry))
+            new MapOf<String, String>(input),
+            new IsEqual<>(new MapOf<String, String>(expected))
         );
     }
 
@@ -289,12 +291,14 @@ public final class MapEnvelopeTest {
 
     @Test
     public void hashCodeDependsOnItems() {
-        final MapEntry<String, String> entry =
-            new MapEntry<>("key9", "value9");
+        final String key = "key9";
+        final String value = "value9";
+        final MapEntry<String, String> input = new MapEntry<>(key, value);
+        final MapEntry<String, String> expected = new MapEntry<>(key, value);
         MatcherAssert.assertThat(
             "hashCode returns different results for same entries",
-            new MapOf<String, String>(entry).hashCode(),
-            new IsEqual<>(new MapOf<String, String>(entry).hashCode())
+            new MapOf<String, String>(input).hashCode(),
+            new IsEqual<>(new MapOf<String, String>(expected).hashCode())
         );
     }
 

--- a/src/test/java/org/cactoos/map/MapEnvelopeTest.java
+++ b/src/test/java/org/cactoos/map/MapEnvelopeTest.java
@@ -219,6 +219,19 @@ public final class MapEnvelopeTest {
     }
 
     @Test
+    public void mapNotEqualsToAnotherClass() {
+        final MapOf<String, String> map =
+            new MapOf<String, String>(new MapEntry<>("key1", "value1"));
+        MatcherAssert.assertThat(
+            "Map equals to an instance of another type",
+            map,
+            new IsNot<>(
+                new IsEqual<>("Totally different type")
+            )
+        );
+    }
+
+    @Test
     public void mapEqualsToMapWithSameEntries() {
         final MapEntry<String, String> entry =
             new MapEntry<>("key2", "value2");

--- a/src/test/java/org/cactoos/map/MapEnvelopeTest.java
+++ b/src/test/java/org/cactoos/map/MapEnvelopeTest.java
@@ -210,7 +210,7 @@ public final class MapEnvelopeTest {
     @Test
     public void mapEqualsToItself() {
         final MapOf<String, String> map =
-            new MapOf<String, String>(new MapEntry<>("key1", "value1"));
+            new MapOf<String, String>(new MapEntry<>("key", "value"));
         MatcherAssert.assertThat(
             "Map doesn't equal to itself",
             map,

--- a/src/test/java/org/cactoos/map/MapEnvelopeTest.java
+++ b/src/test/java/org/cactoos/map/MapEnvelopeTest.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import org.cactoos.func.FuncOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -38,7 +40,9 @@ import org.llorllale.cactoos.matchers.MatcherOf;
  * @since 0.4
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * @checkstyle DiamondOperatorCheck (500 lines)
  */
+@SuppressWarnings("PMD.TooManyMethods")
 public final class MapEnvelopeTest {
 
     /**
@@ -203,4 +207,90 @@ public final class MapEnvelopeTest {
         );
     }
 
+    @Test
+    public void mapEqualsToItself() {
+        final MapOf<String, String> map =
+            new MapOf<String, String>(new MapEntry<>("key1", "value1"));
+        MatcherAssert.assertThat(
+            "Map doesn't equal to itself",
+            map,
+            new IsEqual<>(map)
+        );
+    }
+
+    @Test
+    public void mapEqualsToMapWithSameEntries() {
+        final MapEntry<String, String> entry =
+            new MapEntry<>("key2", "value2");
+        MatcherAssert.assertThat(
+            "Map doesn't equal to another map with same entries",
+            new MapOf<String, String>(entry),
+            new IsEqual<>(new MapOf<String, String>(entry))
+        );
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void equalFailsOnNull() {
+        final MapEntry<String, String> first =
+            new MapEntry<>("key3", "value3");
+        final MapEntry<String, String> second =
+            new MapEntry<>("key4", null);
+        MatcherAssert.assertThat(
+            "Map allows null values, but shouldn't",
+            new MapOf<String, String>(first, second),
+            new IsEqual<>(new MapOf<String, String>(first, second))
+        );
+    }
+
+    @Test
+    public void mapNotEqualsToOtherWithDifferentKeys() {
+        final String value = "value5";
+        MatcherAssert.assertThat(
+            "Map equals to another map with different keys",
+            new MapOf<String, String>(new MapEntry<>("key5", value)),
+            new IsNot<>(
+                new IsEqual<>(
+                    new MapOf<String, String>(
+                        new MapEntry<>("key6", value)
+                    )
+                )
+            )
+        );
+    }
+
+    @Test
+    public void mapNotEqualsToOtherWithDifferentValues() {
+        final String key = "key7";
+        MatcherAssert.assertThat(
+            "Map equals to another map with different values",
+            new MapOf<String, String>(new MapEntry<>(key, "value7")),
+            new IsNot<>(
+                new IsEqual<>(
+                    new MapOf<String, String>(
+                        new MapEntry<>(key, "value8")
+                    )
+                )
+            )
+        );
+    }
+
+    @Test
+    public void hashCodeDependsOnItems() {
+        final MapEntry<String, String> entry =
+            new MapEntry<>("key9", "value9");
+        MatcherAssert.assertThat(
+            "hashCode returns different results for same entries",
+            new MapOf<String, String>(entry).hashCode(),
+            new IsEqual<>(new MapOf<String, String>(entry).hashCode())
+        );
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void hashCodeFailsOnNull() {
+        final MapEntry<String, String> first =
+            new MapEntry<>("key10", "value10");
+        final MapEntry<String, String> second =
+            new MapEntry<>("key11", null);
+        new MapOf<String, String>(first, second).hashCode();
+    }
 }


### PR DESCRIPTION
Pull request for #844.

- implemented methods `equals` and `hashCode` for `MapEnvelope` class. Implementation depends on the entries of the map.
- added new test cases to cover implemented methods
- added a new puzzle to add equals/hashCode for CollectionEnvelope