### PR TITLE
(#997) Fixed rultor merge build missing 'pip' command

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -10,6 +10,7 @@ env:
 install: |
   sudo gem install --no-rdoc --no-ri pdd
   sudo gem install --no-rdoc --no-ri xcop
+  sudo apt install -y python-pip
   sudo pip install gitlint
 architect:
 - llorllale


### PR DESCRIPTION
This PR fixes #997:
* Now installing the `python-pip` package (containing the `pip` command) before installing `gitlint` using `pip`