### PR TITLE
Avoid usage of null value in TimedFunc

### DIFF
--- a/src/main/java/org/cactoos/func/TimedFunc.java
+++ b/src/main/java/org/cactoos/func/TimedFunc.java
@@ -28,17 +28,12 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.cactoos.Func;
-import org.cactoos.Proc;
 
 /**
  * Function that gets interrupted after a certain time has passed.
  * @param <X> Type of input
  * @param <Y> Type of output
  * @since 0.29.3
- * @todo #861:30min Avoid usage of null value in ctor(Proc, long) which is
- *  against design principles.
- *  Perhaps in creating TimedProc?
- *  Please take a look on #551 and #843 for more details.
  */
 public final class TimedFunc<X, Y> implements Func<X, Y> {
 
@@ -51,15 +46,6 @@ public final class TimedFunc<X, Y> implements Func<X, Y> {
      * Milliseconds.
      */
     private final long time;
-
-    /**
-     * Ctor.
-     * @param proc Proc
-     * @param milliseconds Milliseconds
-     */
-    public TimedFunc(final Proc<X> proc, final long milliseconds) {
-        this(new FuncOf<>(proc, null), milliseconds);
-    }
 
     /**
      * Ctor.

--- a/src/test/java/org/cactoos/func/TimedFuncTest.java
+++ b/src/test/java/org/cactoos/func/TimedFuncTest.java
@@ -52,19 +52,6 @@ public final class TimedFuncTest {
         ).apply(true);
     }
 
-    @Test(expected = TimeoutException.class)
-    public void procGetsInterrupted() throws Exception {
-        final long period = 100L;
-        new TimedFunc<Boolean, Boolean>(
-            input -> {
-                new And(
-                    new Endless<>(() -> input)
-                ).value();
-            },
-            period
-        ).apply(true);
-    }
-
     @Test
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public void futureTaskIsCancelled() {


### PR DESCRIPTION
For #887 

According to discussions in #886 and recommendations by ARC (https://github.com/yegor256/cactoos/pull/918#issuecomment-402320948), I simply removed the constructor using `null` and taking a `Proc`.