### PR TITLE
#857: Implement immutable ListIterator

### DIFF
--- a/src/main/java/org/cactoos/list/ListEnvelope.java
+++ b/src/main/java/org/cactoos/list/ListEnvelope.java
@@ -100,12 +100,16 @@ abstract class ListEnvelope<T> extends CollectionEnvelope<T> implements
 
     @Override
     public final ListIterator<T> listIterator() {
-        return this.list.value().listIterator();
+        return new org.cactoos.list.ListIterator<>(
+            this.list.value().listIterator()
+        );
     }
 
     @Override
     public final ListIterator<T> listIterator(final int index) {
-        return this.list.value().listIterator(index);
+        return new org.cactoos.list.ListIterator<>(
+            this.list.value().listIterator(index)
+        );
     }
 
     @Override

--- a/src/main/java/org/cactoos/list/ListIterator.java
+++ b/src/main/java/org/cactoos/list/ListIterator.java
@@ -1,0 +1,99 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.list;
+
+/**
+ * Iterator of the list.
+ *
+ * <p>There is no thread-safety guarantee.
+ *
+ * @param <T> Items type
+ * @since 0.34
+ */
+public final class ListIterator<T> implements java.util.ListIterator<T> {
+
+    /**
+     * Original list iterator.
+     */
+    private final java.util.ListIterator<T> origin;
+
+    /**
+     * Ctor.
+     * @param orig Original list iterator.
+     */
+    public ListIterator(final java.util.ListIterator<T> orig) {
+        this.origin = orig;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return this.origin.hasNext();
+    }
+
+    @Override
+    public T next() {
+        return this.origin.next();
+    }
+
+    @Override
+    public boolean hasPrevious() {
+        return this.origin.hasPrevious();
+    }
+
+    @Override
+    public T previous() {
+        return this.origin.previous();
+    }
+
+    @Override
+    public int nextIndex() {
+        return this.origin.nextIndex();
+    }
+
+    @Override
+    public int previousIndex() {
+        return this.origin.previousIndex();
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException(
+            "Iterator is read-only and doesn't allow removing items"
+        );
+    }
+
+    @Override
+    public void set(final T item) {
+        throw new UnsupportedOperationException(
+            "Iterator is read-only and doesn't allow rewriting items"
+        );
+    }
+
+    @Override
+    public void add(final T item) {
+        throw new UnsupportedOperationException(
+            "Iterator is read-only and doesn't allow adding items"
+        );
+    }
+}

--- a/src/main/java/org/cactoos/list/ListIterator.java
+++ b/src/main/java/org/cactoos/list/ListIterator.java
@@ -23,57 +23,87 @@
  */
 package org.cactoos.list;
 
+import java.util.List;
+import org.cactoos.Scalar;
+import org.cactoos.scalar.StickyScalar;
+import org.cactoos.scalar.UncheckedScalar;
+
 /**
  * Iterator of the list.
  *
  * <p>There is no thread-safety guarantee.
  *
  * @param <T> Items type
- * @since 0.34
+ * @since 0.35
  */
 public final class ListIterator<T> implements java.util.ListIterator<T> {
 
     /**
      * Original list iterator.
      */
-    private final java.util.ListIterator<T> origin;
+    private final UncheckedScalar<java.util.ListIterator<T>> origin;
+
+    /**
+     * Ctor.
+     * @param list List that will be called to get a list iterator.
+     */
+    public ListIterator(final List<T> list) {
+        this(list::listIterator);
+    }
+
+    /**
+     * Ctor.
+     * @param list List that will be called to get a list iterator.
+     * @param index Start index for a newly created list iterator.
+     */
+    public ListIterator(final List<T> list, final int index) {
+        this(() -> list.listIterator(index));
+    }
+
+    /**
+     * Ctor.
+     * @param iter Original list iterator.
+     */
+    public ListIterator(final java.util.ListIterator<T> iter) {
+        this(() -> iter);
+    }
 
     /**
      * Ctor.
      * @param orig Original list iterator.
      */
-    public ListIterator(final java.util.ListIterator<T> orig) {
-        this.origin = orig;
+    public ListIterator(final Scalar<java.util.ListIterator<T>> orig) {
+        this.origin = new UncheckedScalar<>(new StickyScalar<>(orig));
     }
 
     @Override
     public boolean hasNext() {
-        return this.origin.hasNext();
+        return this.origin.value().hasNext();
     }
 
     @Override
     public T next() {
-        return this.origin.next();
+        return this.origin.value().next();
     }
 
     @Override
     public boolean hasPrevious() {
-        return this.origin.hasPrevious();
+        return this.origin.value().hasPrevious();
     }
 
     @Override
     public T previous() {
-        return this.origin.previous();
+        return this.origin.value().previous();
     }
 
     @Override
     public int nextIndex() {
-        return this.origin.nextIndex();
+        return this.origin.value().nextIndex();
     }
 
     @Override
     public int previousIndex() {
-        return this.origin.previousIndex();
+        return this.origin.value().previousIndex();
     }
 
     @Override

--- a/src/test/java/org/cactoos/list/ListEnvelopeTest.java
+++ b/src/test/java/org/cactoos/list/ListEnvelopeTest.java
@@ -27,22 +27,16 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * Test case for {@link ListEnvelope}.
  *
  * @since 0.32
- * @todo #814:30min Implement immutable ListIterator that should
- *  be returned from ListEnvelope when calling `listIterator` method. After
- *  it is implemented remove `@Ignore` from the tests below - all of them
- *  should pass after the change.
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 public final class ListEnvelopeTest {
 
-    @Ignore
     @Test(expected = UnsupportedOperationException.class)
     public void returnsListIteratorWithUnsupportedRemove() {
         final ListEnvelope<String> list = new ListEnvelope<String>(
@@ -51,13 +45,13 @@ public final class ListEnvelopeTest {
                 inner.add("one");
                 return inner;
             }
-        ) { };
+        ) {
+        };
         final Iterator<String> iterator = list.listIterator();
         iterator.next();
         iterator.remove();
     }
 
-    @Ignore
     @Test(expected = UnsupportedOperationException.class)
     public void returnsListIteratorWithUnsupportedSet() {
         final ListEnvelope<String> list = new ListEnvelope<String>(
@@ -66,13 +60,13 @@ public final class ListEnvelopeTest {
                 inner.add("three");
                 return inner;
             }
-        ) { };
+        ) {
+        };
         final ListIterator<String> iterator = list.listIterator();
         iterator.next();
         iterator.set("zero");
     }
 
-    @Ignore
     @Test(expected = UnsupportedOperationException.class)
     public void returnsListIteratorWithUnsupportedAdd() {
         final ListEnvelope<String> list = new ListEnvelope<String>(
@@ -81,7 +75,8 @@ public final class ListEnvelopeTest {
                 inner.add("ten");
                 return inner;
             }
-        ) { };
+        ) {
+        };
         final ListIterator<String> iterator = list.listIterator();
         iterator.next();
         iterator.add("twenty");

--- a/src/test/java/org/cactoos/list/ListEnvelopeTest.java
+++ b/src/test/java/org/cactoos/list/ListEnvelopeTest.java
@@ -88,7 +88,9 @@ public final class ListEnvelopeTest {
     public void getsPreviousIndex() {
         MatcherAssert.assertThat(
             "List iterator returns incorrect previous index",
-            new ListOf<>(1).listIterator().previousIndex(),
+            new org.cactoos.list.ListIterator<>(
+                new ListOf<>(1)
+            ).previousIndex(),
             new IsEqual<>(-1)
         );
     }
@@ -97,7 +99,10 @@ public final class ListEnvelopeTest {
     public void getsPrevious() {
         MatcherAssert.assertThat(
             "List iterator returns incorrect previous item",
-            new ListOf<>(3, 7).listIterator(1).previous(),
+            new org.cactoos.list.ListIterator<>(
+                new ListOf<>(3, 7),
+                1
+            ).previous(),
             new IsEqual<>(3)
         );
     }
@@ -106,7 +111,9 @@ public final class ListEnvelopeTest {
     public void getsNextIndex() {
         MatcherAssert.assertThat(
             "List iterator returns incorrect next index",
-            new ListOf<>(1).listIterator().nextIndex(),
+            new org.cactoos.list.ListIterator<>(
+                new ListOf<>(1)
+            ).nextIndex(),
             new IsEqual<>(0)
         );
     }
@@ -115,7 +122,10 @@ public final class ListEnvelopeTest {
     public void getsNext() {
         MatcherAssert.assertThat(
             "List iterator returns incorrect next item",
-            new ListOf<>(5, 11, 13).listIterator(1).next(),
+            new org.cactoos.list.ListIterator<>(
+                new ListOf<>(5, 11, 13),
+                1
+            ).next(),
             new IsEqual<>(11)
         );
     }

--- a/src/test/java/org/cactoos/list/ListEnvelopeTest.java
+++ b/src/test/java/org/cactoos/list/ListEnvelopeTest.java
@@ -27,6 +27,8 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 
 /**
@@ -34,6 +36,7 @@ import org.junit.Test;
  *
  * @since 0.32
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle MagicNumberCheck (500 lines)
  */
 public final class ListEnvelopeTest {
 
@@ -62,8 +65,7 @@ public final class ListEnvelopeTest {
             }
         ) {
         };
-        final ListIterator<String> iterator = list.listIterator();
-        iterator.next();
+        final ListIterator<String> iterator = list.listIterator(1);
         iterator.set("zero");
     }
 
@@ -80,5 +82,41 @@ public final class ListEnvelopeTest {
         final ListIterator<String> iterator = list.listIterator();
         iterator.next();
         iterator.add("twenty");
+    }
+
+    @Test
+    public void getsPreviousIndex() {
+        MatcherAssert.assertThat(
+            "List iterator returns incorrect previous index",
+            new ListOf<>(1).listIterator().previousIndex(),
+            new IsEqual<>(-1)
+        );
+    }
+
+    @Test
+    public void getsPrevious() {
+        MatcherAssert.assertThat(
+            "List iterator returns incorrect previous item",
+            new ListOf<>(3, 7).listIterator(1).previous(),
+            new IsEqual<>(3)
+        );
+    }
+
+    @Test
+    public void getsNextIndex() {
+        MatcherAssert.assertThat(
+            "List iterator returns incorrect next index",
+            new ListOf<>(1).listIterator().nextIndex(),
+            new IsEqual<>(0)
+        );
+    }
+
+    @Test
+    public void getsNext() {
+        MatcherAssert.assertThat(
+            "List iterator returns incorrect next item",
+            new ListOf<>(5, 11, 13).listIterator(1).next(),
+            new IsEqual<>(11)
+        );
     }
 }


### PR DESCRIPTION
Pull request for #857 

I've implemented a new class `ListIterator` that forbids write operations: `set`, `add` and `remove`. This new iterator impl is used in the ListEnvelope only. As well added a few new test cases to improve test coverage.