### PR TITLE
#892, equals() of MapEnvelope refactored, just one return statement left

### DIFF
--- a/src/main/java/org/cactoos/map/MapEnvelope.java
+++ b/src/main/java/org/cactoos/map/MapEnvelope.java
@@ -149,9 +149,9 @@ public abstract class MapEnvelope<X, Y> implements Map<X, Y> {
             new Or(
                 () -> this == other,
                 new And(
-                    () -> this.getClass() == other.getClass(),
-                    () -> this.size() == ((MapEnvelope<?, ?>) other).size(),
-                    () -> this.contentsEqual((MapEnvelope<?, ?>) other)
+                    () -> Map.class.isAssignableFrom(other.getClass()),
+                    () -> this.size() == ((Map<?, ?>) other).size(),
+                    () -> this.contentsEqual((Map<?, ?>) other)
                 )
             )
         ).value();
@@ -179,12 +179,12 @@ public abstract class MapEnvelope<X, Y> implements Map<X, Y> {
     }
 
     /**
-     * Indicates whether contents of an other {@code MapEnvelope} is the same
+     * Indicates whether contents of an other {@code Map} is the same
      * as contents of this one on entry-by-entry basis.
-     * @param other Another instance of {@code MapEnvelope} to compare with
+     * @param other Another instance of {@code Map} to compare with
      * @return True if contents are equal false otherwise
      */
-    private Boolean contentsEqual(final MapEnvelope<?, ?> other) {
+    private Boolean contentsEqual(final Map<?, ?> other) {
         return new UncheckedScalar<>(
             new And(
                 (entry) -> {

--- a/src/main/java/org/cactoos/map/MapEnvelope.java
+++ b/src/main/java/org/cactoos/map/MapEnvelope.java
@@ -150,7 +150,7 @@ public abstract class MapEnvelope<X, Y> implements Map<X, Y> {
                 () -> this == other,
                 new And(
                     () -> this.getClass() == other.getClass(),
-                    () -> this.sizeEqual((MapEnvelope<?, ?>) other),
+                    () -> this.size() == ((MapEnvelope<?, ?>) other).size(),
                     () -> this.contentsEqual((MapEnvelope<?, ?>) other)
                 )
             )
@@ -176,16 +176,6 @@ public abstract class MapEnvelope<X, Y> implements Map<X, Y> {
                 this.map.value().entrySet()
             )
         ).value();
-    }
-
-    /**
-     * Indicates whether an other {@code MapEnvelope} has the same number
-     * of entries as this one.
-     * @param other Another instance of {@code MapEnvelope} to compare with
-     * @return True if number of entries are the same, false otherwise
-     */
-    private boolean sizeEqual(final MapEnvelope<?, ?> other) {
-        return this.entrySet().size() == other.entrySet().size();
     }
 
     /**


### PR DESCRIPTION
Fix for #892 

- `equals()` of `MapEnvelope` refactored, just one return statement left