### PR TITLE
For #942: Fixed `TextEnvelope.equals()` misbehavior.

### DIFF
--- a/src/main/java/org/cactoos/text/TextEnvelope.java
+++ b/src/main/java/org/cactoos/text/TextEnvelope.java
@@ -74,9 +74,9 @@ public abstract class TextEnvelope implements Text {
     }
 
     // @todo #942:30min Refactor TextEnvelope.equals(). Current implementation
-    // of TextEnvelope.equals() uses some things that we must avoid, like more
-    // than one return on method, instance of usage and typecasting. Refactor
-    // this method so we can get rid of these smelly things.
+    //  of TextEnvelope.equals() uses some things that we must avoid, like more
+    //  than one return on method, instance of usage and typecasting. Refactor
+    //  this method so we can get rid of these smelly things.
     //
     @Override
     @SuppressWarnings("PMD.OnlyOneReturn")
@@ -84,10 +84,10 @@ public abstract class TextEnvelope implements Text {
         if (this == obj) {
             return true;
         }
-        if (!(obj instanceof TextEnvelope)) {
+        if (!(obj instanceof Text)) {
             return false;
         }
-        final TextEnvelope that = (TextEnvelope) obj;
+        final Text that = (Text) obj;
         return new UncheckedText(this).asString().equals(
             new UncheckedText(that).asString()
         );

--- a/src/main/java/org/cactoos/text/TextEnvelope.java
+++ b/src/main/java/org/cactoos/text/TextEnvelope.java
@@ -73,8 +73,23 @@ public abstract class TextEnvelope implements Text {
         return new UncheckedScalar<>(this.origin).value().hashCode();
     }
 
+    // @todo #942:30min Refactor TextEnvelope.equals(). Current implementation
+    // of TextEnvelope.equals() uses some things that we must avoid, like more
+    // than one return on method, instance of usage and typecasting. Refactor
+    // this method so we can get rid of these smelly things.
+    //
     @Override
+    @SuppressWarnings("PMD.OnlyOneReturn")
     public final boolean equals(final Object obj) {
-        return new UncheckedScalar<>(this.origin).value().equals(obj);
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof TextEnvelope)) {
+            return false;
+        }
+        final TextEnvelope that = (TextEnvelope) obj;
+        return new UncheckedText(this).asString().equals(
+            new UncheckedText(that).asString()
+        );
     }
 }

--- a/src/test/java/org/cactoos/text/TextEnvelopeTest.java
+++ b/src/test/java/org/cactoos/text/TextEnvelopeTest.java
@@ -51,15 +51,32 @@ public final class TextEnvelopeTest {
     }
     /**
      * Test for {@link TextEnvelope#equals(Object)} method. Must assert
-     * that the envelope value is equal to its string value.
+     * that the envelope value is equal another text representing the same
+     * value.
      */
     @Test
     public void testEquals() {
         final String text = "equals";
         MatcherAssert.assertThat(
-            "Envelope value does not match its represented String value",
+            "Envelope does not match text representing the same value",
             new TextEnvelopeDummy(text),
-            new IsEqual<>(text)
+            new IsEqual<>(new TextOf(text))
+        );
+    }
+
+    /**
+     * Test for {@link TextEnvelope#equals(Object)} method. Must assert
+     * that the envelope value is equal another text representing the same
+     * value (in this case a {@link JoinedText}).
+     */
+    @Test
+    public void testEqualsOtherText() {
+        MatcherAssert.assertThat(
+            "Envelope does not match another text representing the same value",
+            new TextEnvelopeDummy("isequaltoanothertext"),
+            new IsEqual<>(
+                new JoinedText("", "is", "equal", "to", "another", "text")
+            )
         );
     }
     /**


### PR DESCRIPTION
For #942:
- Fixed `TextEnvelope.equals()` misbehavior;
- Fixed `TextEnvelopeTests` tests regarding `TextEnvelope.equals()`;
- Added puzzle for refactoring and making code more elegant.