### PR TITLE
#893, unit test has been added to prove comparison of classes derived from MapEnvelope works

### DIFF
--- a/src/test/java/org/cactoos/map/MapEnvelopeTest.java
+++ b/src/test/java/org/cactoos/map/MapEnvelopeTest.java
@@ -314,4 +314,20 @@ public final class MapEnvelopeTest {
             new MapEntry<>("key11", null);
         new MapOf<String, String>(first, second).hashCode();
     }
+
+    @Test
+    public void comparesClassesDerivedFromMapEnvelope() {
+        final MapEntry<String, String> entry =
+            new MapEntry<>("key12", "value12");
+        MatcherAssert.assertThat(
+            new MapOf<String, String>(
+                entry
+            ),
+            new IsEqual<>(
+                new StickyMap<String, String>(
+                    entry
+                )
+            )
+        );
+    }
 }


### PR DESCRIPTION
This is for #893 

This issue was fixed with pull request for #892 - there was a `Map.class.isAssignableFrom(other.getClass())` check added to `equals()`

Unit test has been added to prove comparison of instances of different classes derived from `MapEnvelope` works: `comparesClassesDerivedFromMapEnvelope` in `MapEnvelopeTest`