### PR TITLE
#897, classes implementing Text were refactored to extend TextEnvelope in package org.cactoos.time

### DIFF
--- a/src/main/java/org/cactoos/text/Base64Text.java
+++ b/src/main/java/org/cactoos/text/Base64Text.java
@@ -30,8 +30,10 @@ import org.cactoos.io.BytesOf;
 
 /**
  * Decodes the origin text using the Base64 encoding scheme.
- *
  * @since 0.20.2
+ * @todo #897:30min Continue refactoring all classes implementing Text to extend
+ *  TextEnvelope - asString() should be removed and implementation from
+ *  TextEnvelope should be used.
  */
 public final class Base64Text implements Text {
 
@@ -66,5 +68,4 @@ public final class Base64Text implements Text {
             )
         ).asString();
     }
-
 }

--- a/src/main/java/org/cactoos/text/JoinedText.java
+++ b/src/main/java/org/cactoos/text/JoinedText.java
@@ -35,9 +35,6 @@ import org.cactoos.iterable.Mapped;
  * <p>There is no thread-safety guarantee.
  *
  * @since 0.9
- * @todo #878:30min Continue refactoring all classes implementing Text to extend
- *  TextEnvelope - in most cases asString should be removed and implementation
- *  from TextEnvelope should be used.
  */
 public final class JoinedText extends TextEnvelope {
 
@@ -86,5 +83,4 @@ public final class JoinedText extends TextEnvelope {
             return joint.toString();
         });
     }
-
 }

--- a/src/main/java/org/cactoos/time/DateAsText.java
+++ b/src/main/java/org/cactoos/time/DateAsText.java
@@ -29,19 +29,15 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.Locale;
-import org.cactoos.Text;
+import org.cactoos.Scalar;
+import org.cactoos.text.TextEnvelope;
 
 /**
  * Formatter for {@link Date} instances.
  * @since 0.27
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class DateAsText implements Text {
-
-    /**
-     * Internal text carrying the formatted date.
-     */
-    private final ZonedDateTimeAsText text;
+public final class DateAsText extends TextEnvelope {
 
     /**
      * Formats current time using the ISO format.
@@ -124,16 +120,13 @@ public final class DateAsText implements Text {
      * @param formatter The formatter to use.
      */
     public DateAsText(final Date date, final DateTimeFormatter formatter) {
-        this.text = new ZonedDateTimeAsText(
-            ZonedDateTime.ofInstant(date.toInstant(), ZoneId.of("UTC")),
+        super((Scalar<String>) () -> new ZonedDateTimeAsText(
+            ZonedDateTime.ofInstant(
+                date.toInstant(),
+                ZoneId.of("UTC")
+            ),
             formatter
-        );
+        ).asString());
     }
-
-    @Override
-    public String asString() {
-        return this.text.asString();
-    }
-
 }
 

--- a/src/main/java/org/cactoos/time/LocalDateAsText.java
+++ b/src/main/java/org/cactoos/time/LocalDateAsText.java
@@ -29,20 +29,15 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
-import org.cactoos.Text;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.Scalar;
+import org.cactoos.text.TextEnvelope;
 
 /**
  * Formatter for {@link java.time.LocalDate} instances.
  * @since 0.27
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class LocalDateAsText implements Text {
-
-    /**
-     * Scalar carrying the formatted date.
-     */
-    private final UncheckedScalar<String> formatted;
+public final class LocalDateAsText extends TextEnvelope {
 
     /**
      * Formats date using ISO date time format.
@@ -80,16 +75,8 @@ public final class LocalDateAsText implements Text {
      */
     public LocalDateAsText(final LocalDate date,
         final DateTimeFormatter formatter) {
-        this.formatted = new UncheckedScalar<>(
-            () -> formatter.format(
-                ZonedDateTime.of(date, LocalTime.MIN, ZoneId.systemDefault())
-            )
-        );
+        super((Scalar<String>) () -> formatter.format(
+            ZonedDateTime.of(date, LocalTime.MIN, ZoneId.systemDefault())
+        ));
     }
-
-    @Override
-    public String asString() {
-        return this.formatted.value();
-    }
-
 }

--- a/src/main/java/org/cactoos/time/LocalDateTimeAsText.java
+++ b/src/main/java/org/cactoos/time/LocalDateTimeAsText.java
@@ -27,20 +27,15 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
-import org.cactoos.Text;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.Scalar;
+import org.cactoos.text.TextEnvelope;
 
 /**
  * Formatter for {@link java.time.LocalDateTime} instances.
  * @since 0.27
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class LocalDateTimeAsText implements Text {
-
-    /**
-     * Scalar carrying the formatted date.
-     */
-    private final UncheckedScalar<String> formatted;
+public final class LocalDateTimeAsText extends TextEnvelope {
 
     /**
      * Formats date using ISO date time format.
@@ -78,14 +73,9 @@ public final class LocalDateTimeAsText implements Text {
      */
     public LocalDateTimeAsText(final LocalDateTime date,
         final DateTimeFormatter formatter) {
-        this.formatted = new UncheckedScalar<>(
-            () -> formatter.format(date.atZone(ZoneId.systemDefault()))
+        super((Scalar<String>) () -> formatter.format(
+            date.atZone(ZoneId.systemDefault())
+            )
         );
     }
-
-    @Override
-    public String asString() {
-        return this.formatted.value();
-    }
-
 }

--- a/src/main/java/org/cactoos/time/OffsetDateTimeAsText.java
+++ b/src/main/java/org/cactoos/time/OffsetDateTimeAsText.java
@@ -26,20 +26,15 @@ package org.cactoos.time;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
-import org.cactoos.Text;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.Scalar;
+import org.cactoos.text.TextEnvelope;
 
 /**
  * Formatter for {@link java.time.OffsetDateTime} instances.
  * @since 0.27
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class OffsetDateTimeAsText implements Text {
-
-    /**
-     * Scalar carrying the formatted date.
-     */
-    private final UncheckedScalar<String> formatted;
+public final class OffsetDateTimeAsText extends TextEnvelope {
 
     /**
      * Formats date using ISO date time format.
@@ -78,14 +73,6 @@ public final class OffsetDateTimeAsText implements Text {
      */
     public OffsetDateTimeAsText(final OffsetDateTime date,
         final DateTimeFormatter formatter) {
-        this.formatted = new UncheckedScalar<>(
-            () -> formatter.format(date)
-        );
+        super((Scalar<String>) () -> formatter.format(date));
     }
-
-    @Override
-    public String asString() {
-        return this.formatted.value();
-    }
-
 }

--- a/src/main/java/org/cactoos/time/ZonedDateTimeAsText.java
+++ b/src/main/java/org/cactoos/time/ZonedDateTimeAsText.java
@@ -26,20 +26,15 @@ package org.cactoos.time;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
-import org.cactoos.Text;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.Scalar;
+import org.cactoos.text.TextEnvelope;
 
 /**
  * Formatter for {@link java.time.ZonedDateTime} instances.
  * @since 0.27
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class ZonedDateTimeAsText implements Text {
-
-    /**
-     * Scalar carrying the formatted date.
-     */
-    private final UncheckedScalar<String> formatted;
+public final class ZonedDateTimeAsText extends TextEnvelope {
 
     /**
      * Formats date using ISO date time format.
@@ -77,14 +72,6 @@ public final class ZonedDateTimeAsText implements Text {
      */
     public ZonedDateTimeAsText(final ZonedDateTime date,
         final DateTimeFormatter formatter) {
-        this.formatted = new UncheckedScalar<>(
-            () -> formatter.format(date)
-        );
+        super((Scalar<String>) () -> formatter.format(date));
     }
-
-    @Override
-    public String asString() {
-        return this.formatted.value();
-    }
-
 }

--- a/src/test/java/org/cactoos/time/DateAsTextTest.java
+++ b/src/test/java/org/cactoos/time/DateAsTextTest.java
@@ -23,6 +23,7 @@
  */
 package org.cactoos.time;
 
+import java.io.IOException;
 import java.util.Calendar;
 import java.util.Locale;
 import java.util.TimeZone;
@@ -40,7 +41,7 @@ import org.junit.Test;
 public final class DateAsTextTest {
 
     @Test
-    public void formatsCurrentTime() {
+    public void formatsCurrentTime() throws IOException {
         MatcherAssert.assertThat(
             "Can't format current time",
             new DateAsText().asString(),
@@ -49,7 +50,7 @@ public final class DateAsTextTest {
     }
 
     @Test
-    public void dateFormattedUsingIsoFormatter() {
+    public void dateFormattedUsingIsoFormatter() throws IOException {
         final Calendar calendar =
             Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         calendar.set(2017, Calendar.DECEMBER, 13, 14, 15, 16);
@@ -62,7 +63,7 @@ public final class DateAsTextTest {
     }
 
     @Test
-    public void dateFormattedUsingCustomFormat() {
+    public void dateFormattedUsingCustomFormat() throws IOException {
         final Calendar calendar =
             Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         calendar.set(2017, Calendar.DECEMBER, 13, 14, 15, 16);
@@ -76,7 +77,8 @@ public final class DateAsTextTest {
     }
 
     @Test
-    public void dateFormattedUsingCustomFormatDifferentLocale() {
+    public void dateFormattedUsingCustomFormatDifferentLocale()
+        throws IOException {
         final Calendar calendar =
             Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         calendar.set(2017, Calendar.DECEMBER, 13, 14, 15, 16);
@@ -90,7 +92,7 @@ public final class DateAsTextTest {
     }
 
     @Test
-    public void millisFormattedUsingIsoFormatter() {
+    public void millisFormattedUsingIsoFormatter() throws IOException {
         final Calendar calendar =
             Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         calendar.set(2017, Calendar.DECEMBER, 13, 14, 15, 16);
@@ -103,7 +105,7 @@ public final class DateAsTextTest {
     }
 
     @Test
-    public void millisFormattedUsingCustomFormat() {
+    public void millisFormattedUsingCustomFormat() throws IOException {
         final Calendar calendar =
             Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         calendar.set(2017, Calendar.DECEMBER, 13, 14, 15, 16);
@@ -118,7 +120,8 @@ public final class DateAsTextTest {
     }
 
     @Test
-    public void millisFormattedUsingCustomFormatDifferentLocale() {
+    public void millisFormattedUsingCustomFormatDifferentLocale()
+        throws IOException {
         final Calendar calendar =
             Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         calendar.set(2017, Calendar.DECEMBER, 13, 14, 15, 16);

--- a/src/test/java/org/cactoos/time/LocalDateAsTextTest.java
+++ b/src/test/java/org/cactoos/time/LocalDateAsTextTest.java
@@ -23,6 +23,7 @@
  */
 package org.cactoos.time;
 
+import java.io.IOException;
 import java.text.MessageFormat;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -42,7 +43,7 @@ import org.junit.Test;
 public final class LocalDateAsTextTest {
 
     @Test
-    public void localDateFormattedAsIsoDateTime() {
+    public void localDateFormattedAsIsoDateTime() throws IOException {
         final LocalDate date = LocalDate.of(2017, 12, 13);
         MatcherAssert.assertThat(
             "Can't format a LocalDate with default/ISO format.",
@@ -58,7 +59,7 @@ public final class LocalDateAsTextTest {
     }
 
     @Test
-    public void localDateFormattedWithFormatString() {
+    public void localDateFormattedWithFormatString() throws IOException {
         final LocalDate date = LocalDate.of(2017, 12, 13);
         MatcherAssert.assertThat(
             "Can't format a LocalDate with format.",
@@ -68,7 +69,8 @@ public final class LocalDateAsTextTest {
     }
 
     @Test
-    public void localDateFormattedWithFormatStringWithLocale() {
+    public void localDateFormattedWithFormatStringWithLocale()
+        throws IOException {
         final LocalDate date = LocalDate.of(2017, 12, 13);
         MatcherAssert.assertThat(
             "Can't format a LocalDate with format using locale.",
@@ -80,12 +82,11 @@ public final class LocalDateAsTextTest {
     }
 
     @Test
-    public void currentLocalDateAsText() {
+    public void currentLocalDateAsText() throws IOException {
         MatcherAssert.assertThat(
             "Can't format a LocalDate with ISO format.",
             new LocalDateAsText(LocalDate.now()).asString(),
             Matchers.notNullValue()
         );
     }
-
 }

--- a/src/test/java/org/cactoos/time/LocalDateTimeAsTextTest.java
+++ b/src/test/java/org/cactoos/time/LocalDateTimeAsTextTest.java
@@ -23,6 +23,7 @@
  */
 package org.cactoos.time;
 
+import java.io.IOException;
 import java.text.MessageFormat;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -41,7 +42,7 @@ import org.junit.Test;
 public final class LocalDateTimeAsTextTest {
 
     @Test
-    public void localDateTimeFormattedAsIsoDateTime() {
+    public void localDateTimeFormattedAsIsoDateTime() throws IOException {
         final LocalDateTime date = LocalDateTime.of(
             2017, 12, 13, 14, 15, 16, 17
         );
@@ -58,7 +59,7 @@ public final class LocalDateTimeAsTextTest {
     }
 
     @Test
-    public void localDateTimeFormattedWithFormatString() {
+    public void localDateTimeFormattedWithFormatString() throws IOException {
         final LocalDateTime date = LocalDateTime.of(
             2017, 12, 13, 14, 15, 16, 17
         );
@@ -70,7 +71,8 @@ public final class LocalDateTimeAsTextTest {
     }
 
     @Test
-    public void localDateTimeFormattedWithFormatStringWithLocale() {
+    public void localDateTimeFormattedWithFormatStringWithLocale()
+        throws IOException {
         final LocalDateTime date = LocalDateTime.of(
             2017, 12, 13, 14, 15, 16, 17
         );
@@ -84,7 +86,7 @@ public final class LocalDateTimeAsTextTest {
     }
 
     @Test
-    public void currentLocalDateTimeAsText() {
+    public void currentLocalDateTimeAsText() throws IOException {
         MatcherAssert.assertThat(
             "Can't format a LocalDateTime with ISO format.",
             new LocalDateTimeAsText(LocalDateTime.now()).asString(),

--- a/src/test/java/org/cactoos/time/OffsetDateTimeAsTextTest.java
+++ b/src/test/java/org/cactoos/time/OffsetDateTimeAsTextTest.java
@@ -23,6 +23,7 @@
  */
 package org.cactoos.time;
 
+import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Locale;
@@ -40,7 +41,7 @@ import org.junit.Test;
 public final class OffsetDateTimeAsTextTest {
 
     @Test
-    public void offsetDateTimeFormattedAsIsoDateTime() {
+    public void offsetDateTimeFormattedAsIsoDateTime() throws IOException {
         final OffsetDateTime date = OffsetDateTime.of(
             2017, 12, 13, 14, 15, 16, 17, ZoneOffset.ofHours(1)
         );
@@ -52,7 +53,7 @@ public final class OffsetDateTimeAsTextTest {
     }
 
     @Test
-    public void offsetDateTimeFormattedWithFormatString() {
+    public void offsetDateTimeFormattedWithFormatString() throws IOException {
         final OffsetDateTime date = OffsetDateTime.of(
             2017, 12, 13, 14, 15, 16, 17, ZoneOffset.ofHours(1)
         );
@@ -64,7 +65,8 @@ public final class OffsetDateTimeAsTextTest {
     }
 
     @Test
-    public void offsetDateTimeFormattedWithFormatStringWithLocale() {
+    public void offsetDateTimeFormattedWithFormatStringWithLocale()
+        throws IOException {
         final OffsetDateTime date = OffsetDateTime.of(
             2017, 12, 13, 14, 15, 16, 17, ZoneOffset.ofHours(1)
         );
@@ -78,7 +80,7 @@ public final class OffsetDateTimeAsTextTest {
     }
 
     @Test
-    public void currentOffsetDateTimeAsText() {
+    public void currentOffsetDateTimeAsText() throws IOException {
         MatcherAssert.assertThat(
             "Can't format a OffsetDateTime with ISO format.",
             new OffsetDateTimeAsText(OffsetDateTime.now()).asString(),

--- a/src/test/java/org/cactoos/time/ZonedDateTimeAsTextTest.java
+++ b/src/test/java/org/cactoos/time/ZonedDateTimeAsTextTest.java
@@ -23,6 +23,7 @@
  */
 package org.cactoos.time;
 
+import java.io.IOException;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Locale;
@@ -40,7 +41,7 @@ import org.junit.Test;
 public final class ZonedDateTimeAsTextTest {
 
     @Test
-    public void zonedDateTimeFormattedAsIsoDateTime() {
+    public void zonedDateTimeFormattedAsIsoDateTime() throws IOException {
         final ZonedDateTime date = ZonedDateTime.of(
             2017, 12, 13, 14, 15, 16, 17, ZoneId.of("Europe/Berlin")
         );
@@ -52,7 +53,7 @@ public final class ZonedDateTimeAsTextTest {
     }
 
     @Test
-    public void zonedDateTimeFormattedWithFormatString() {
+    public void zonedDateTimeFormattedWithFormatString() throws IOException {
         final ZonedDateTime date = ZonedDateTime.of(
             2017, 12, 13, 14, 15, 16, 17, ZoneId.of("Europe/Berlin")
         );
@@ -64,7 +65,8 @@ public final class ZonedDateTimeAsTextTest {
     }
 
     @Test
-    public void zonedDateTimeFormattedWithFormatStringWithLocale() {
+    public void zonedDateTimeFormattedWithFormatStringWithLocale()
+        throws IOException {
         final ZonedDateTime date = ZonedDateTime.of(
             2017, 12, 13, 14, 15, 16, 17, ZoneId.of("Europe/Berlin")
         );
@@ -78,7 +80,7 @@ public final class ZonedDateTimeAsTextTest {
     }
 
     @Test
-    public void currentZonedDateTimeAsText() {
+    public void currentZonedDateTimeAsText() throws IOException {
         MatcherAssert.assertThat(
             "Can't format a ZonedDateTime with ISO format.",
             new ZonedDateTimeAsText(ZonedDateTime.now()).asString(),


### PR DESCRIPTION
this is for #897 

- all classes implementing `Text` were refactored to extend `TextEnvelope` in package `org.cactoos.time`
- unit tests have been adjusted in accordance with changes to classes implementing Text in package org.cactoos.time
- new puzzle has been created