### PR TITLE
# 955 Refactor text envelope equals

### DIFF
--- a/src/main/java/org/cactoos/text/TextEnvelope.java
+++ b/src/main/java/org/cactoos/text/TextEnvelope.java
@@ -26,7 +26,9 @@ package org.cactoos.text;
 import java.io.IOException;
 import org.cactoos.Scalar;
 import org.cactoos.Text;
+import org.cactoos.scalar.And;
 import org.cactoos.scalar.IoCheckedScalar;
+import org.cactoos.scalar.Or;
 import org.cactoos.scalar.UncheckedScalar;
 
 /**
@@ -73,23 +75,18 @@ public abstract class TextEnvelope implements Text {
         return new UncheckedScalar<>(this.origin).value().hashCode();
     }
 
-    // @todo #942:30min Refactor TextEnvelope.equals(). Current implementation
-    //  of TextEnvelope.equals() uses some things that we must avoid, like more
-    //  than one return on method, instance of usage and typecasting. Refactor
-    //  this method so we can get rid of these smelly things.
-    //
     @Override
-    @SuppressWarnings("PMD.OnlyOneReturn")
     public final boolean equals(final Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (!(obj instanceof Text)) {
-            return false;
-        }
-        final Text that = (Text) obj;
-        return new UncheckedText(this).asString().equals(
-            new UncheckedText(that).asString()
-        );
+        return new UncheckedScalar<>(
+            new Or(
+                () -> this == obj,
+                new And(
+                    () -> obj instanceof Text,
+                    () -> new UncheckedText(this)
+                        .asString()
+                        .equals(new UncheckedText((Text) obj).asString())
+                )
+            )
+        ).value();
     }
 }

--- a/src/test/java/org/cactoos/text/TextEnvelopeTest.java
+++ b/src/test/java/org/cactoos/text/TextEnvelopeTest.java
@@ -28,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import org.cactoos.Scalar;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
 import org.junit.Test;
 
 /**
@@ -79,6 +80,38 @@ public final class TextEnvelopeTest {
             )
         );
     }
+
+    /**
+     * Test for {@link TextEnvelope#equals(Object)} method. Must assert
+     * that the envelope value is not equal another object not being a
+     * instance of Text without failing
+     */
+    @Test
+    public void testDoesNotEqualsNonTextObject() {
+        MatcherAssert.assertThat(
+            "Envelope does not match another object which is not a string",
+            new TextEnvelopeDummy("is not equals to null"),
+            new IsNot<>(
+                new IsEqual<>(new Object())
+            )
+        );
+    }
+
+    /**
+     * Test for {@link TextEnvelope#equals(Object)} method. Must assert
+     * that the envelope value is not equal to null without failing
+     */
+    @Test
+    @SuppressWarnings("PMD.EqualsNull")
+    public void testDoesNotEqualsFalse() {
+        MatcherAssert.assertThat(
+            "Envelope does not equals null",
+            new TextEnvelopeDummy("is not equals to not Text object")
+                .equals(null),
+            new IsEqual<>(false)
+        );
+    }
+
     /**
      * Test for {@link TextEnvelope#hashCode()} method. Must assert that
      * the {@link TextEnvelope} hashCode is equals to the hashCode of


### PR DESCRIPTION
I did not handle null in the equals method because it wasn't handle before. I am new to this project and to this way of coding, even if I road your two books, I am a bit disoriented.

I am a bit puzzle by the fact your linter does not accept variable namedLikeThat, would be happy to know why ?

Because previous code handle equals with object not being an instance of Text but there were no test, I added one.

About my Javadoc, I know it's not good, but I am not used to Javadoc my method especially when there are private (I think I name them and type them in a way they often don't need Javadoc).

Also, do you have a suggestion for a plugin for IDEA to run all your linter simply?
