### PR TITLE
#850: Resurrect skipped iterator, iterable and collection

### DIFF
--- a/src/main/java/org/cactoos/collection/Skipped.java
+++ b/src/main/java/org/cactoos/collection/Skipped.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.collection;
+
+import java.util.Collection;
+import org.cactoos.iterable.IterableOf;
+
+/**
+ * Skipped collection.
+ *
+ * <p>There is no thread-safety guarantee.
+ *
+ * @param <T> Type of source item
+ * @since 0.34
+ */
+public final class Skipped<T> extends CollectionEnvelope<T> {
+
+    /**
+     * Ctor.
+     * @param skip How many to skip
+     * @param src Source elements
+     */
+    @SafeVarargs
+    public Skipped(final int skip, final T... src) {
+        this(new IterableOf<>(src), skip);
+    }
+
+    /**
+     * Ctor.
+     * @param src Source iterable
+     * @param skip How many to skip
+     */
+    public Skipped(final Iterable<T> src, final int skip) {
+        this(new CollectionOf<T>(src), skip);
+    }
+
+    /**
+     * Ctor.
+     * @param src Source collection
+     * @param skip How many to skip
+     */
+    public Skipped(final Collection<T> src, final int skip) {
+        super(() -> new CollectionOf<T>(
+            new org.cactoos.iterable.Skipped<T>(src, skip)
+        ));
+    }
+}

--- a/src/main/java/org/cactoos/iterable/Skipped.java
+++ b/src/main/java/org/cactoos/iterable/Skipped.java
@@ -1,0 +1,57 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.iterable;
+
+/**
+ * Skipped iterable.
+ *
+ * <p>There is no thread-safety guarantee.</p>
+ *
+ * @param <T> Element type
+ * @since 0.34
+ */
+public final class Skipped<T> extends IterableEnvelope<T> {
+
+    /**
+     * Ctor.
+     * @param skip How many to skip
+     * @param src The underlying iterable
+     */
+    @SafeVarargs
+    public Skipped(final int skip, final T... src) {
+        this(new IterableOf<>(src), skip);
+    }
+
+    /**
+     * Ctor.
+     * @param iterable Decorated iterable
+     * @param skip Count skip elements
+     */
+    public Skipped(final Iterable<T> iterable, final int skip) {
+        super(() -> () -> new org.cactoos.iterator.Skipped<>(
+            iterable.iterator(),
+            skip
+        ));
+    }
+}

--- a/src/main/java/org/cactoos/iterator/Skipped.java
+++ b/src/main/java/org/cactoos/iterator/Skipped.java
@@ -1,0 +1,85 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.iterator;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * Skipped iterator.
+ *
+ * <p>There is no thread-safety guarantee.</p>
+ *
+ * @param <T> Element type
+ * @since 0.34
+ */
+public final class Skipped<T> implements Iterator<T> {
+
+    /**
+     * Decorated iterator.
+     */
+    private final Iterator<T> origin;
+
+    /**
+     * Count skip elements.
+     */
+    private int skip;
+
+    /**
+     * Ctor.
+     * @param iterator Decorated iterator
+     * @param skp Count skip elements
+     */
+    public Skipped(final Iterator<T> iterator, final int skp) {
+        this.origin = iterator;
+        this.skip = skp;
+    }
+
+    @Override
+    public boolean hasNext() {
+        this.omit();
+        return this.origin.hasNext();
+    }
+
+    @Override
+    public T next() {
+        this.omit();
+        if (!this.hasNext()) {
+            throw new NoSuchElementException(
+                "The iterator doesn't have items any more"
+            );
+        }
+        return this.origin.next();
+    }
+
+    /**
+     * Skip first N items.
+     */
+    private void omit() {
+        while (this.skip > 0 && this.origin.hasNext()) {
+            this.origin.next();
+            --this.skip;
+        }
+    }
+}

--- a/src/test/java/org/cactoos/collection/SkippedTest.java
+++ b/src/test/java/org/cactoos/collection/SkippedTest.java
@@ -1,0 +1,126 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.cactoos.collection;
+
+import org.cactoos.iterable.IterableOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test Case for {@link Skipped}.
+ *
+ * @since 0.34
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class SkippedTest {
+
+    @Test
+    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
+    public void skipIterable() {
+        MatcherAssert.assertThat(
+            "Can't skip elements in iterable",
+            new Skipped<>(
+                new IterableOf<>("one", "two", "three", "four"),
+                2
+            ),
+            Matchers.contains(
+                "three",
+                "four"
+            )
+        );
+    }
+
+    @Test
+    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
+    public void skipArray() {
+        MatcherAssert.assertThat(
+            "Can't skip elements in array",
+            new Skipped<>(
+                2,
+                "one", "two", "three", "four"
+            ),
+            Matchers.contains(
+                "three",
+                "four"
+            )
+        );
+    }
+
+    @Test
+    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
+    public void skipCollection() {
+        MatcherAssert.assertThat(
+            "Can't skip elements in collection",
+            new Skipped<>(
+                new CollectionOf<>("one", "two", "three", "four"),
+                2
+            ),
+            Matchers.contains(
+                "three",
+                "four"
+            )
+        );
+    }
+
+    @Test
+    public void skippedAllElements() {
+        MatcherAssert.assertThat(
+            "Can't skip all elements",
+            new Skipped<>(
+                2,
+                "one", "two"
+            ),
+            Matchers.empty()
+        );
+    }
+
+    @Test
+    public void skippedMoreThanExists() {
+        MatcherAssert.assertThat(
+            "Can't skip more than exists",
+            new Skipped<>(
+                Integer.MAX_VALUE,
+                "one", "two"
+            ),
+            Matchers.empty()
+        );
+    }
+
+    @Test
+    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
+    public void skippedNegativeSize() {
+        MatcherAssert.assertThat(
+            "Can't process negative skipped size",
+            new Skipped<>(
+                -1,
+                "one", "two", "three", "four"
+            ),
+            Matchers.contains(
+                "one", "two", "three", "four"
+            )
+        );
+    }
+}

--- a/src/test/java/org/cactoos/iterable/SkippedTest.java
+++ b/src/test/java/org/cactoos/iterable/SkippedTest.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.iterable;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test Case for {@link Skipped}.
+ *
+ * @since 0.34
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class SkippedTest {
+
+    @Test
+    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
+    public void skipIterable() {
+        MatcherAssert.assertThat(
+            "Can't skip elements in iterable",
+            new Skipped<>(
+                2,
+                "one", "two", "three", "four"
+            ),
+            Matchers.contains(
+                "three",
+                "four"
+            )
+        );
+    }
+}

--- a/src/test/java/org/cactoos/iterator/SkippedTest.java
+++ b/src/test/java/org/cactoos/iterator/SkippedTest.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.iterator;
+
+import java.util.NoSuchElementException;
+import org.cactoos.iterable.IterableOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test Case for {@link Skipped}.
+ *
+ * @since 0.34
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class SkippedTest {
+
+    @Test
+    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
+    public void skipIterator() {
+        MatcherAssert.assertThat(
+            "Can't skip elements in iterator",
+            () -> new Skipped<>(
+                new IterableOf<>(
+                    "one", "two", "three", "four"
+                ).iterator(),
+                2
+            ),
+            Matchers.contains(
+                "three",
+                "four"
+            )
+        );
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void errorSkippedMoreThanExists() {
+        new Skipped<>(
+            new IterableOf<>(
+                "one", "two"
+            ).iterator(),
+            2
+        ).next();
+    }
+}


### PR DESCRIPTION
Pull request for #850 

I've restored skipped iterator, iterable and collection with small adjustments. As well related tests have been restored.