### PR TITLE
Use OO matchers instead of statics 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,17 +147,22 @@ The MIT License (MIT)
             <artifactId>forbiddenapis</artifactId>
             <version>2.5</version>
             <configuration>
-              <!--
-               @todo #588:30min In the continuation of #588, all the calls
-                to Matchers should be replaced with their OO counterparts.
-                This todo should be updated with a new one until everything is
-                done. At the end the configuration property below should be
-                removed so that calls to forbidden APIs fail the build.  
-               -->
-              <failOnViolation>false</failOnViolation>
               <signaturesFiles>
                 <signaturesFile>./src/test/resources/forbidden-apis.txt</signaturesFile>
               </signaturesFiles>
+              <!--
+               @todo #903:30min In the continuation of #588, all the calls
+                to Matchers should be replaced with their OO counterparts.
+                This todo should be updated with a new one until everything is
+                done. The newly covered classes should be added to the include
+                configuration property below. At the end, the configuration
+                property below should be completely removed so that calls
+                to forbidden APIs always fail the build for every classes.  
+               -->
+              <includes>
+                <include>org/cactoos/bytes/*.class</include>
+                <include>org/cactoos/map/*.class</include>
+              </includes>
             </configuration>
             <executions>
               <execution>

--- a/src/test/java/org/cactoos/map/BehavesAsMap.java
+++ b/src/test/java/org/cactoos/map/BehavesAsMap.java
@@ -26,8 +26,11 @@ package org.cactoos.map;
 import java.util.Map;
 import org.hamcrest.Description;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.collection.IsMapContaining;
+import org.hamcrest.core.IsAnything;
+import org.hamcrest.core.IsCollectionContaining;
+import org.hamcrest.core.IsEqual;
 
 /**
  * Matcher for collection.
@@ -61,10 +64,32 @@ public final class BehavesAsMap<K, V> extends TypeSafeMatcher<Map<K, V>>  {
 
     @Override
     public boolean matchesSafely(final Map<K, V> map) {
-        MatcherAssert.assertThat(map, Matchers.hasKey(this.key));
-        MatcherAssert.assertThat(map, Matchers.hasValue(this.value));
-        MatcherAssert.assertThat(map.keySet(), Matchers.hasItem(this.key));
-        MatcherAssert.assertThat(map.values(), Matchers.hasItem(this.value));
+        MatcherAssert.assertThat(
+            "Doesn't contain the key",
+            map,
+            new IsMapContaining<>(
+                new IsEqual<>(this.key),
+                new IsAnything<>()
+            )
+        );
+        MatcherAssert.assertThat(
+            "Doesn't contain the value",
+            map,
+            new IsMapContaining<>(
+                new IsAnything<>(),
+                new IsEqual<>(this.value)
+            )
+        );
+        MatcherAssert.assertThat(
+            "Doesn't contain the key in #keySet()",
+            map.keySet(),
+            new IsCollectionContaining<>(new IsEqual<>(this.key))
+        );
+        MatcherAssert.assertThat(
+            "Doesn't contain the value in #values()",
+            map.values(),
+            new IsCollectionContaining<>(new IsEqual<>(this.value))
+        );
         return true;
     }
 

--- a/src/test/java/org/cactoos/map/ClearDeletesAllValues.java
+++ b/src/test/java/org/cactoos/map/ClearDeletesAllValues.java
@@ -26,8 +26,8 @@ package org.cactoos.map;
 import java.util.Map;
 import org.hamcrest.Description;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.core.IsEqual;
 
 /**
  * Check a clear method.
@@ -43,7 +43,8 @@ public final class ClearDeletesAllValues<K, V> extends
     public boolean matchesSafely(final Map<K, V> map) {
         map.clear();
         MatcherAssert.assertThat(
-            map.isEmpty(), Matchers.is(true)
+            "Can't be cleared",
+            map.isEmpty(), new IsEqual<>(true)
         );
         return true;
     }

--- a/src/test/java/org/cactoos/map/GroupedTest.java
+++ b/src/test/java/org/cactoos/map/GroupedTest.java
@@ -27,7 +27,7 @@ import java.util.HashSet;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.collection.IsMapContaining;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 
@@ -77,9 +77,9 @@ public final class GroupedTest {
                 number -> number,
                 Object::toString
             ),
-            Matchers.hasEntry(
-                1,
-                new ListOf<>("1", "1", "1")
+            new IsMapContaining<>(
+                new IsEqual<>(1),
+                new IsEqual<>(new ListOf<>("1", "1", "1"))
             )
         );
     }

--- a/src/test/java/org/cactoos/map/MapEntryTest.java
+++ b/src/test/java/org/cactoos/map/MapEntryTest.java
@@ -24,7 +24,6 @@
 package org.cactoos.map;
 
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 
@@ -43,7 +42,7 @@ public final class MapEntryTest {
         MatcherAssert.assertThat(
             "Can't get key in the map entry",
             new MapEntry<>(key, value).getKey(),
-            Matchers.equalTo(key)
+            new IsEqual<>(key)
         );
     }
 
@@ -54,7 +53,7 @@ public final class MapEntryTest {
         MatcherAssert.assertThat(
             "Can't get value in the map entry",
             new MapEntry<>(key, value).getValue(),
-            Matchers.equalTo(value)
+            new IsEqual<>(value)
         );
     }
 
@@ -70,7 +69,7 @@ public final class MapEntryTest {
         MatcherAssert.assertThat(
             "MapEntries are not equals",
             new MapEntry<>(key, value).equals(new MapEntry<>(key, value)),
-            Matchers.equalTo(true)
+            new IsEqual<>(true)
         );
     }
 
@@ -80,7 +79,7 @@ public final class MapEntryTest {
             "the hash code are not equals",
             new MapEntry<>("elegant", "objects").hashCode(),
             // @checkstyle MagicNumber (1 line)
-            Matchers.equalTo(32739498)
+            new IsEqual<>(32739498)
         );
     }
 

--- a/src/test/java/org/cactoos/map/MapEnvelopeTest.java
+++ b/src/test/java/org/cactoos/map/MapEnvelopeTest.java
@@ -26,7 +26,6 @@ package org.cactoos.map;
 import java.util.Map;
 import org.cactoos.func.FuncOf;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNot;
 import org.junit.Rule;
@@ -142,7 +141,7 @@ public final class MapEnvelopeTest {
             new MapNoNulls<>(
                 new MapOf<Integer, Integer>()
             ).isEmpty(),
-            Matchers.is(true)
+            new IsEqual<>(true)
         );
     }
 
@@ -155,7 +154,7 @@ public final class MapEnvelopeTest {
                     new MapEntry<>(1, 0)
                 )
             ).isEmpty(),
-            Matchers.is(false)
+            new IsEqual<>(false)
         );
     }
 
@@ -168,7 +167,7 @@ public final class MapEnvelopeTest {
                     new MapEntry<>(1, 0)
                 )
             ).containsKey(1),
-            Matchers.is(true)
+            new IsEqual<>(true)
         );
     }
 
@@ -181,7 +180,7 @@ public final class MapEnvelopeTest {
                     new MapEntry<>(1, 0)
                 )
             ).containsKey(0),
-            Matchers.is(false)
+            new IsEqual<>(false)
         );
     }
 
@@ -194,7 +193,7 @@ public final class MapEnvelopeTest {
                     new MapEntry<>(1, 0)
                 )
             ).containsValue(0),
-            Matchers.is(true)
+            new IsEqual<>(true)
         );
     }
 
@@ -207,7 +206,7 @@ public final class MapEnvelopeTest {
                     new MapEntry<>(1, 0)
                 )
             ).containsValue(1),
-            Matchers.is(false)
+            new IsEqual<>(false)
         );
     }
 

--- a/src/test/java/org/cactoos/map/MapNoNullsTest.java
+++ b/src/test/java/org/cactoos/map/MapNoNullsTest.java
@@ -24,8 +24,10 @@
 package org.cactoos.map;
 
 import java.util.HashMap;
+import org.cactoos.iterable.IterableOf;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.collection.IsMapContaining;
+import org.hamcrest.core.AllOf;
 import org.hamcrest.core.IsEqual;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -349,6 +351,7 @@ public final class MapNoNullsTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void entrySet() {
         MatcherAssert.assertThat(
             "Can't call #entrySet()",
@@ -360,9 +363,11 @@ public final class MapNoNullsTest {
                     }
                 }
             ),
-            Matchers.allOf(
-                Matchers.hasEntry(1, 1),
-                Matchers.hasEntry(0, 0)
+            new AllOf<>(
+                new IterableOf<>(
+                    new IsMapContaining<>(new IsEqual<>(1), new IsEqual<>(1)),
+                    new IsMapContaining<>(new IsEqual<>(0), new IsEqual<>(0))
+                )
             )
         );
     }

--- a/src/test/java/org/cactoos/map/MapOfTest.java
+++ b/src/test/java/org/cactoos/map/MapOfTest.java
@@ -32,7 +32,12 @@ import org.cactoos.func.FuncOf;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterator.Repeated;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.collection.IsMapContaining;
+import org.hamcrest.core.AllOf;
+import org.hamcrest.core.IsAnything;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
+import org.hamcrest.core.StringStartsWith;
 import org.junit.Test;
 
 /**
@@ -66,9 +71,9 @@ public final class MapOfTest {
                 new MapEntry<>(0, "hello, "),
                 new MapEntry<>(1, "world!")
             ),
-            Matchers.hasEntry(
-                Matchers.equalTo(0),
-                Matchers.startsWith("hello")
+            new IsMapContaining<>(
+                new IsEqual<>(0),
+                new StringStartsWith("hello")
             )
         );
     }
@@ -87,7 +92,7 @@ public final class MapOfTest {
         MatcherAssert.assertThat(
             "Can't sense the changes in the underlying map",
             map.size(),
-            Matchers.not(Matchers.equalTo(map.size()))
+            new IsNot<>(new IsEqual<>(map.size()))
         );
     }
 
@@ -104,7 +109,7 @@ public final class MapOfTest {
                     }
                 )
             ),
-            Matchers.hasKey(0)
+            new IsMapContaining<>(new IsEqual<>(0), new IsAnything<>())
         );
     }
 
@@ -116,7 +121,7 @@ public final class MapOfTest {
                 new MapEntry<>(-1, 0),
                 new MapEntry<>(1, 2)
             ).toString(),
-            Matchers.equalTo("{-1=0, 1=2}")
+            new IsEqual<>("{-1=0, 1=2}")
         );
     }
 
@@ -140,7 +145,7 @@ public final class MapOfTest {
                     )
                 )
             ).toString(),
-            Matchers.equalTo("{-1={4=7, first=second}, 1={green=red, 2.7=3.1}}")
+            new IsEqual<>("{-1={4=7, first=second}, 1={green=red, 2.7=3.1}}")
         );
     }
 
@@ -149,11 +154,12 @@ public final class MapOfTest {
         MatcherAssert.assertThat(
             "Can't convert empty map to string",
             new MapOf<Integer, Map<String, String>>().toString(),
-            Matchers.equalTo("{}")
+            new IsEqual<>("{}")
         );
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void createsMapFromMapAndMapEntries() {
         MatcherAssert.assertThat(
             "Can't create a map from map and map entries",
@@ -163,9 +169,11 @@ public final class MapOfTest {
                 ),
                 new MapEntry<Integer, Integer>(1, 1)
             ),
-            Matchers.allOf(
-                Matchers.hasEntry(0, 0),
-                Matchers.hasEntry(1, 1)
+            new AllOf<>(
+                new IterableOf<>(
+                    new IsMapContaining<>(new IsEqual<>(0), new IsEqual<>(0)),
+                    new IsMapContaining<>(new IsEqual<>(1), new IsEqual<>(1))
+                )
             )
         );
     }
@@ -179,11 +187,12 @@ public final class MapOfTest {
                 new FuncOf<Integer, Integer>(0),
                 new IterableOf<Integer>(0)
             ),
-            Matchers.hasEntry(0, 0)
+            new IsMapContaining<>(new IsEqual<>(0), new IsEqual<>(0))
         );
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void createsMapFromMapFunctionsAndIterable() {
         MatcherAssert.assertThat(
             "Can't create a map from map, functions and iterable.",
@@ -195,9 +204,11 @@ public final class MapOfTest {
                 ),
                 new IterableOf<>(0)
             ),
-            Matchers.allOf(
-                Matchers.hasEntry(0, 0),
-                Matchers.hasEntry(1, 1)
+            new AllOf<>(
+                new IterableOf<>(
+                    new IsMapContaining<>(new IsEqual<>(0), new IsEqual<>(0)),
+                    new IsMapContaining<>(new IsEqual<>(1), new IsEqual<>(1))
+                )
             )
         );
     }

--- a/src/test/java/org/cactoos/map/PutAllUpdatesValues.java
+++ b/src/test/java/org/cactoos/map/PutAllUpdatesValues.java
@@ -26,7 +26,6 @@ package org.cactoos.map;
 import java.util.Map;
 import org.hamcrest.Description;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
 
 /**
@@ -67,10 +66,11 @@ public final class PutAllUpdatesValues<K, V> extends
                 new MapEntry<>(this.key, this.value)
             )
         );
-        MatcherAssert.assertThat(map, Matchers.hasKey(this.key));
-        MatcherAssert.assertThat(map, Matchers.hasValue(this.value));
-        MatcherAssert.assertThat(map.keySet(), Matchers.hasItem(this.key));
-        MatcherAssert.assertThat(map.values(), Matchers.hasItem(this.value));
+        MatcherAssert.assertThat(
+            "Can't behave as a map after putAll",
+            map,
+            new BehavesAsMap<K, V>(this.key, this.value)
+        );
         return true;
     }
 

--- a/src/test/java/org/cactoos/map/PutUpdatesValues.java
+++ b/src/test/java/org/cactoos/map/PutUpdatesValues.java
@@ -26,7 +26,6 @@ package org.cactoos.map;
 import java.util.Map;
 import org.hamcrest.Description;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
 
 /**
@@ -63,10 +62,11 @@ public final class PutUpdatesValues<K, V> extends
     @Override
     public boolean matchesSafely(final Map<K, V> map) {
         map.put(this.key, this.value);
-        MatcherAssert.assertThat(map, Matchers.hasKey(this.key));
-        MatcherAssert.assertThat(map, Matchers.hasValue(this.value));
-        MatcherAssert.assertThat(map.keySet(), Matchers.hasItem(this.key));
-        MatcherAssert.assertThat(map.values(), Matchers.hasItem(this.value));
+        MatcherAssert.assertThat(
+            "Can't behave as a map after put",
+            map,
+            new BehavesAsMap<K, V>(this.key, this.value)
+        );
         return true;
     }
 

--- a/src/test/java/org/cactoos/map/RemoveDeletesValues.java
+++ b/src/test/java/org/cactoos/map/RemoveDeletesValues.java
@@ -26,8 +26,11 @@ package org.cactoos.map;
 import java.util.Map;
 import org.hamcrest.Description;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.collection.IsMapContaining;
+import org.hamcrest.core.IsCollectionContaining;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
 
 /**
  * Check a remove method.
@@ -64,20 +67,28 @@ public final class RemoveDeletesValues<K, V> extends
     public boolean matchesSafely(final Map<K, V> map) {
         map.remove(this.key);
         MatcherAssert.assertThat(
+            "Contains the key/value after remove",
             map,
-            Matchers.not(Matchers.hasKey(this.key))
+            new IsNot<>(
+                new IsMapContaining<>(
+                    new IsEqual<>(this.key),
+                    new IsEqual<>(this.value)
+                )
+            )
         );
         MatcherAssert.assertThat(
-            map,
-            Matchers.not(Matchers.hasValue(this.value))
-        );
-        MatcherAssert.assertThat(
+            "Contains the key in #keySet() after remove",
             map.keySet(),
-            Matchers.not(Matchers.hasItem(this.key))
+            new IsNot<>(
+                new IsCollectionContaining<>(new IsEqual<>(this.key))
+            )
         );
         MatcherAssert.assertThat(
+            "Contains the value in #values() after remove",
             map.values(),
-            Matchers.not(Matchers.hasItem(this.value))
+            new IsNot<>(
+                new IsCollectionContaining<>(new IsEqual<>(this.value))
+            )
         );
         return true;
     }

--- a/src/test/java/org/cactoos/map/SolidMapTest.java
+++ b/src/test/java/org/cactoos/map/SolidMapTest.java
@@ -30,7 +30,9 @@ import org.cactoos.text.SubText;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UpperText;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.collection.IsMapContaining;
+import org.hamcrest.core.AllOf;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 import org.llorllale.cactoos.matchers.MatcherOf;
 import org.llorllale.cactoos.matchers.RunsInThreads;
@@ -62,7 +64,11 @@ public final class SolidMapTest {
         MatcherAssert.assertThat(
             "Can't behave as a map in multiple threads",
             map -> {
-                MatcherAssert.assertThat(map, new BehavesAsMap<>(0, 1));
+                MatcherAssert.assertThat(
+                    "Can't behave as a map in thread",
+                    map,
+                    new BehavesAsMap<>(0, 1)
+                );
                 return true;
             },
             new RunsInThreads<>(
@@ -82,7 +88,7 @@ public final class SolidMapTest {
         );
         MatcherAssert.assertThat(
             "Can't map only once",
-            map.get(0), Matchers.equalTo(map.get(0))
+            map.get(0), new IsEqual<>(map.get(0))
         );
     }
 
@@ -100,7 +106,7 @@ public final class SolidMapTest {
                 new MapEntry<>(2, 12),
                 new MapEntry<>(3, 13)
             ).size(),
-            Matchers.equalTo(4)
+            new IsEqual<>(4)
         );
     }
 
@@ -109,18 +115,19 @@ public final class SolidMapTest {
     public void acceptsEmptyArray() {
         MatcherAssert.assertThat(
             "Accepts empty array of entries",
-            new SolidMap<>(
+            new SolidMap<Integer, Integer>(
                 new SolidMap<>(
                     new MapEntry<>(0, 10),
                     new MapEntry<>(1, 11)
                 ),
                 (Map.Entry<Integer, Integer>[]) new Map.Entry<?, ?>[0]
             ).size(),
-            Matchers.equalTo(2)
+            new IsEqual<>(2)
         );
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void mapsIterableWithKeyFuncAndValueFunc() {
         final SolidMap<String, String> map = new SolidMap<>(
             key -> new SubText(new TextOf(key), 0, 1).asString(),
@@ -130,16 +137,18 @@ public final class SolidMapTest {
         MatcherAssert.assertThat(
             "Functions are not applied to key and value",
             map,
-            Matchers.allOf(
-                Matchers.hasEntry(
-                    Matchers.equalTo("a"),
-                    Matchers.equalTo("AA")
-                ),
-                Matchers.hasEntry(
-                    Matchers.equalTo("b"),
-                    Matchers.equalTo("BB")
-                ),
-                new MatcherOf<>(m -> m.size() == 2)
+            new AllOf<>(
+                new IterableOf<>(
+                    new IsMapContaining<>(
+                        new IsEqual<>("a"),
+                        new IsEqual<>("AA")
+                    ),
+                    new IsMapContaining<>(
+                        new IsEqual<>("b"),
+                        new IsEqual<>("BB")
+                    ),
+                    new MatcherOf<>(m -> m.size() == 2)
+                )
             )
         );
     }
@@ -159,6 +168,7 @@ public final class SolidMapTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void mapsIterableWithMapEntryFunc() {
         MatcherAssert.assertThat(
             "Function are not applied to entry",
@@ -169,16 +179,18 @@ public final class SolidMapTest {
                 ),
                 new IterableOf<>("aa", "bb")
             ),
-            Matchers.allOf(
-                Matchers.hasEntry(
-                    Matchers.equalTo("a"),
-                    Matchers.equalTo("AA")
-                ),
-                Matchers.hasEntry(
-                    Matchers.equalTo("b"),
-                    Matchers.equalTo("BB")
-                ),
-                new MatcherOf<>(m -> m.size() == 2)
+            new AllOf<>(
+                new IterableOf<>(
+                    new IsMapContaining<>(
+                        new IsEqual<>("a"),
+                        new IsEqual<>("AA")
+                    ),
+                    new IsMapContaining<>(
+                        new IsEqual<>("b"),
+                        new IsEqual<>("BB")
+                    ),
+                    new MatcherOf<>(m -> m.size() == 2)
+                )
             )
         );
     }

--- a/src/test/java/org/cactoos/map/StickyMapTest.java
+++ b/src/test/java/org/cactoos/map/StickyMapTest.java
@@ -31,7 +31,10 @@ import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterator.Repeated;
 import org.cactoos.text.FormattedText;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.collection.IsMapContaining;
+import org.hamcrest.core.IsAnything;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.StringEndsWith;
 import org.junit.Test;
 
 /**
@@ -72,7 +75,7 @@ public final class StickyMapTest {
         MatcherAssert.assertThat(
             "Can't ignore the changes in the underlying map",
             map.size(),
-            Matchers.equalTo(map.size())
+            new IsEqual<>(map.size())
         );
     }
 
@@ -84,7 +87,10 @@ public final class StickyMapTest {
                 new MapEntry<>("first", "Jeffrey"),
                 new MapEntry<>("last", "Lebowski")
             ),
-            Matchers.hasValue(Matchers.endsWith("ski"))
+            new IsMapContaining<>(
+                new IsAnything<>(),
+                new StringEndsWith("ski")
+            )
         );
     }
 
@@ -100,7 +106,10 @@ public final class StickyMapTest {
                 new MapEntry<>("year", "2017"),
                 new MapEntry<>("mileage", "12,000")
             ),
-            Matchers.hasValue(Matchers.endsWith(",000"))
+            new IsMapContaining<>(
+                new IsAnything<>(),
+                new StringEndsWith(",000")
+            )
         );
     }
 
@@ -118,7 +127,10 @@ public final class StickyMapTest {
                 ),
                 new IterableOf<>("yellow", "red", "blue")
             ),
-            Matchers.hasValue(Matchers.equalTo("BLUE"))
+            new IsMapContaining<>(
+                new IsAnything<>(),
+                new IsEqual<>("BLUE")
+            )
         );
     }
 
@@ -135,7 +147,10 @@ public final class StickyMapTest {
                 ),
                 new IterableOf<>("yellow!", "red!", "blue!")
             ),
-            Matchers.hasValue(Matchers.equalTo("BLUE!"))
+            new IsMapContaining<>(
+                new IsAnything<>(),
+                new IsEqual<>("BLUE!")
+            )
         );
     }
 }

--- a/src/test/java/org/cactoos/map/SyncMapTest.java
+++ b/src/test/java/org/cactoos/map/SyncMapTest.java
@@ -53,7 +53,11 @@ public final class SyncMapTest {
         MatcherAssert.assertThat(
             "Can't behave as a map in multiple threads",
             map -> {
-                MatcherAssert.assertThat(map, new BehavesAsMap<>(0, 1));
+                MatcherAssert.assertThat(
+                    "Can't behave as a map in thread",
+                    map,
+                    new BehavesAsMap<>(0, 1)
+                );
                 return true;
             },
             new RunsInThreads<>(


### PR DESCRIPTION
This is for #903.

I continued the work on migrating to OO matchers by doing the whole `map` package.

I also enabled the forbidden apis maven plugin only for this package and `bytes` (that was done for #588) so that we don't regress with time.

I updated the `@todo` so that work can continue.