### PR TITLE
#824: Use cactoos FormattedText instead of static String format.

### DIFF
--- a/src/main/java/org/cactoos/collection/CollectionNoNulls.java
+++ b/src/main/java/org/cactoos/collection/CollectionNoNulls.java
@@ -26,6 +26,8 @@ package org.cactoos.collection;
 import java.util.Collection;
 import java.util.Iterator;
 import org.cactoos.iterator.IteratorNoNulls;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 
 /**
  * A decorator of {@link Collection} that tolerates no NULLs.
@@ -82,9 +84,11 @@ public final class CollectionNoNulls<X> implements Collection<X> {
         for (int idx = 0; idx < array.length; ++idx) {
             if (array[idx] == null) {
                 throw new IllegalStateException(
-                    String.format(
-                        "Item #%d of #toArray() is NULL", idx
-                    )
+                    new UncheckedText(
+                        new FormattedText(
+                            "Item #%d of #toArray() is NULL", idx
+                        )
+                    ).asString()
                 );
             }
         }
@@ -98,9 +102,11 @@ public final class CollectionNoNulls<X> implements Collection<X> {
         for (int idx = 0; idx < array.length; ++idx) {
             if (array[idx] == null) {
                 throw new IllegalStateException(
-                    String.format(
-                        "Item #%d of #toArray(array) is NULL", idx
-                    )
+                    new UncheckedText(
+                        new FormattedText(
+                            "Item #%d of #toArray(array) is NULL", idx
+                        )
+                    ).asString()
                 );
             }
         }

--- a/src/main/java/org/cactoos/io/LoggingInputStream.java
+++ b/src/main/java/org/cactoos/io/LoggingInputStream.java
@@ -32,6 +32,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.cactoos.scalar.StickyScalar;
 import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 
 /**
  * Logged input stream.
@@ -139,19 +141,21 @@ public final class LoggingInputStream extends InputStream {
             this.bytes.getAndAdd(byts);
             this.time.getAndAdd(millis);
         }
-        final String msg = String.format(
-            "Read %d byte(s) from %s in %dms.",
-            this.bytes.get(),
-            this.source,
-            this.time.get()
+        final UncheckedText msg = new UncheckedText(
+            new FormattedText(
+                "Read %d byte(s) from %s in %dms.",
+                this.bytes.get(),
+                this.source,
+                this.time.get()
+            )
         );
         if (byts > 0) {
             if (!this.level.value().equals(Level.INFO)) {
-                this.logger.log(this.level.value(), msg);
+                this.logger.log(this.level.value(), msg.asString());
             }
         } else {
             if (this.level.value().equals(Level.INFO)) {
-                this.logger.info(msg);
+                this.logger.info(msg.asString());
             }
         }
         return byts;
@@ -162,11 +166,13 @@ public final class LoggingInputStream extends InputStream {
         final long skipped = this.origin.skip(num);
         this.logger.log(
             this.level.value(),
-            String.format(
-                "Skipped %d byte(s) from %s.",
-                skipped,
-                this.source
-            )
+            new UncheckedText(
+                new FormattedText(
+                    "Skipped %d byte(s) from %s.",
+                    skipped,
+                    this.source
+                )
+            ).asString()
         );
         return skipped;
     }
@@ -176,11 +182,13 @@ public final class LoggingInputStream extends InputStream {
         final int avail = this.origin.available();
         this.logger.log(
             this.level.value(),
-            String.format(
-                "There is(are) %d byte(s) available from %s.",
-                avail,
-                this.source
-            )
+            new UncheckedText(
+                new FormattedText(
+                    "There is(are) %d byte(s) available from %s.",
+                    avail,
+                    this.source
+                )
+            ).asString()
         );
         return avail;
     }
@@ -190,10 +198,12 @@ public final class LoggingInputStream extends InputStream {
         this.origin.close();
         this.logger.log(
             this.level.value(),
-            String.format(
-                "Closed input stream from %s.",
-                this.source
-            )
+            new UncheckedText(
+                new FormattedText(
+                    "Closed input stream from %s.",
+                    this.source
+                )
+            ).asString()
         );
     }
 
@@ -202,11 +212,13 @@ public final class LoggingInputStream extends InputStream {
         this.origin.mark(limit);
         this.logger.log(
             this.level.value(),
-            String.format(
-                "Marked position %d from %s.",
-                limit,
-                this.source
-            )
+            new UncheckedText(
+                new FormattedText(
+                    "Marked position %d from %s.",
+                    limit,
+                    this.source
+                )
+            ).asString()
         );
     }
 
@@ -215,10 +227,12 @@ public final class LoggingInputStream extends InputStream {
         this.origin.reset();
         this.logger.log(
             this.level.value(),
-            String.format(
-                "Reset input stream from %s.",
-                this.source
-            )
+            new UncheckedText(
+                new FormattedText(
+                    "Reset input stream from %s.",
+                    this.source
+                )
+            ).asString()
         );
     }
 
@@ -233,10 +247,12 @@ public final class LoggingInputStream extends InputStream {
         }
         this.logger.log(
             this.level.value(),
-            String.format(
-                msg,
-                this.source
-            )
+            new UncheckedText(
+                new FormattedText(
+                    msg,
+                    this.source
+                )
+            ).asString()
         );
         return supported;
     }

--- a/src/main/java/org/cactoos/io/LoggingOutputStream.java
+++ b/src/main/java/org/cactoos/io/LoggingOutputStream.java
@@ -30,6 +30,8 @@ import java.time.Instant;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 
 /**
  * Logged output stream.
@@ -123,12 +125,14 @@ public final class LoggingOutputStream extends OutputStream {
         if (!level.equals(Level.INFO)) {
             this.logger.log(
                 level,
-                String.format(
-                    "Written %d byte(s) to %s in %dms.",
-                    this.bytes.get(),
-                    this.destination,
-                    this.time.get()
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "Written %d byte(s) to %s in %dms.",
+                        this.bytes.get(),
+                        this.destination,
+                        this.time.get()
+                    )
+                ).asString()
             );
         }
     }
@@ -140,20 +144,24 @@ public final class LoggingOutputStream extends OutputStream {
         if (level.equals(Level.INFO)) {
             this.logger.log(
                 level,
-                String.format(
-                    "Written %d byte(s) to %s in %dms.",
-                    this.bytes.get(),
-                    this.destination,
-                    this.time.get()
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "Written %d byte(s) to %s in %dms.",
+                        this.bytes.get(),
+                        this.destination,
+                        this.time.get()
+                    )
+                ).asString()
             );
         }
         this.logger.log(
             level,
-            String.format(
-                "Closed output stream from %s.",
-                this.destination
-            )
+            new UncheckedText(
+                new FormattedText(
+                    "Closed output stream from %s.",
+                    this.destination
+                )
+            ).asString()
         );
     }
 
@@ -164,21 +172,24 @@ public final class LoggingOutputStream extends OutputStream {
         if (level.equals(Level.INFO)) {
             this.logger.log(
                 level,
-                String.format(
-                    "Written %d byte(s) to %s in %dms.",
-                    this.bytes.get(),
-                    this.destination,
-                    this.time.get()
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "Written %d byte(s) to %s in %dms.",
+                        this.bytes.get(),
+                        this.destination,
+                        this.time.get()
+                    )
+                ).asString()
             );
         }
         this.logger.log(
             level,
-            String.format(
-                "Flushed output stream from %s.",
-                this.destination
-            )
+            new UncheckedText(
+                new FormattedText(
+                    "Flushed output stream from %s.",
+                    this.destination
+                )
+            ).asString()
         );
     }
-
 }

--- a/src/main/java/org/cactoos/iterator/IteratorNoNulls.java
+++ b/src/main/java/org/cactoos/iterator/IteratorNoNulls.java
@@ -25,6 +25,8 @@ package org.cactoos.iterator;
 
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicLong;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 
 /**
  * A decorator of an {@link Iterator} that returns no NULL.
@@ -65,10 +67,12 @@ public final class IteratorNoNulls<X> implements Iterator<X> {
         final X next = this.iterator.next();
         if (next == null) {
             throw new IllegalStateException(
-                String.format(
-                    "Item #%d of %s is NULL",
-                    this.pos.get(), this.iterator
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "Item #%d of %s is NULL",
+                        this.pos.get(), this.iterator
+                    )
+                ).asString()
             );
         }
         this.pos.incrementAndGet();
@@ -79,5 +83,4 @@ public final class IteratorNoNulls<X> implements Iterator<X> {
     public void remove() {
         this.iterator.remove();
     }
-
 }

--- a/src/main/java/org/cactoos/list/ListNoNulls.java
+++ b/src/main/java/org/cactoos/list/ListNoNulls.java
@@ -28,6 +28,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import org.cactoos.collection.CollectionNoNulls;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 
 /**
  * A decorator of {@link List} that tolerates no NULLs.
@@ -130,10 +132,13 @@ public final class ListNoNulls<T> implements List<T> {
         final T item = this.list.get(index);
         if (item == null) {
             throw new IllegalStateException(
-                String.format(
-                    "Item #%d of %s is NULL",
-                    index, this.list
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "Item #%d of %s is NULL",
+                        index,
+                        this.list
+                    )
+                ).asString()
             );
         }
         return item;
@@ -143,19 +148,23 @@ public final class ListNoNulls<T> implements List<T> {
     public T set(final int index, final T item) {
         if (item == null) {
             throw new IllegalArgumentException(
-                String.format(
-                    "Item can't be NULL in #set(%d,T)",
-                    index
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "Item can't be NULL in #set(%d,T)",
+                        index
+                    )
+                ).asString()
             );
         }
         final T result = this.list.set(index, item);
         if (result == null) {
             throw new IllegalStateException(
-                String.format(
-                    "Result of #set(%d,T) is NULL",
-                    index
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "Result of #set(%d,T) is NULL",
+                        index
+                    )
+                ).asString()
             );
         }
         return result;
@@ -165,10 +174,12 @@ public final class ListNoNulls<T> implements List<T> {
     public void add(final int index, final T item) {
         if (item == null) {
             throw new IllegalArgumentException(
-                String.format(
-                    "Item can't be NULL in #add(%d,T)",
-                    index
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "Item can't be NULL in #add(%d,T)",
+                        index
+                    )
+                ).asString()
             );
         }
         this.list.add(index, item);
@@ -179,10 +190,12 @@ public final class ListNoNulls<T> implements List<T> {
         final T result = this.list.remove(index);
         if (result == null) {
             throw new IllegalStateException(
-                String.format(
-                    "Result of #remove(%d) is NULL",
-                    index
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "Result of #remove(%d) is NULL",
+                        index
+                    )
+                ).asString()
             );
         }
         return result;

--- a/src/main/java/org/cactoos/map/MapEntry.java
+++ b/src/main/java/org/cactoos/map/MapEntry.java
@@ -24,6 +24,8 @@
 package org.cactoos.map;
 
 import java.util.Map;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 
 /**
  * MapEntry as {@link java.util.AbstractMap.Entry}.
@@ -57,7 +59,13 @@ public final class MapEntry<K, V> implements Map.Entry<K, V> {
 
     @Override
     public String toString() {
-        return String.format("%s=%s", this.key, this.value);
+        return new UncheckedText(
+            new FormattedText(
+                "%s=%s",
+                this.key,
+                this.value
+            )
+        ).asString();
     }
 
     @Override

--- a/src/main/java/org/cactoos/map/MapNoNulls.java
+++ b/src/main/java/org/cactoos/map/MapNoNulls.java
@@ -27,6 +27,8 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import org.cactoos.collection.CollectionNoNulls;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 
 /**
  * A decorator of {@link Map} that tolerates no NULLs.
@@ -93,10 +95,12 @@ public class MapNoNulls<K, V> implements Map<K, V> {
         final V value = this.map.get(key);
         if (value == null) {
             throw new IllegalStateException(
-                String.format(
-                    "Value returned by #get(%s) is NULL",
-                    key
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "Value returned by #get(%s) is NULL",
+                        key
+                    )
+                ).asString()
             );
         }
         return value;
@@ -106,25 +110,32 @@ public class MapNoNulls<K, V> implements Map<K, V> {
     public final V put(final K key, final V value) {
         if (key == null) {
             throw new IllegalStateException(
-                String.format(
-                    "Key at #put(K,%s) is NULL", value
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "Key at #put(K,%s) is NULL",
+                        value
+                    )
+                ).asString()
             );
         }
         if (value == null) {
             throw new IllegalStateException(
-                String.format(
-                    "Value at #put(%s,V) is NULL", key
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "Value at #put(%s,V) is NULL", key
+                    )
+                ).asString()
             );
         }
         final V result = this.map.put(key, value);
         if (result == null) {
             throw new IllegalStateException(
-                String.format(
-                    "Value returned by #put(%s,%s) is NULL",
-                    key, value
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "Value returned by #put(%s,%s) is NULL",
+                        key, value
+                    )
+                ).asString()
             );
         }
         return result;
@@ -140,10 +151,12 @@ public class MapNoNulls<K, V> implements Map<K, V> {
         final V result = this.map.remove(key);
         if (result == null) {
             throw new IllegalStateException(
-                String.format(
-                    "Value returned by #remove(%s) is NULL",
-                    key
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "Value returned by #remove(%s) is NULL",
+                        key
+                    )
+                ).asString()
             );
         }
         return result;
@@ -174,5 +187,4 @@ public class MapNoNulls<K, V> implements Map<K, V> {
     public final Set<Map.Entry<K, V>> entrySet() {
         return this.map.entrySet();
     }
-
 }

--- a/src/main/java/org/cactoos/scalar/AndInThreads.java
+++ b/src/main/java/org/cactoos/scalar/AndInThreads.java
@@ -35,6 +35,7 @@ import org.cactoos.Scalar;
 import org.cactoos.func.FuncOf;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.Mapped;
+import org.cactoos.text.FormattedText;
 
 /**
  * Logical conjunction, in multiple threads.
@@ -237,10 +238,10 @@ public final class AndInThreads implements Scalar<Boolean> {
             try {
                 if (!this.service.awaitTermination(1L, TimeUnit.MINUTES)) {
                     throw new IllegalStateException(
-                        String.format(
+                        new FormattedText(
                             "Can't terminate the service, result=%b",
                             result
-                        )
+                        ).asString()
                     );
                 }
             } catch (final InterruptedException ex) {
@@ -250,5 +251,4 @@ public final class AndInThreads implements Scalar<Boolean> {
         }
         return result;
     }
-
 }

--- a/src/main/java/org/cactoos/scalar/CheckedScalar.java
+++ b/src/main/java/org/cactoos/scalar/CheckedScalar.java
@@ -26,6 +26,8 @@ package org.cactoos.scalar;
 import org.cactoos.Func;
 import org.cactoos.Scalar;
 import org.cactoos.func.UncheckedFunc;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 
 /**
  * Scalar that wraps an original checked exception thrown by the origin using
@@ -108,7 +110,15 @@ public final class CheckedScalar<T, E extends Exception> implements Scalar<T> {
             exp.getClass(), wrapped.getClass()
         ).value();
         final String message = wrapped.getMessage()
-            .replaceFirst(String.format("%s: ", exp.getClass().getName()), "");
+            .replaceFirst(
+                new UncheckedText(
+                    new FormattedText(
+                        "%s: ",
+                        exp.getClass().getName()
+                    )
+                ).asString(),
+                ""
+            );
         if (level >= 0 && message.equals(exp.getMessage())) {
             wrapped = (E) exp;
         }

--- a/src/test/java/org/cactoos/collection/CollectionNoNullsTest.java
+++ b/src/test/java/org/cactoos/collection/CollectionNoNullsTest.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.collection;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Test cases for {@link CollectionNoNulls}.
+ *
+ * <p>There is no thread-safety guarantee.
+ *
+ * @since 0.35
+ * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle MagicNumberCheck (500 lines)
+ */
+public final class CollectionNoNullsTest {
+
+    /**
+     * A rule for handling an exception.
+     */
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void throwsErrorIfNullInToArray() {
+        this.exception.expect(IllegalStateException.class);
+        this.exception.expectMessage(
+            "Item #1 of #toArray() is NULL"
+        );
+        new CollectionNoNulls<>(
+            new CollectionOf<>(1, null, 3)
+        ).toArray();
+    }
+
+    @Test
+    public void throwsErrorIfNullInToArrayWithArg() {
+        this.exception.expect(IllegalStateException.class);
+        this.exception.expectMessage(
+            "Item #1 of #toArray(array) is NULL"
+        );
+        new CollectionNoNulls<>(
+            new CollectionOf<>(1, null, 3)
+        ).toArray(new Object[3]);
+    }
+}

--- a/src/test/java/org/cactoos/func/ProcOfTest.java
+++ b/src/test/java/org/cactoos/func/ProcOfTest.java
@@ -26,6 +26,7 @@ package org.cactoos.func;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
+import org.cactoos.text.FormattedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -51,10 +52,10 @@ public final class ProcOfTest {
             }
         ).exec("You can use any input in a Runnable.");
         MatcherAssert.assertThat(
-            String.format(
+            new FormattedText(
                 "Wrong result when created with a Runnable. Expected %s",
                 str
-            ),
+            ).asString(),
             list,
             Matchers.contains(str)
         );
@@ -74,10 +75,10 @@ public final class ProcOfTest {
             }
         ).exec("You can use any input in a Callable");
         MatcherAssert.assertThat(
-            String.format(
+            new FormattedText(
                 "Wrong result when created with a Callable. Expected %s",
                 str
-            ),
+            ).asString(),
             list,
             Matchers.contains(str)
         );
@@ -94,13 +95,12 @@ public final class ProcOfTest {
             }
         ).exec(str);
         MatcherAssert.assertThat(
-            String.format(
+            new FormattedText(
                 "Wrong result when created with a Func. Expected %s",
                 str
-            ),
+            ).asString(),
             list,
             Matchers.contains(str)
         );
     }
-
 }

--- a/src/test/java/org/cactoos/io/TempFileTest.java
+++ b/src/test/java/org/cactoos/io/TempFileTest.java
@@ -26,6 +26,7 @@ package org.cactoos.io;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import org.cactoos.text.FormattedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -86,8 +87,10 @@ public final class TempFileTest {
 
     @Test
     public void createFileWithPrefix() throws Exception {
-        final String prefix =
-            String.format("randomPrefix%s", System.currentTimeMillis());
+        final String prefix = new FormattedText(
+            "randomPrefix%s",
+            System.currentTimeMillis()
+        ).asString();
         try (final TempFile file = new TempFile(prefix, "")) {
             MatcherAssert.assertThat(
                 "File not created with the given prefix",
@@ -99,9 +102,9 @@ public final class TempFileTest {
 
     @Test
     public void createFileWithSuffix() throws Exception {
-        final String suffix = String.format(
+        final String suffix = new FormattedText(
             "randomSuffix%s", System.currentTimeMillis()
-        );
+        ).asString();
         try (final TempFile file = new TempFile("", suffix)) {
             MatcherAssert.assertThat(
                 "File not created with the given suffix",

--- a/src/test/java/org/cactoos/iterator/IteratorNoNullsTest.java
+++ b/src/test/java/org/cactoos/iterator/IteratorNoNullsTest.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.iterator;
+
+import java.util.Iterator;
+import org.hamcrest.core.StringContains;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Test cases for {@link IteratorNoNulls}.
+ *
+ * <p>There is no thread-safety guarantee.
+ *
+ * @since 0.35
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class IteratorNoNullsTest {
+
+    /**
+     * A rule for handling an exception.
+     */
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void nextThrowsErrorIfNull() {
+        this.exception.expect(IllegalStateException.class);
+        this.exception.expectMessage(
+            new StringContains(
+                "Item #0 of org.cactoos.iterator.IteratorNoNullsTest"
+            )
+        );
+        new IteratorNoNulls<>(
+            new Iterator<Integer>() {
+                @Override
+                public boolean hasNext() {
+                    return true;
+                }
+
+                @Override
+                public Integer next() {
+                    return null;
+                }
+            }
+        ).next();
+    }
+}

--- a/src/test/java/org/cactoos/list/ListNoNullsTest.java
+++ b/src/test/java/org/cactoos/list/ListNoNullsTest.java
@@ -1,0 +1,104 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.list;
+
+import java.util.ArrayList;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Test cases for {@link ListNoNulls}.
+ *
+ * <p>There is no thread-safety guarantee.
+ *
+ * @since 0.35
+ * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle MagicNumberCheck (500 lines)
+ */
+public final class ListNoNullsTest {
+
+    /**
+     * A rule for handling an exception.
+     */
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void getThrowsErrorIfNull() {
+        this.exception.expect(IllegalStateException.class);
+        this.exception.expectMessage(
+            "Item #1 of [1, null, 3] is NULL"
+        );
+        new ListNoNulls<>(
+            new ListOf<>(1, null, 3)
+        ).get(1);
+    }
+
+    @Test
+    public void setThrowsErrorIfArgumentNull() {
+        this.exception.expect(IllegalArgumentException.class);
+        this.exception.expectMessage(
+            "Item can't be NULL in #set(2,T)"
+        );
+        new ListNoNulls<>(
+            new ListOf<>(1, null, 3)
+        ).set(2, null);
+    }
+
+    @Test
+    public void setThrowsErrorIfPreviousValueNull() {
+        this.exception.expect(IllegalStateException.class);
+        this.exception.expectMessage(
+            "Result of #set(0,T) is NULL"
+        );
+        final ArrayList<Integer> list = new ArrayList<>(1);
+        list.add(null);
+        new ListNoNulls<>(list).set(0, 2);
+    }
+
+    @Test
+    public void addThrowsErrorIfArgumentNull() {
+        this.exception.expect(IllegalArgumentException.class);
+        this.exception.expectMessage(
+            "Item can't be NULL in #add(0,T)"
+        );
+        new ListNoNulls<>(
+            new ArrayList<>(1)
+        ).add(0, null);
+    }
+
+    @Test
+    public void removeThrowsErrorIfValueNull() {
+        this.exception.expect(IllegalStateException.class);
+        this.exception.expectMessage(
+            "Result of #remove(0) is NULL"
+        );
+        final ArrayList<Integer> list = new ArrayList<>(1);
+        list.add(null);
+        new ListNoNulls<>(
+            list
+        ).remove(0);
+    }
+}

--- a/src/test/java/org/cactoos/map/MapEntryTest.java
+++ b/src/test/java/org/cactoos/map/MapEntryTest.java
@@ -25,6 +25,7 @@ package org.cactoos.map;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 
 /**
@@ -83,4 +84,12 @@ public final class MapEntryTest {
         );
     }
 
+    @Test
+    public void toStringMethod() {
+        MatcherAssert.assertThat(
+            "ToString method returns unexpected value",
+            new MapEntry<>("somekey", "somevalue").toString(),
+            new IsEqual<>("somekey=somevalue")
+        );
+    }
 }

--- a/src/test/java/org/cactoos/map/MapNoNullsTest.java
+++ b/src/test/java/org/cactoos/map/MapNoNullsTest.java
@@ -28,7 +28,9 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 /**
  * Test case for {@link MapNoNulls}.
@@ -37,12 +39,20 @@ import org.junit.Test;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-@SuppressWarnings({
-    "PMD.TooManyMethods",
-    "PMD.NonStaticInitializer",
-    "serial"
-    })
+@SuppressWarnings(
+    {
+        "PMD.TooManyMethods",
+        "PMD.NonStaticInitializer",
+        "serial"
+    }
+)
 public final class MapNoNullsTest {
+
+    /**
+     * A rule for handling an exception.
+     */
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
 
     @Test
     public void getSize() {
@@ -355,5 +365,31 @@ public final class MapNoNullsTest {
                 Matchers.hasEntry(0, 0)
             )
         );
+    }
+
+    @Test
+    public void putThrowsErrorIfValueNull() {
+        this.exception.expect(IllegalStateException.class);
+        this.exception.expectMessage(
+            "Value at #put(1,V) is NULL"
+        );
+        new MapNoNulls<Integer, Integer>(
+            new HashMap<>()
+        ).put(1, null);
+    }
+
+    @Test
+    public void putThrowsErrorIfPreviousValueNull() {
+        this.exception.expect(IllegalStateException.class);
+        this.exception.expectMessage(
+            "Value returned by #put(1,2) is NULL"
+        );
+        new MapNoNulls<>(
+            new HashMap<Integer, Integer>() {
+                {
+                    put(1, null);
+                }
+            }
+        ).put(1, 2);
     }
 }

--- a/src/test/java/org/cactoos/map/StickyMapTest.java
+++ b/src/test/java/org/cactoos/map/StickyMapTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterator.Repeated;
+import org.cactoos.text.FormattedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -60,7 +61,8 @@ public final class StickyMapTest {
         final Map<Integer, Integer> map = new StickyMap<>(
             new MapOf<>(
                 () -> new Repeated<>(
-                    size.incrementAndGet(), () -> new MapEntry<>(
+                    size.incrementAndGet(),
+                    () -> new MapEntry<>(
                         new SecureRandom().nextInt(),
                         1
                     )
@@ -125,7 +127,7 @@ public final class StickyMapTest {
         MatcherAssert.assertThat(
             "Can't transform and decorate a list of entries with two funcs",
             new StickyMap<String, String>(
-                color -> String.format("[%s]", color),
+                color -> new FormattedText("[%s]", color).asString(),
                 String::toUpperCase,
                 new StickyMap<String, String>(
                     new MapEntry<>("black!", "Black!"),
@@ -136,5 +138,4 @@ public final class StickyMapTest {
             Matchers.hasValue(Matchers.equalTo("BLUE!"))
         );
     }
-
 }


### PR DESCRIPTION
Pull request for #824.

All usages of `String.format` has been replaced with "FormattedText" (wrapped into "UncheckedText" when it's needed).