### PR TITLE
#980 Avoid compound names for packages with scalar, set, text, and time

### DIFF
--- a/src/main/java/org/cactoos/package-info.java
+++ b/src/main/java/org/cactoos/package-info.java
@@ -35,9 +35,5 @@
  * @since 0.1
  * @see <a href="http://www.cactoos.org">Project site www.cactoos.org</a>
  * @see <a href="https://github.com/yegor256/cactoos">GitHub repository</a>
- * @todo #964:30min Continue applying the new class naming convention in effect:
- *  avoid compound names for decorators. Continue renaming classes according to
- *  this table: https://github.com/yegor256/cactoos/issues/913#issuecomment-402332247.
- *  Remaining packages are scalar, set, text, and time.
  */
 package org.cactoos;

--- a/src/main/java/org/cactoos/scalar/package-info.java
+++ b/src/main/java/org/cactoos/scalar/package-info.java
@@ -26,5 +26,9 @@
  * Scalars.
  *
  * @since 0.12
+ * @todo #980:30min Continue applying the new class naming convention in effect:
+ *  avoid compound names for decorators. Continue renaming classes implementing
+ *  the {@link org.cactoos.Scalar}. More details you can find here
+ *  https://github.com/yegor256/cactoos/issues/913#issuecomment-402332247.
  */
 package org.cactoos.scalar;

--- a/src/main/java/org/cactoos/set/package-info.java
+++ b/src/main/java/org/cactoos/set/package-info.java
@@ -26,5 +26,9 @@
  * Sets.
  *
  * @since 0.49.2
+ * @todo #980:30min Continue applying the new class naming convention in effect:
+ *  avoid compound names for decorators. Continue renaming classes implementing
+ *  the {@link java.util.Set}. More details you can find here
+ *  https://github.com/yegor256/cactoos/issues/913#issuecomment-402332247.
  */
 package org.cactoos.set;

--- a/src/main/java/org/cactoos/text/Abbreviated.java
+++ b/src/main/java/org/cactoos/text/Abbreviated.java
@@ -35,7 +35,7 @@ import org.cactoos.Text;
  *  TextEnvelope - asString() should be removed and implementation from
  *  TextEnvelope should be used.
  */
-public final class AbbreviatedText implements Text {
+public final class Abbreviated implements Text {
 
     /**
      * The default max line width.
@@ -64,7 +64,7 @@ public final class AbbreviatedText implements Text {
      *
      * @param text The Text
      */
-    public AbbreviatedText(final String text) {
+    public Abbreviated(final String text) {
         this(new TextOf(text));
     }
 
@@ -75,8 +75,8 @@ public final class AbbreviatedText implements Text {
      *
      * @param text The Text
      */
-    public AbbreviatedText(final Text text) {
-        this(text, AbbreviatedText.MAX_WIDTH);
+    public Abbreviated(final Text text) {
+        this(text, Abbreviated.MAX_WIDTH);
     }
 
     /**
@@ -85,7 +85,7 @@ public final class AbbreviatedText implements Text {
      * @param text A String
      * @param max Max width of the result string
      */
-    public AbbreviatedText(final String text, final int max) {
+    public Abbreviated(final String text, final int max) {
         this(new TextOf(text), max);
     }
 
@@ -94,7 +94,7 @@ public final class AbbreviatedText implements Text {
      * @param text The Text
      * @param max Max width of the result string
      */
-    public AbbreviatedText(final Text text, final int max) {
+    public Abbreviated(final Text text, final int max) {
         this.origin = text;
         this.width = max;
     }
@@ -110,7 +110,7 @@ public final class AbbreviatedText implements Text {
                 new SubText(
                     this.origin,
                     0,
-                    this.width - AbbreviatedText.ELLIPSES_WIDTH
+                    this.width - Abbreviated.ELLIPSES_WIDTH
                 ).asString()
             );
         }

--- a/src/main/java/org/cactoos/text/Base64Text.java
+++ b/src/main/java/org/cactoos/text/Base64Text.java
@@ -31,6 +31,9 @@ import org.cactoos.io.BytesOf;
 /**
  * Decodes the origin text using the Base64 encoding scheme.
  * @since 0.20.2
+ * @todo #980:30min Define new name for Base64Text and TextBase64 in order to
+ *  avoid compound names. These classes are using for decode/encode text using
+ *  the radix-64 representation.
  */
 public final class Base64Text extends TextEnvelope {
 

--- a/src/main/java/org/cactoos/text/Sync.java
+++ b/src/main/java/org/cactoos/text/Sync.java
@@ -32,7 +32,7 @@ import org.cactoos.Text;
  *
  * @since 0.18
  */
-public final class SyncText implements Text {
+public final class Sync implements Text {
 
     /**
      * The text.
@@ -48,7 +48,7 @@ public final class SyncText implements Text {
      * Ctor.
      * @param text The text
      */
-    public SyncText(final Text text) {
+    public Sync(final Text text) {
         this(text, text);
     }
 
@@ -57,7 +57,7 @@ public final class SyncText implements Text {
      * @param text The text
      * @param lck The lock
      */
-    public SyncText(final Text text, final Object lck) {
+    public Sync(final Text text, final Object lck) {
         this.origin = text;
         this.lock = lck;
     }

--- a/src/main/java/org/cactoos/text/Synced.java
+++ b/src/main/java/org/cactoos/text/Synced.java
@@ -32,7 +32,7 @@ import org.cactoos.Text;
  *
  * @since 0.18
  */
-public final class Sync implements Text {
+public final class Synced implements Text {
 
     /**
      * The text.
@@ -48,7 +48,7 @@ public final class Sync implements Text {
      * Ctor.
      * @param text The text
      */
-    public Sync(final Text text) {
+    public Synced(final Text text) {
         this(text, text);
     }
 
@@ -57,7 +57,7 @@ public final class Sync implements Text {
      * @param text The text
      * @param lck The lock
      */
-    public Sync(final Text text, final Object lck) {
+    public Synced(final Text text, final Object lck) {
         this.origin = text;
         this.lock = lck;
     }

--- a/src/main/java/org/cactoos/text/package-info.java
+++ b/src/main/java/org/cactoos/text/package-info.java
@@ -26,5 +26,9 @@
  * Text.
  *
  * @since 0.1
+ * @todo #980:30min Continue applying the new class naming convention in effect:
+ *  avoid compound names for decorators. Continue renaming classes implementing
+ *  the {@link org.cactoos.Text}. More details you can find here
+ *  https://github.com/yegor256/cactoos/issues/913#issuecomment-402332247.
  */
 package org.cactoos.text;

--- a/src/main/java/org/cactoos/time/package-info.java
+++ b/src/main/java/org/cactoos/time/package-info.java
@@ -26,5 +26,9 @@
  * Time.
  *
  * @since 1.0
+ * @todo #980:30min Classes from package {@link org.cactoos.time} which are
+ *  ending with `AsText` are extending TextEnvelope. It means that they are
+ *  instances of {@link org.cactoos.Text}. They should be merged with
+ *  {@link org.cactoos.text.TextOf} as ctor(s).
  */
 package org.cactoos.time;

--- a/src/test/java/org/cactoos/text/AbbreviatedTest.java
+++ b/src/test/java/org/cactoos/text/AbbreviatedTest.java
@@ -28,12 +28,12 @@ import org.junit.Test;
 import org.llorllale.cactoos.matchers.TextHasString;
 
 /**
- * Test case for {@link AbbreviatedText}.
+ * Test case for {@link Abbreviated}.
  * @since 0.29
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 @SuppressWarnings("PMD.TooManyMethods")
-public final class AbbreviatedTextTest {
+public final class AbbreviatedTest {
 
     @Test
     public void abbreviatesAnEmptyText() {
@@ -41,7 +41,7 @@ public final class AbbreviatedTextTest {
         MatcherAssert.assertThat(
             "Can't abbreviate an msg text",
             // @checkstyle MagicNumber (1 line)
-            new AbbreviatedText(msg, 8),
+            new Abbreviated(msg, 8),
             new TextHasString(msg)
         );
     }
@@ -51,7 +51,7 @@ public final class AbbreviatedTextTest {
         MatcherAssert.assertThat(
             "Can't abbreviate a text",
             // @checkstyle MagicNumber (1 line)
-            new AbbreviatedText("hello world", 8),
+            new Abbreviated("hello world", 8),
             new TextHasString("hello...")
         );
     }
@@ -61,7 +61,7 @@ public final class AbbreviatedTextTest {
         MatcherAssert.assertThat(
             "Can't abbreviate a text one char smaller",
             // @checkstyle MagicNumber (1 line)
-            new AbbreviatedText("oo programming", 10),
+            new Abbreviated("oo programming", 10),
             new TextHasString("oo prog...")
         );
     }
@@ -72,7 +72,7 @@ public final class AbbreviatedTextTest {
         MatcherAssert.assertThat(
             "Can't abbreviate a text with same length",
             // @checkstyle MagicNumber (1 line)
-            new AbbreviatedText(msg, 15),
+            new Abbreviated(msg, 15),
             new TextHasString(msg)
         );
     }
@@ -83,7 +83,7 @@ public final class AbbreviatedTextTest {
         MatcherAssert.assertThat(
             "Can't abbreviate a text one char bigger",
             // @checkstyle MagicNumber (1 line)
-            new AbbreviatedText(msg, 17),
+            new Abbreviated(msg, 17),
             new TextHasString(msg)
         );
     }
@@ -94,7 +94,7 @@ public final class AbbreviatedTextTest {
         MatcherAssert.assertThat(
             "Can't abbreviate a text two chars bigger",
             // @checkstyle MagicNumber (1 line)
-            new AbbreviatedText(msg, 15),
+            new Abbreviated(msg, 15),
             new TextHasString(msg)
         );
     }
@@ -105,7 +105,7 @@ public final class AbbreviatedTextTest {
         MatcherAssert.assertThat(
             "Can't abbreviate a text with width bigger than length",
             // @checkstyle MagicNumber (1 line)
-            new AbbreviatedText(msg, 50),
+            new Abbreviated(msg, 50),
             new TextHasString(msg)
         );
     }
@@ -115,7 +115,7 @@ public final class AbbreviatedTextTest {
         // @checkstyle LineLengthCheck (10 line)
         MatcherAssert.assertThat(
             "Can't abbreviate a text bigger than default max width",
-            new AbbreviatedText(
+            new Abbreviated(
                 "The quick brown fox jumps over the lazy black dog and after that returned to the cave"
             ),
             new TextHasString(

--- a/src/test/java/org/cactoos/text/TextOfTest.java
+++ b/src/test/java/org/cactoos/text/TextOfTest.java
@@ -49,7 +49,7 @@ public final class TextOfTest {
     public void readsInputIntoText() throws Exception {
         MatcherAssert.assertThat(
             "Can't read text from Input",
-            new Sync(
+            new Synced(
                 new TextOf(
                     new InputOf("привет, друг!"),
                     StandardCharsets.UTF_8

--- a/src/test/java/org/cactoos/text/TextOfTest.java
+++ b/src/test/java/org/cactoos/text/TextOfTest.java
@@ -49,7 +49,7 @@ public final class TextOfTest {
     public void readsInputIntoText() throws Exception {
         MatcherAssert.assertThat(
             "Can't read text from Input",
-            new SyncText(
+            new Sync(
                 new TextOf(
                     new InputOf("привет, друг!"),
                     StandardCharsets.UTF_8


### PR DESCRIPTION
This PR for #980  contains:
 - 1 todo task for the renaming of Text(s)
 - 1 todo task for the renaming of Scalar(s)
 - 1 todo task for the renaming of Set(s)
 - 1 todo task for the renaming of `org.cactoos.time` classes
 - Renaming of few Text implementations