### PR TITLE
#911 remove ctors with Iterator parameters from map and scalar packages

### DIFF
--- a/src/main/java/org/cactoos/list/package-info.java
+++ b/src/main/java/org/cactoos/list/package-info.java
@@ -26,5 +26,12 @@
  * Lists, tests.
  *
  * @since 0.14
+ * @todo #911:30min Continue remove ctors with Iterator parameters.
+ *  Need to remove ctors with Iterator parameters (and substitute
+ *  them with ctors with Iterable parameters) in list package.
+ *  This changes will make it necessary to correct the tests
+ *  for ListEnvelope children classes
  */
 package org.cactoos.list;
+
+

--- a/src/main/java/org/cactoos/list/package-info.java
+++ b/src/main/java/org/cactoos/list/package-info.java
@@ -33,5 +33,3 @@
  *  for ListEnvelope children classes
  */
 package org.cactoos.list;
-
-

--- a/src/main/java/org/cactoos/map/Solid.java
+++ b/src/main/java/org/cactoos/map/Solid.java
@@ -23,7 +23,6 @@
  */
 package org.cactoos.map;
 
-import java.util.Iterator;
 import java.util.Map;
 import org.cactoos.Func;
 import org.cactoos.iterable.IterableOf;
@@ -132,14 +131,6 @@ public final class Solid<X, Y> extends MapEnvelope<X, Y> {
      */
     public Solid(final Iterable<Map.Entry<X, Y>> list) {
         this(new MapOf<>(list));
-    }
-
-    /**
-     * Ctor.
-     * @param list Entries for the entries
-     */
-    public Solid(final Iterator<Map.Entry<X, Y>> list) {
-        this(() -> list);
     }
 
     /**

--- a/src/main/java/org/cactoos/map/Sticky.java
+++ b/src/main/java/org/cactoos/map/Sticky.java
@@ -25,7 +25,6 @@ package org.cactoos.map;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import org.cactoos.Func;
 import org.cactoos.iterable.IterableOf;
@@ -141,15 +140,6 @@ public final class Sticky<X, Y> extends MapEnvelope<X, Y> {
      */
     public Sticky(final Iterable<Map.Entry<X, Y>> list) {
         this(new MapOf<>(list));
-    }
-
-    /**
-     * Ctor.
-     * @param list Entries for the entries
-     * @since 0.21
-     */
-    public Sticky(final Iterator<Map.Entry<X, Y>> list) {
-        this(() -> list);
     }
 
     /**

--- a/src/main/java/org/cactoos/map/Synced.java
+++ b/src/main/java/org/cactoos/map/Synced.java
@@ -23,7 +23,6 @@
  */
 package org.cactoos.map;
 
-import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.cactoos.Func;
@@ -134,14 +133,6 @@ public final class Synced<X, Y> extends MapEnvelope<X, Y> {
      */
     public Synced(final Iterable<Map.Entry<X, Y>> list) {
         this(new MapOf<>(list));
-    }
-
-    /**
-     * Ctor.
-     * @param list Entries for the entries
-     */
-    public Synced(final Iterator<Map.Entry<X, Y>> list) {
-        this(() -> list);
     }
 
     /**

--- a/src/main/java/org/cactoos/scalar/And.java
+++ b/src/main/java/org/cactoos/scalar/And.java
@@ -23,7 +23,6 @@
  */
 package org.cactoos.scalar;
 
-import java.util.Iterator;
 import org.cactoos.Func;
 import org.cactoos.Proc;
 import org.cactoos.Scalar;
@@ -110,17 +109,6 @@ public final class And implements Scalar<Boolean> {
 
     /**
      * Ctor.
-     * @param src The iterator
-     * @param proc Proc to use
-     * @param <X> Type of items in the iterator
-     * @since 0.34
-     */
-    public <X> And(final Proc<X> proc, final Iterator<X> src) {
-        this(proc, new IterableOf<>(src));
-    }
-
-    /**
-     * Ctor.
      * @param src The iterable
      * @param proc Proc to use
      * @param <X> Type of items in the iterable
@@ -128,17 +116,6 @@ public final class And implements Scalar<Boolean> {
      */
     public <X> And(final Proc<X> proc, final Iterable<X> src) {
         this(new FuncOf<>(proc, true), src);
-    }
-
-    /**
-     * Ctor.
-     * @param src The iterator
-     * @param func Func to map
-     * @param <X> Type of items in the iterator
-     * @since 0.34
-     */
-    public <X> And(final Func<X, Boolean> func, final Iterator<X> src) {
-        this(func, new IterableOf<>(src));
     }
 
     /**
@@ -180,15 +157,6 @@ public final class And implements Scalar<Boolean> {
     @SafeVarargs
     public And(final Scalar<Boolean>... scalar) {
         this(new IterableOf<>(scalar));
-    }
-
-    /**
-     * Ctor.
-     * @param iterator The iterator.
-     * @since 0.34
-     */
-    public And(final Iterator<Scalar<Boolean>> iterator) {
-        this(new IterableOf<>(iterator));
     }
 
     /**

--- a/src/main/java/org/cactoos/scalar/AndWithIndex.java
+++ b/src/main/java/org/cactoos/scalar/AndWithIndex.java
@@ -23,7 +23,6 @@
  */
 package org.cactoos.scalar;
 
-import java.util.Iterator;
 import org.cactoos.BiFunc;
 import org.cactoos.BiProc;
 import org.cactoos.Func;

--- a/src/main/java/org/cactoos/scalar/AndWithIndex.java
+++ b/src/main/java/org/cactoos/scalar/AndWithIndex.java
@@ -133,15 +133,6 @@ public final class AndWithIndex implements Scalar<Boolean> {
 
     /**
      * Ctor.
-     * @param src The iterator
-     * @since 0.24
-     */
-    public AndWithIndex(final Iterator<Func<Integer, Boolean>> src) {
-        this(new IterableOf<>(src));
-    }
-
-    /**
-     * Ctor.
      * @param src The iterable
      */
     public AndWithIndex(final Iterable<Func<Integer, Boolean>> src) {

--- a/src/main/java/org/cactoos/scalar/LengthOf.java
+++ b/src/main/java/org/cactoos/scalar/LengthOf.java
@@ -45,15 +45,6 @@ public final class LengthOf extends NumberEnvelope {
 
     /**
      * Ctor.
-     * @param items The iterator
-     * @param <T> The type of items
-     */
-    public <T> LengthOf(final Iterator<T> items) {
-        this(() -> items);
-    }
-
-    /**
-     * Ctor.
      * @param items The array
      * @param <T> The type of items
      */

--- a/src/main/java/org/cactoos/scalar/Or.java
+++ b/src/main/java/org/cactoos/scalar/Or.java
@@ -133,17 +133,6 @@ public final class Or implements Scalar<Boolean> {
      * @param src The iterable
      * @param func Func to map
      * @param <X> Type of items in the iterable
-     * @since 0.24
-     */
-    public <X> Or(final Func<X, Boolean> func, final Iterator<X> src) {
-        this(func, new IterableOf<>(src));
-    }
-
-    /**
-     * Ctor.
-     * @param src The iterable
-     * @param func Func to map
-     * @param <X> Type of items in the iterable
      */
     public <X> Or(final Func<X, Boolean> func, final Iterable<X> src) {
         this(
@@ -176,15 +165,6 @@ public final class Or implements Scalar<Boolean> {
     @SafeVarargs
     public Or(final Scalar<Boolean>... scalar) {
         this(new IterableOf<>(scalar));
-    }
-
-    /**
-     * Ctor.
-     * @param iterator The iterator.
-     * @since 0.24
-     */
-    public Or(final Iterator<Scalar<Boolean>> iterator) {
-        this(new IterableOf<>(iterator));
     }
 
     /**

--- a/src/test/java/org/cactoos/iterator/HeadOfTest.java
+++ b/src/test/java/org/cactoos/iterator/HeadOfTest.java
@@ -60,11 +60,13 @@ public final class HeadOfTest {
     public void returnsIntactIterator() throws Exception {
         MatcherAssert.assertThat(
             new LengthOf(
-                new HeadOf<>(
-                    3,
-                    new IterableOf<>(
-                        "one", "two"
-                    ).iterator()
+                new IterableOf<> (
+                    new HeadOf<>(
+                        3,
+                        new IterableOf<>(
+                            "one", "two"
+                        ).iterator()
+                    )
                 )
             ).intValue(),
             Matchers.equalTo(2)

--- a/src/test/java/org/cactoos/iterator/HeadOfTest.java
+++ b/src/test/java/org/cactoos/iterator/HeadOfTest.java
@@ -60,7 +60,7 @@ public final class HeadOfTest {
     public void returnsIntactIterator() throws Exception {
         MatcherAssert.assertThat(
             new LengthOf(
-                new IterableOf<> (
+                new IterableOf<>(
                     new HeadOf<>(
                         3,
                         new IterableOf<>(

--- a/src/test/java/org/cactoos/iterator/JoinedTest.java
+++ b/src/test/java/org/cactoos/iterator/JoinedTest.java
@@ -25,6 +25,8 @@ package org.cactoos.iterator;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+
+import org.cactoos.iterable.IterableOf;
 import org.cactoos.scalar.LengthOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -32,8 +34,9 @@ import org.junit.Test;
 
 /**
  * Test case for {@link Joined}.
- * @since 0.14
+ *
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @since 0.14
  */
 public final class JoinedTest {
 
@@ -42,11 +45,13 @@ public final class JoinedTest {
         MatcherAssert.assertThat(
             "Can't concatenate mapped iterators together",
             new LengthOf(
-                new IteratorNoNulls<>(
-                    new Joined<Iterator<String>>(
-                        new Mapped<>(
-                            input -> new IteratorOf<>(input),
-                            new IteratorOf<>("x")
+                new IterableOf<>(
+                    new IteratorNoNulls<>(
+                        new Joined<Iterator<String>>(
+                            new Mapped<>(
+                                input -> new IteratorOf<>(input),
+                                new IteratorOf<>("x")
+                            )
                         )
                     )
                 )

--- a/src/test/java/org/cactoos/iterator/JoinedTest.java
+++ b/src/test/java/org/cactoos/iterator/JoinedTest.java
@@ -25,7 +25,6 @@ package org.cactoos.iterator;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.scalar.LengthOf;
 import org.hamcrest.MatcherAssert;
@@ -35,8 +34,8 @@ import org.junit.Test;
 /**
  * Test case for {@link Joined}.
  *
- * @checkstyle JavadocMethodCheck (500 lines)
  * @since 0.14
+ * @checkstyle JavadocMethodCheck (500 lines)
  */
 public final class JoinedTest {
 

--- a/src/test/java/org/cactoos/iterator/PartitionedTest.java
+++ b/src/test/java/org/cactoos/iterator/PartitionedTest.java
@@ -26,7 +26,6 @@ package org.cactoos.iterator;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.NoSuchElementException;
-
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.list.ListOf;
 import org.cactoos.scalar.LengthOf;
@@ -37,9 +36,9 @@ import org.junit.Test;
 /**
  * Test case for {@link Partitioned}.
  *
+ * @since 0.29
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle MagicNumber (500 lines)
- * @since 0.29
  */
 public final class PartitionedTest {
 

--- a/src/test/java/org/cactoos/iterator/PartitionedTest.java
+++ b/src/test/java/org/cactoos/iterator/PartitionedTest.java
@@ -26,6 +26,8 @@ package org.cactoos.iterator;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.NoSuchElementException;
+
+import org.cactoos.iterable.IterableOf;
 import org.cactoos.list.ListOf;
 import org.cactoos.scalar.LengthOf;
 import org.hamcrest.MatcherAssert;
@@ -35,9 +37,9 @@ import org.junit.Test;
 /**
  * Test case for {@link Partitioned}.
  *
- * @since 0.29
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle MagicNumber (500 lines)
+ * @since 0.29
  */
 public final class PartitionedTest {
 
@@ -46,7 +48,9 @@ public final class PartitionedTest {
         MatcherAssert.assertThat(
             "Can't generate an empty Partitioned.",
             new LengthOf(
-                new Partitioned<>(1, Collections.emptyIterator())
+                new IterableOf<>(
+                    new Partitioned<>(1, Collections.emptyIterator())
+                )
             ).intValue(),
             Matchers.equalTo(0)
         );

--- a/src/test/java/org/cactoos/iterator/RepeatedTest.java
+++ b/src/test/java/org/cactoos/iterator/RepeatedTest.java
@@ -23,6 +23,7 @@
  */
 package org.cactoos.iterator;
 
+import org.cactoos.iterable.IterableOf;
 import org.cactoos.scalar.LengthOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -31,8 +32,8 @@ import org.junit.Test;
 /**
  * Test case for {@link Repeated}.
  *
- * @since 0.4
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @since 0.4
  */
 public final class RepeatedTest {
 
@@ -43,8 +44,10 @@ public final class RepeatedTest {
         MatcherAssert.assertThat(
             "Can't generate an iterable with fixed size",
             new LengthOf(
-                new Repeated<>(
-                    size, element
+                new IterableOf<>(
+                    new Repeated<>(
+                        size, element
+                    )
                 )
             ).intValue(),
             Matchers.equalTo(size)

--- a/src/test/java/org/cactoos/iterator/RepeatedTest.java
+++ b/src/test/java/org/cactoos/iterator/RepeatedTest.java
@@ -32,8 +32,8 @@ import org.junit.Test;
 /**
  * Test case for {@link Repeated}.
  *
- * @checkstyle JavadocMethodCheck (500 lines)
  * @since 0.4
+ * @checkstyle JavadocMethodCheck (500 lines)
  */
 public final class RepeatedTest {
 

--- a/src/test/java/org/cactoos/iterator/TailOfTest.java
+++ b/src/test/java/org/cactoos/iterator/TailOfTest.java
@@ -60,11 +60,13 @@ public final class TailOfTest {
     public void returnsIntactIterator() throws Exception {
         MatcherAssert.assertThat(
             new LengthOf(
-                new TailOf<>(
-                    3,
-                    new IterableOf<>(
-                        "one", "two"
-                    ).iterator()
+                new IterableOf<>(
+                    new TailOf<>(
+                        3,
+                        new IterableOf<>(
+                            "one", "two"
+                        ).iterator()
+                    )
                 )
             ).intValue(),
             Matchers.equalTo(2)

--- a/src/test/java/org/cactoos/scalar/AndTest.java
+++ b/src/test/java/org/cactoos/scalar/AndTest.java
@@ -82,14 +82,6 @@ public final class AndTest {
     }
 
     @Test
-    public void emptyIterator() throws Exception {
-        MatcherAssert.assertThat(
-            new And(new IteratorOf<Scalar<Boolean>>()),
-            new ScalarHasValue<>(true)
-        );
-    }
-
-    @Test
     public void testProcIterable() throws Exception {
         final List<Integer> list = new LinkedList<>();
         new And(
@@ -102,18 +94,6 @@ public final class AndTest {
         );
     }
 
-    @Test
-    public void testProcIterator() throws Exception {
-        final List<Integer> list = new LinkedList<>();
-        new And(
-            (Proc<Integer>) list::add,
-            new IteratorOf<>(1, 1)
-        ).value();
-        MatcherAssert.assertThat(
-            list,
-            Matchers.contains(1, 1)
-        );
-    }
 
     @Test
     public void testProcVarargs() throws Exception {
@@ -139,16 +119,6 @@ public final class AndTest {
         );
     }
 
-    @Test
-    public void testFuncIterator() throws Exception {
-        MatcherAssert.assertThat(
-            new And(
-                input -> input > 0,
-                new IteratorOf<>(1, -1, 0)
-            ),
-            new ScalarHasValue<>(false)
-        );
-    }
 
     @Test
     public void testFuncVarargs() throws Exception {

--- a/src/test/java/org/cactoos/scalar/AndTest.java
+++ b/src/test/java/org/cactoos/scalar/AndTest.java
@@ -28,7 +28,6 @@ import java.util.List;
 import org.cactoos.Proc;
 import org.cactoos.Scalar;
 import org.cactoos.iterable.IterableOf;
-import org.cactoos.iterator.IteratorOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -94,7 +93,6 @@ public final class AndTest {
         );
     }
 
-
     @Test
     public void testProcVarargs() throws Exception {
         final List<Integer> list = new LinkedList<>();
@@ -118,8 +116,6 @@ public final class AndTest {
             new ScalarHasValue<>(false)
         );
     }
-
-
     @Test
     public void testFuncVarargs() throws Exception {
         MatcherAssert.assertThat(

--- a/src/test/java/org/cactoos/scalar/LengthOfTest.java
+++ b/src/test/java/org/cactoos/scalar/LengthOfTest.java
@@ -34,9 +34,9 @@ import org.junit.Test;
 /**
  * Test case for {@link LengthOf}.
  *
- * @since 0.1.0
  * @checkstyle MagicNumberCheck (500 lines)
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @since 0.1.0
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public final class LengthOfTest {
@@ -147,7 +147,9 @@ public final class LengthOfTest {
         MatcherAssert.assertThat(
             "Can't calculate length of iterator for integer",
             new LengthOf(
-                new ListOf<>(1, 2, 3, 4).iterator()
+                new IterableOf<>(
+                    new ListOf<>(1, 2, 3, 4)
+                )
             ).intValue(),
             Matchers.equalTo(4)
         );
@@ -158,7 +160,9 @@ public final class LengthOfTest {
         MatcherAssert.assertThat(
             "Can't calculate length of iterator for double",
             new LengthOf(
-                new ListOf<>(1, 2, 3, 4).iterator()
+                new IterableOf<>(
+                    new ListOf<>(1, 2, 3, 4)
+                )
             ).doubleValue(),
             Matchers.equalTo(4.0)
         );
@@ -169,20 +173,11 @@ public final class LengthOfTest {
         MatcherAssert.assertThat(
             "Can't calculate length of iterator for float",
             new LengthOf(
-                new ListOf<>(1, 2, 3, 4).iterator()
+                new IterableOf<>(
+                    new ListOf<>(1, 2, 3, 4)
+                )
             ).floatValue(),
             Matchers.equalTo(4.0f)
-        );
-    }
-
-    @Test
-    public void lengthOfEmptyIterator() {
-        MatcherAssert.assertThat(
-            "Can't calculate length of empty iterator",
-            new LengthOf(
-                new ListOf<>().iterator()
-            ).intValue(),
-            Matchers.equalTo(0)
         );
     }
 }

--- a/src/test/java/org/cactoos/scalar/OrTest.java
+++ b/src/test/java/org/cactoos/scalar/OrTest.java
@@ -89,14 +89,6 @@ public final class OrTest {
     }
 
     @Test
-    public void emptyIterator() throws Exception {
-        MatcherAssert.assertThat(
-            new Or(new IteratorOf<Scalar<Boolean>>()),
-            new ScalarHasValue<>(false)
-        );
-    }
-
-    @Test
     public void testProcIterable() throws Exception {
         final List<Integer> list = new LinkedList<>();
         new Or(
@@ -141,17 +133,6 @@ public final class OrTest {
             new Or(
                 input -> input > 0,
                 new IterableOf<>(-1, 1, 0)
-            ),
-            new ScalarHasValue<>(true)
-        );
-    }
-
-    @Test
-    public void testFuncIterator() throws Exception {
-        MatcherAssert.assertThat(
-            new Or(
-                input -> input > 0,
-                new IteratorOf<>(-1, 1, 0)
             ),
             new ScalarHasValue<>(true)
         );


### PR DESCRIPTION
This PR:

- removes ctors with Iterator params from map pakage
- removes ctors with Iterator params from scalar pakage
- fixes test affected with first and second changes
- leaves TODO in order to continue task in list package