### PR TITLE
 #953 - add gradle dependency info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,19 @@ These are the [design principles](http://www.elegantobjects.org#principles) behi
 The library has no dependencies. All you need is this
 (get the latest version [here](https://github.com/yegor256/cactoos/releases)):
 
+Maven:
 ```xml
 <dependency>
   <groupId>org.cactoos</groupId>
   <artifactId>cactoos</artifactId>
 </dependency>
+```
+
+Gradle:
+```groovy
+dependencies {
+    compile 'org.cactoos:cactoos:<version>'
+}
 ```
 
 Java version required: 1.8+.


### PR DESCRIPTION
Related issue #953 

/cc @llorllale @yegor256 

How it looks:
![screen shot 2018-09-26 at 12 11 22](https://user-images.githubusercontent.com/11976836/46073490-51ae7900-c185-11e8-9f24-64c5f201f8e2.png)
