### PR TITLE
#861 Remove FuncOf.ctr(Proc<X>)

### DIFF
--- a/src/main/java/org/cactoos/func/AsyncFunc.java
+++ b/src/main/java/org/cactoos/func/AsyncFunc.java
@@ -45,6 +45,10 @@ import org.cactoos.Proc;
  * @param <X> Type of input
  * @param <Y> Type of output
  * @since 0.10
+ * @todo #861:30min Avoid usage of null value in ctor(Proc<X>, ExecutorService),
+ * ctor(Proc<X>, ThreadFactory) and ctor(Proc<X>) which is against design principles.
+ * Perhaps with a creation of AsyncProc or removal of this functionality?
+ * Please take a look on #551 and #843 for more details.
  */
 public final class AsyncFunc<X, Y> implements Func<X, Future<Y>>, Proc<X> {
 
@@ -63,7 +67,7 @@ public final class AsyncFunc<X, Y> implements Func<X, Future<Y>>, Proc<X> {
      * @param proc The proc
      */
     public AsyncFunc(final Proc<X> proc) {
-        this(new FuncOf<>(proc));
+        this(new FuncOf<>(proc, null));
     }
 
     /**
@@ -80,7 +84,7 @@ public final class AsyncFunc<X, Y> implements Func<X, Future<Y>>, Proc<X> {
      * @param fct Factory
      */
     public AsyncFunc(final Proc<X> proc, final ThreadFactory fct) {
-        this(new FuncOf<>(proc), fct);
+        this(new FuncOf<>(proc, null), fct);
     }
 
     /**
@@ -99,7 +103,7 @@ public final class AsyncFunc<X, Y> implements Func<X, Future<Y>>, Proc<X> {
      * @since 0.17
      */
     public AsyncFunc(final Proc<X> proc, final ExecutorService exec) {
-        this(new FuncOf<>(proc), exec);
+        this(new FuncOf<>(proc, null), exec);
     }
 
     /**

--- a/src/main/java/org/cactoos/func/FuncOf.java
+++ b/src/main/java/org/cactoos/func/FuncOf.java
@@ -76,14 +76,6 @@ public final class FuncOf<X, Y> implements Func<X, Y> {
     /**
      * Ctor.
      * @param proc The proc
-     */
-    public FuncOf(final Proc<X> proc) {
-        this(proc, null);
-    }
-
-    /**
-     * Ctor.
-     * @param proc The proc
      * @param result Result to return
      */
     public FuncOf(final Proc<X> proc, final Y result) {

--- a/src/main/java/org/cactoos/func/IoCheckedProc.java
+++ b/src/main/java/org/cactoos/func/IoCheckedProc.java
@@ -34,6 +34,8 @@ import org.cactoos.Proc;
  *
  * @param <X> Type of input
  * @since 0.4
+ * @todo #861:30min Avoid usage of null value in exec(X) which is against design principles.
+ * Please take a look on #551 and #843 for more details.
  */
 public final class IoCheckedProc<X> implements Proc<X> {
 
@@ -52,7 +54,7 @@ public final class IoCheckedProc<X> implements Proc<X> {
 
     @Override
     public void exec(final X input) throws IOException {
-        new IoCheckedFunc<>(new FuncOf<>(this.proc)).apply(input);
+        new IoCheckedFunc<>(new FuncOf<>(this.proc, null)).apply(input);
     }
 
 }

--- a/src/main/java/org/cactoos/func/RepeatedFunc.java
+++ b/src/main/java/org/cactoos/func/RepeatedFunc.java
@@ -33,6 +33,9 @@ import org.cactoos.Proc;
  * @param <X> Type of input
  * @param <Y> Type of output
  * @since 0.6
+ * @todo #861:30min Avoid usage of null value in ctor(Proc<X>, int) which is against design principles.
+ * Perhaps in creating RepeatedProc<X>?
+ * Please take a look on #551 and #843 for more details.
  */
 public final class RepeatedFunc<X, Y> implements Func<X, Y> {
 
@@ -53,7 +56,7 @@ public final class RepeatedFunc<X, Y> implements Func<X, Y> {
      * @since 0.12
      */
     public RepeatedFunc(final Proc<X> proc, final int max) {
-        this(new FuncOf<>(proc), max);
+        this(new FuncOf<>(proc, null), max);
     }
 
     /**

--- a/src/main/java/org/cactoos/func/RetryFunc.java
+++ b/src/main/java/org/cactoos/func/RetryFunc.java
@@ -34,6 +34,10 @@ import org.cactoos.Proc;
  * @param <X> Type of input
  * @param <Y> Type of output
  * @since 0.8
+ * @todo #861:30min Avoid usage of null value in ctor(Proc<X>), ctor(Proc<X>, int),
+ * ctor(Proc<X>, Func<Integer, Boolean>) which is against design principles.
+ * Perhaps in creating RetryProc<X>?
+ * Please take a look on #551 and #843 for more details.
  */
 public final class RetryFunc<X, Y> implements Func<X, Y> {
 
@@ -53,7 +57,7 @@ public final class RetryFunc<X, Y> implements Func<X, Y> {
      * @since 0.12
      */
     public RetryFunc(final Proc<X> proc) {
-        this(new FuncOf<>(proc));
+        this(new FuncOf<>(proc, null));
     }
 
     /**
@@ -63,7 +67,7 @@ public final class RetryFunc<X, Y> implements Func<X, Y> {
      * @since 0.12
      */
     public RetryFunc(final Proc<X> proc, final int attempts) {
-        this(new FuncOf<>(proc), attempts);
+        this(new FuncOf<>(proc, null), attempts);
     }
 
     /**
@@ -73,7 +77,7 @@ public final class RetryFunc<X, Y> implements Func<X, Y> {
      * @since 0.12
      */
     public RetryFunc(final Proc<X> proc, final Func<Integer, Boolean> ext) {
-        this(new FuncOf<>(proc), ext);
+        this(new FuncOf<>(proc, null), ext);
     }
 
     /**

--- a/src/main/java/org/cactoos/func/TimedFunc.java
+++ b/src/main/java/org/cactoos/func/TimedFunc.java
@@ -35,6 +35,10 @@ import org.cactoos.Proc;
  * @param <X> Type of input
  * @param <Y> Type of output
  * @since 0.29.3
+ * @todo #861:30min Avoid usage of null value in ctor(Proc<X>, long) which is
+ * against design principles.
+ * Perhaps in creating TimedProc<X>?
+ * Please take a look on #551 and #843 for more details.
  */
 public final class TimedFunc<X, Y> implements Func<X, Y> {
 
@@ -54,7 +58,7 @@ public final class TimedFunc<X, Y> implements Func<X, Y> {
      * @param milliseconds Milliseconds
      */
     public TimedFunc(final Proc<X> proc, final long milliseconds) {
-        this(new FuncOf<>(proc), milliseconds);
+        this(new FuncOf<>(proc, null), milliseconds);
     }
 
     /**

--- a/src/main/java/org/cactoos/func/UncheckedProc.java
+++ b/src/main/java/org/cactoos/func/UncheckedProc.java
@@ -32,6 +32,8 @@ import org.cactoos.Proc;
  *
  * @param <X> Type of input
  * @since 0.2
+ * @todo #861:30min Avoid usage of null value in exec(X) which is against design principles.
+ * Please take a look on #551 and #843 for more details.
  */
 public final class UncheckedProc<X> implements Proc<X> {
 
@@ -50,7 +52,7 @@ public final class UncheckedProc<X> implements Proc<X> {
 
     @Override
     public void exec(final X input) {
-        new UncheckedFunc<>(new FuncOf<>(this.proc)).apply(input);
+        new UncheckedFunc<>(new FuncOf<>(this.proc, null)).apply(input);
     }
 
 }

--- a/src/test/java/org/cactoos/func/FuncOfTest.java
+++ b/src/test/java/org/cactoos/func/FuncOfTest.java
@@ -49,19 +49,6 @@ public final class FuncOfTest {
     }
 
     @Test
-    public void convertsProcWithNoResultIntoFunc() throws Exception {
-        final AtomicBoolean done = new AtomicBoolean(false);
-        MatcherAssert.assertThat(
-            new FuncOf<String, Boolean>(
-                input -> {
-                    done.set(true);
-                }
-            ).apply("hello you"),
-            Matchers.nullValue()
-        );
-    }
-
-    @Test
     public void convertsValueIntoFunc() throws Exception {
         MatcherAssert.assertThat(
             new FuncOf<String, Boolean>(

--- a/src/test/java/org/cactoos/map/MapEnvelopeTest.java
+++ b/src/test/java/org/cactoos/map/MapEnvelopeTest.java
@@ -62,7 +62,8 @@ public final class MapEnvelopeTest {
             ),
             new MatcherOf<>(
                 new FuncOf<>(
-                    (map) -> map.put(2, 2)
+                    (map) -> map.put(2, 2),
+                    true
                 ))
         );
     }
@@ -82,7 +83,8 @@ public final class MapEnvelopeTest {
             ),
             new MatcherOf<>(
                 new FuncOf<>(
-                    (map) -> map.remove(0)
+                    (map) -> map.remove(0),
+                    true
                 ))
         );
     }
@@ -102,7 +104,8 @@ public final class MapEnvelopeTest {
             ),
             new MatcherOf<>(
                 new FuncOf<>(
-                    (map) -> map.putAll(new MapOf<Integer, Integer>())
+                    (map) -> map.putAll(new MapOf<Integer, Integer>()),
+                    true
                 ))
         );
     }
@@ -122,7 +125,8 @@ public final class MapEnvelopeTest {
             ),
             new MatcherOf<>(
                 new FuncOf<>(
-                    Map::clear
+                    Map::clear,
+                    true
                 ))
         );
     }


### PR DESCRIPTION
Pull request for #861

 * Remove FuncOf(Proc<X>) that use null
 * Create separete puzzles for each case which is not straightforward.

