### PR TITLE
#852: Fix the NoNulls classes API inconsistency

### DIFF
--- a/src/main/java/org/cactoos/Func.java
+++ b/src/main/java/org/cactoos/Func.java
@@ -63,7 +63,7 @@ public interface Func<X, Y> {
      * @param <Y> Type of output
      * @since 0.10
      * @todo #852:30min Move NoNulls implementations of Func, BiFunc, Proc, and
-     *  BiProc to their own packages in order to provide the NoNulls classes API
+     *  BiProc to their own classes in order to provide the NoNulls classes API
      *  consistency.
      */
     final class NoNulls<X, Y> implements Func<X, Y> {

--- a/src/main/java/org/cactoos/Func.java
+++ b/src/main/java/org/cactoos/Func.java
@@ -62,6 +62,9 @@ public interface Func<X, Y> {
      * @param <X> Type of input
      * @param <Y> Type of output
      * @since 0.10
+     * @todo #852:30min Move NoNulls implementations of Func, BiFunc, Proc, and
+     *  BiProc to their own packages in order to provide the NoNulls classes API
+     *  consistency.
      */
     final class NoNulls<X, Y> implements Func<X, Y> {
         /**

--- a/src/main/java/org/cactoos/Input.java
+++ b/src/main/java/org/cactoos/Input.java
@@ -59,6 +59,9 @@ public interface Input {
      * Input check for no nulls.
      *
      * @since 0.10
+     * @todo #852:30min Move NoNulls implementations of Input, Output, and Bytes
+     *  to their own packages in order to provide the NoNulls classes API
+     *  consistency.
      */
     final class NoNulls implements Input {
         /**

--- a/src/main/java/org/cactoos/Input.java
+++ b/src/main/java/org/cactoos/Input.java
@@ -60,7 +60,7 @@ public interface Input {
      *
      * @since 0.10
      * @todo #852:30min Move NoNulls implementations of Input, Output, and Bytes
-     *  to their own packages in order to provide the NoNulls classes API
+     *  to their own classes in order to provide the NoNulls classes API
      *  consistency.
      */
     final class NoNulls implements Input {

--- a/src/main/java/org/cactoos/Scalar.java
+++ b/src/main/java/org/cactoos/Scalar.java
@@ -56,39 +56,4 @@ public interface Scalar<T> {
      */
     T value() throws Exception;
 
-    /**
-     * Scalar check for no nulls.
-     *
-     * @param <T> Type of result
-     * @since 0.11
-     */
-    final class NoNulls<T> implements Scalar<T> {
-        /**
-         * The scalar.
-         */
-        private final Scalar<T> origin;
-        /**
-         * Ctor.
-         * @param sclr The scalar
-         */
-        public NoNulls(final Scalar<T> sclr) {
-            this.origin = sclr;
-        }
-        @Override
-        public T value() throws Exception {
-            if (this.origin == null) {
-                throw new IllegalArgumentException(
-                    "NULL instead of a valid scalar"
-                );
-            }
-            final T value = this.origin.value();
-            if (value == null) {
-                throw new IllegalStateException(
-                    "NULL instead of a valid value"
-                );
-            }
-            return value;
-        }
-    }
-
 }

--- a/src/main/java/org/cactoos/Text.java
+++ b/src/main/java/org/cactoos/Text.java
@@ -43,42 +43,4 @@ public interface Text {
      * @throws Exception If fails
      */
     String asString() throws Exception;
-
-    /**
-     * Text check for no nulls.
-     *
-     * <p>There is no thread-safety guarantee.
-     *
-     * @since 0.11
-     */
-    final class NoNulls implements Text {
-        /**
-         * The origin text.
-         */
-        private final Text origin;
-
-        /**
-         * Ctor.
-         * @param text The text
-         */
-        public NoNulls(final Text text) {
-            this.origin = text;
-        }
-
-        @Override
-        public String asString() throws Exception {
-            if (this.origin == null) {
-                throw new IllegalArgumentException(
-                    "NULL instead of a valid text"
-                );
-            }
-            final String string = this.origin.asString();
-            if (string == null) {
-                throw new IllegalStateException(
-                    "NULL instead of a valid result string"
-                );
-            }
-            return string;
-        }
-    }
 }

--- a/src/main/java/org/cactoos/collection/CollectionNoNulls.java
+++ b/src/main/java/org/cactoos/collection/CollectionNoNulls.java
@@ -26,7 +26,6 @@ package org.cactoos.collection;
 import org.cactoos.iterator.IteratorNoNulls;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.UncheckedText;
-
 import java.util.Collection;
 import java.util.Iterator;
 

--- a/src/main/java/org/cactoos/collection/CollectionNoNulls.java
+++ b/src/main/java/org/cactoos/collection/CollectionNoNulls.java
@@ -23,11 +23,11 @@
  */
 package org.cactoos.collection;
 
+import java.util.Collection;
+import java.util.Iterator;
 import org.cactoos.iterator.IteratorNoNulls;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.UncheckedText;
-import java.util.Collection;
-import java.util.Iterator;
 
 /**
  * A decorator of {@link Collection} that tolerates no NULLs.

--- a/src/main/java/org/cactoos/collection/CollectionNoNulls.java
+++ b/src/main/java/org/cactoos/collection/CollectionNoNulls.java
@@ -23,11 +23,12 @@
  */
 package org.cactoos.collection;
 
-import java.util.Collection;
-import java.util.Iterator;
 import org.cactoos.iterator.IteratorNoNulls;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.UncheckedText;
+
+import java.util.Collection;
+import java.util.Iterator;
 
 /**
  * A decorator of {@link Collection} that tolerates no NULLs.
@@ -38,7 +39,7 @@ import org.cactoos.text.UncheckedText;
  * @since 0.27
  * @todo #852:30min Rename XxxNoNulls implementations of Collection and Iterator
  *  to NoNulls to avoid the compound names. They should be present in their own
- *  packages in order to provide the NoNulls classes API consistency.
+ *  classes in order to provide the NoNulls classes API consistency.
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public final class CollectionNoNulls<X> implements Collection<X> {

--- a/src/main/java/org/cactoos/collection/CollectionNoNulls.java
+++ b/src/main/java/org/cactoos/collection/CollectionNoNulls.java
@@ -36,6 +36,9 @@ import org.cactoos.text.UncheckedText;
  *
  * @param <X> Element type
  * @since 0.27
+ * @todo #852:30min Rename XxxNoNulls implementations of Collection and Iterator
+ *  to NoNulls to avoid the compound names. They should be present in their own
+ *  packages in order to provide the NoNulls classes API consistency.
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public final class CollectionNoNulls<X> implements Collection<X> {

--- a/src/main/java/org/cactoos/iterable/Solid.java
+++ b/src/main/java/org/cactoos/iterable/Solid.java
@@ -23,7 +23,7 @@
  */
 package org.cactoos.iterable;
 
-import org.cactoos.Scalar;
+import org.cactoos.scalar.NoNulls;
 import org.cactoos.scalar.SolidScalar;
 
 /**
@@ -51,9 +51,9 @@ public final class Solid<X> extends IterableEnvelope<X> {
      */
     public Solid(final Iterable<X> iterable) {
         super(
-            new Scalar.NoNulls<Iterable<X>>(
-                new SolidScalar<Iterable<X>>(
-                    () -> new Synced<X>(new Sticky<>(iterable))
+            new NoNulls<>(
+                new SolidScalar<>(
+                    () -> new Synced<>(new Sticky<>(iterable))
                 )
             )
         );

--- a/src/main/java/org/cactoos/scalar/NoNulls.java
+++ b/src/main/java/org/cactoos/scalar/NoNulls.java
@@ -21,43 +21,41 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.cactoos;
+package org.cactoos.scalar;
 
-import org.cactoos.text.NoNulls;
-import org.cactoos.text.TextOf;
-import org.hamcrest.MatcherAssert;
-import org.junit.Test;
-import org.llorllale.cactoos.matchers.TextHasString;
+import org.cactoos.Scalar;
 
 /**
- * Test case for {@link Text}.
+ * Scalar check for no nulls.
+ *
+ * @param <T> Type of result
  * @since 0.11
- * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class TextTest {
-
-    @Test(expected = IllegalArgumentException.class)
-    public void failForNullArgument() throws Exception {
-        new NoNulls(null).asString();
+public final class NoNulls<T> implements Scalar<T> {
+    /**
+     * The scalar.
+     */
+    private final Scalar<T> origin;
+    /**
+     * Ctor.
+     * @param sclr The scalar
+     */
+    public NoNulls(final Scalar<T> sclr) {
+        this.origin = sclr;
     }
-
-    @Test(expected = IllegalStateException.class)
-    public void failForNullResult() throws Exception {
-        new NoNulls(
-            () -> null
-        ).asString();
+    @Override
+    public T value() throws Exception {
+        if (this.origin == null) {
+            throw new IllegalArgumentException(
+                "NULL instead of a valid scalar"
+            );
+        }
+        final T value = this.origin.value();
+        if (value == null) {
+            throw new IllegalStateException(
+                "NULL instead of a valid value"
+            );
+        }
+        return value;
     }
-
-    @Test
-    public void okForNoNulls() {
-        final String message = "Hello";
-        MatcherAssert.assertThat(
-            "Can't work with null text",
-            new NoNulls(
-                new TextOf(message)
-            ),
-            new TextHasString(message)
-        );
-    }
-
 }

--- a/src/main/java/org/cactoos/text/NoNulls.java
+++ b/src/main/java/org/cactoos/text/NoNulls.java
@@ -21,43 +21,44 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.cactoos;
+package org.cactoos.text;
 
-import org.cactoos.text.NoNulls;
-import org.cactoos.text.TextOf;
-import org.hamcrest.MatcherAssert;
-import org.junit.Test;
-import org.llorllale.cactoos.matchers.TextHasString;
+import org.cactoos.Text;
 
 /**
- * Test case for {@link Text}.
+ * Text check for no nulls.
+ *
+ * <p>There is no thread-safety guarantee.
+ *
  * @since 0.11
- * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class TextTest {
+public final class NoNulls implements Text {
+    /**
+     * The origin text.
+     */
+    private final Text origin;
 
-    @Test(expected = IllegalArgumentException.class)
-    public void failForNullArgument() throws Exception {
-        new NoNulls(null).asString();
+    /**
+     * Ctor.
+     * @param text The text
+     */
+    public NoNulls(final Text text) {
+        this.origin = text;
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void failForNullResult() throws Exception {
-        new NoNulls(
-            () -> null
-        ).asString();
+    @Override
+    public String asString() throws Exception {
+        if (this.origin == null) {
+            throw new IllegalArgumentException(
+                "NULL instead of a valid text"
+            );
+        }
+        final String string = this.origin.asString();
+        if (string == null) {
+            throw new IllegalStateException(
+                "NULL instead of a valid result string"
+            );
+        }
+        return string;
     }
-
-    @Test
-    public void okForNoNulls() {
-        final String message = "Hello";
-        MatcherAssert.assertThat(
-            "Can't work with null text",
-            new NoNulls(
-                new TextOf(message)
-            ),
-            new TextHasString(message)
-        );
-    }
-
 }

--- a/src/test/java/org/cactoos/ScalarTest.java
+++ b/src/test/java/org/cactoos/ScalarTest.java
@@ -24,7 +24,9 @@
 package org.cactoos;
 
 import org.cactoos.scalar.NoNulls;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 /**
  * Test case for {@link NoNulls}.
@@ -33,13 +35,23 @@ import org.junit.Test;
  */
 public final class ScalarTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    /**
+     * A rule for handling an exception.
+     */
+    @Rule
+    public final ExpectedException cause = ExpectedException.none();
+
+    @Test
     public void failForNullArgument() throws Exception {
+        this.cause.expect(IllegalArgumentException.class);
+        this.cause.expectMessage("NULL instead of a valid scalar");
         new NoNulls<>(null).value();
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void failForNullResult() throws Exception {
+        this.cause.expect(IllegalStateException.class);
+        this.cause.expectMessage("NULL instead of a valid value");
         new NoNulls<>(() -> null).value();
     }
 

--- a/src/test/java/org/cactoos/ScalarTest.java
+++ b/src/test/java/org/cactoos/ScalarTest.java
@@ -23,10 +23,11 @@
  */
 package org.cactoos;
 
+import org.cactoos.scalar.NoNulls;
 import org.junit.Test;
 
 /**
- * Test case for {@link Scalar.NoNulls}.
+ * Test case for {@link NoNulls}.
  * @since 0.11
  * @checkstyle JavadocMethodCheck (500 lines)
  */
@@ -34,16 +35,16 @@ public final class ScalarTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void failForNullArgument() throws Exception {
-        new Scalar.NoNulls<>(null).value();
+        new NoNulls<>(null).value();
     }
 
     @Test(expected = IllegalStateException.class)
     public void failForNullResult() throws Exception {
-        new Scalar.NoNulls<>(() -> null).value();
+        new NoNulls<>(() -> null).value();
     }
 
     @Test
     public void okForNoNulls() throws Exception {
-        new Scalar.NoNulls<>(() -> 1).value();
+        new NoNulls<>(() -> 1).value();
     }
 }

--- a/src/test/java/org/cactoos/TextTest.java
+++ b/src/test/java/org/cactoos/TextTest.java
@@ -26,7 +26,9 @@ package org.cactoos;
 import org.cactoos.text.NoNulls;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.llorllale.cactoos.matchers.TextHasString;
 
 /**
@@ -36,13 +38,23 @@ import org.llorllale.cactoos.matchers.TextHasString;
  */
 public final class TextTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    /**
+     * A rule for handling an exception.
+     */
+    @Rule
+    public final ExpectedException cause = ExpectedException.none();
+
+    @Test
     public void failForNullArgument() throws Exception {
+        this.cause.expect(IllegalArgumentException.class);
+        this.cause.expectMessage("NULL instead of a valid text");
         new NoNulls(null).asString();
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void failForNullResult() throws Exception {
+        this.cause.expect(IllegalStateException.class);
+        this.cause.expectMessage("NULL instead of a valid result string");
         new NoNulls(
             () -> null
         ).asString();


### PR DESCRIPTION
This PR for #852 contains:
 - 1 todo task for modification of Bytes, Input, Output
 - 1 todo task for modification of Collection, Iterator (all others implementation of collections are already fixed)
 - 1 todo task for modification of Proc, Func, BiFunc, BiProc
 - Moved NoNulls for Scalar and Text, with fixes for their unit-tests and usage