### PR TITLE
A non-serializable value is stored into a non-transient field

### DIFF
--- a/src/main/java/org/cactoos/Scalar.java
+++ b/src/main/java/org/cactoos/Scalar.java
@@ -23,6 +23,7 @@
  */
 package org.cactoos;
 
+import java.io.Serializable;
 import org.cactoos.scalar.IoCheckedScalar;
 import org.cactoos.scalar.StickyScalar;
 import org.cactoos.scalar.UncheckedScalar;
@@ -47,7 +48,7 @@ import org.cactoos.scalar.UncheckedScalar;
  * @see IoCheckedScalar
  * @since 0.1
  */
-public interface Scalar<T> {
+public interface Scalar<T> extends Serializable {
 
     /**
      * Convert it to the value.
@@ -63,6 +64,7 @@ public interface Scalar<T> {
      * @since 0.11
      */
     final class NoNulls<T> implements Scalar<T> {
+        private static final long serialVersionUID = -1222477011113790856L;
         /**
          * The scalar.
          */

--- a/src/main/java/org/cactoos/io/TempFile.java
+++ b/src/main/java/org/cactoos/io/TempFile.java
@@ -50,6 +50,7 @@ import org.cactoos.text.TextOf;
  * @since 1.0
  */
 public final class TempFile implements Scalar<Path>, Closeable {
+    private static final long serialVersionUID = -3598132867953052765L;
     /**
      * Creates the temporary file, returning its path.
      */

--- a/src/main/java/org/cactoos/scalar/And.java
+++ b/src/main/java/org/cactoos/scalar/And.java
@@ -81,6 +81,7 @@ import org.cactoos.iterable.Mapped;
  */
 public final class And implements Scalar<Boolean> {
 
+    private static final long serialVersionUID = -9179136181397095585L;
     /**
      * The iterator.
      */

--- a/src/main/java/org/cactoos/scalar/AndInThreads.java
+++ b/src/main/java/org/cactoos/scalar/AndInThreads.java
@@ -56,6 +56,7 @@ import org.cactoos.text.FormattedText;
  */
 public final class AndInThreads implements Scalar<Boolean> {
 
+    private static final long serialVersionUID = -2441733307904191408L;
     /**
      * The service.
      */

--- a/src/main/java/org/cactoos/scalar/AndWithIndex.java
+++ b/src/main/java/org/cactoos/scalar/AndWithIndex.java
@@ -65,6 +65,7 @@ import org.cactoos.iterable.Mapped;
  */
 public final class AndWithIndex implements Scalar<Boolean> {
 
+    private static final long serialVersionUID = 311733366547201721L;
     /**
      * The iterator.
      */

--- a/src/main/java/org/cactoos/scalar/BoolOf.java
+++ b/src/main/java/org/cactoos/scalar/BoolOf.java
@@ -42,6 +42,7 @@ import org.cactoos.text.TextOf;
  */
 public final class BoolOf implements Scalar<Boolean> {
 
+    private static final long serialVersionUID = -554166749686477820L;
     /**
      * Source text.
      */

--- a/src/main/java/org/cactoos/scalar/CheckedScalar.java
+++ b/src/main/java/org/cactoos/scalar/CheckedScalar.java
@@ -41,6 +41,7 @@ import org.cactoos.text.UncheckedText;
  */
 public final class CheckedScalar<T, E extends Exception> implements Scalar<T> {
 
+    private static final long serialVersionUID = 8828642584935688685L;
     /**
      * Function that wraps exception.
      */

--- a/src/main/java/org/cactoos/scalar/Constant.java
+++ b/src/main/java/org/cactoos/scalar/Constant.java
@@ -52,6 +52,7 @@ import org.cactoos.Scalar;
  */
 public final class Constant<T> implements Scalar<T> {
 
+    private static final long serialVersionUID = -3683103754580310224L;
     /**
      * Pre-computed value.
      */

--- a/src/main/java/org/cactoos/scalar/Equality.java
+++ b/src/main/java/org/cactoos/scalar/Equality.java
@@ -41,6 +41,7 @@ import org.cactoos.Scalar;
  */
 public final class Equality<T extends Bytes> implements Scalar<Integer> {
 
+    private static final long serialVersionUID = -7471438709253520125L;
     /**
      * Left.
      */

--- a/src/main/java/org/cactoos/scalar/Equals.java
+++ b/src/main/java/org/cactoos/scalar/Equals.java
@@ -41,6 +41,7 @@ import org.cactoos.Scalar;
  */
 public final class Equals<T extends Comparable<T>> implements Scalar<Boolean> {
 
+    private static final long serialVersionUID = -7530924366217018962L;
     /**
      * The first scalar.
      */

--- a/src/main/java/org/cactoos/scalar/False.java
+++ b/src/main/java/org/cactoos/scalar/False.java
@@ -34,6 +34,8 @@ import org.cactoos.Scalar;
  */
 public final class False implements Scalar<Boolean> {
 
+    private static final long serialVersionUID = -2664432243848291578L;
+
     @Override
     public Boolean value() {
         return false;

--- a/src/main/java/org/cactoos/scalar/FirstOf.java
+++ b/src/main/java/org/cactoos/scalar/FirstOf.java
@@ -40,6 +40,7 @@ import org.cactoos.iterable.IterableOf;
  */
 public final class FirstOf<T> implements Scalar<T> {
 
+    private static final long serialVersionUID = -3392821074016910262L;
     /**
      * Condition for getting the element.
      */

--- a/src/main/java/org/cactoos/scalar/Folded.java
+++ b/src/main/java/org/cactoos/scalar/Folded.java
@@ -36,6 +36,7 @@ import org.cactoos.iterable.IterableOf;
  */
 public final class Folded<X, T> implements Scalar<X> {
 
+    private static final long serialVersionUID = 8248271231724362891L;
     /**
      * Original iterable.
      */

--- a/src/main/java/org/cactoos/scalar/HighestOf.java
+++ b/src/main/java/org/cactoos/scalar/HighestOf.java
@@ -58,6 +58,7 @@ import org.cactoos.iterable.Mapped;
  */
 public final class HighestOf<T extends Comparable<T>> implements Scalar<T> {
 
+    private static final long serialVersionUID = -3547227188915899404L;
     /**
      * Result.
      */

--- a/src/main/java/org/cactoos/scalar/InheritanceLevel.java
+++ b/src/main/java/org/cactoos/scalar/InheritanceLevel.java
@@ -46,6 +46,7 @@ import org.cactoos.Scalar;
  */
 public final class InheritanceLevel implements Scalar<Integer> {
 
+    private static final long serialVersionUID = 5599786552966927799L;
     /**
      * Base class.
      */

--- a/src/main/java/org/cactoos/scalar/IoCheckedScalar.java
+++ b/src/main/java/org/cactoos/scalar/IoCheckedScalar.java
@@ -42,6 +42,7 @@ import org.cactoos.Scalar;
  */
 public final class IoCheckedScalar<T> implements Scalar<T> {
 
+    private static final long serialVersionUID = -4789269346443852640L;
     /**
      * Original scalar.
      */

--- a/src/main/java/org/cactoos/scalar/ItemAt.java
+++ b/src/main/java/org/cactoos/scalar/ItemAt.java
@@ -40,6 +40,7 @@ import org.cactoos.text.FormattedText;
  */
 public final class ItemAt<T> implements Scalar<T> {
 
+    private static final long serialVersionUID = 7368435910244914095L;
     /**
      * {@link StickyScalar} that holds the value of the iterator
      *  at the position specified in the constructor.

--- a/src/main/java/org/cactoos/scalar/LowestOf.java
+++ b/src/main/java/org/cactoos/scalar/LowestOf.java
@@ -58,6 +58,7 @@ import org.cactoos.iterable.Mapped;
  */
 public final class LowestOf<T extends Comparable<T>> implements Scalar<T> {
 
+    private static final long serialVersionUID = -2222625577885475646L;
     /**
      * Result.
      */

--- a/src/main/java/org/cactoos/scalar/Not.java
+++ b/src/main/java/org/cactoos/scalar/Not.java
@@ -40,6 +40,7 @@ import org.cactoos.Scalar;
  */
 public final class Not implements Scalar<Boolean> {
 
+    private static final long serialVersionUID = 4973341605261222251L;
     /**
      * The origin scalar.
      */

--- a/src/main/java/org/cactoos/scalar/Or.java
+++ b/src/main/java/org/cactoos/scalar/Or.java
@@ -79,6 +79,7 @@ import org.cactoos.iterable.Mapped;
  */
 public final class Or implements Scalar<Boolean> {
 
+    private static final long serialVersionUID = 1724930938560755347L;
     /**
      * The iterator.
      */

--- a/src/main/java/org/cactoos/scalar/PropertiesOf.java
+++ b/src/main/java/org/cactoos/scalar/PropertiesOf.java
@@ -47,6 +47,7 @@ import org.cactoos.text.TextOf;
  */
 public final class PropertiesOf implements Scalar<Properties> {
 
+    private static final long serialVersionUID = -3324338867796015345L;
     /**
      * The underlying properties.
      */

--- a/src/main/java/org/cactoos/scalar/Reduced.java
+++ b/src/main/java/org/cactoos/scalar/Reduced.java
@@ -74,6 +74,7 @@ import org.cactoos.iterable.Mapped;
  */
 public final class Reduced<T> implements Scalar<T> {
 
+    private static final long serialVersionUID = 7503459295879462493L;
     /**
      * Items.
      */

--- a/src/main/java/org/cactoos/scalar/RetryScalar.java
+++ b/src/main/java/org/cactoos/scalar/RetryScalar.java
@@ -55,6 +55,7 @@ import org.cactoos.func.RetryFunc;
  */
 public final class RetryScalar<T> implements Scalar<T> {
 
+    private static final long serialVersionUID = -1760023419280919562L;
     /**
      * Original scalar.
      */

--- a/src/main/java/org/cactoos/scalar/ScalarWithFallback.java
+++ b/src/main/java/org/cactoos/scalar/ScalarWithFallback.java
@@ -41,6 +41,7 @@ import org.cactoos.map.MapOf;
  */
 public final class ScalarWithFallback<T> implements Scalar<T> {
 
+    private static final long serialVersionUID = -3397993816703066227L;
     /**
      * The origin scalar.
      */

--- a/src/main/java/org/cactoos/scalar/SolidScalar.java
+++ b/src/main/java/org/cactoos/scalar/SolidScalar.java
@@ -37,6 +37,7 @@ import org.cactoos.Scalar;
  */
 public final class SolidScalar<T> implements Scalar<T> {
 
+    private static final long serialVersionUID = -7401355531940909176L;
     /**
      * Origin.
      */

--- a/src/main/java/org/cactoos/scalar/StickyScalar.java
+++ b/src/main/java/org/cactoos/scalar/StickyScalar.java
@@ -59,6 +59,7 @@ import org.cactoos.func.StickyFunc;
  */
 public final class StickyScalar<T> implements Scalar<T> {
 
+    private static final long serialVersionUID = 4016178182153587930L;
     /**
      * Func.
      */

--- a/src/main/java/org/cactoos/scalar/SumOfDoubleScalar.java
+++ b/src/main/java/org/cactoos/scalar/SumOfDoubleScalar.java
@@ -44,6 +44,7 @@ import org.cactoos.Scalar;
  */
 public final class SumOfDoubleScalar implements Scalar<Double> {
 
+    private static final long serialVersionUID = 5665225232632637513L;
     /**
      * Varargs of Scalar to sum up values from.
      */

--- a/src/main/java/org/cactoos/scalar/SumOfFloatScalar.java
+++ b/src/main/java/org/cactoos/scalar/SumOfFloatScalar.java
@@ -44,6 +44,7 @@ import org.cactoos.Scalar;
  */
 public final class SumOfFloatScalar implements Scalar<Float> {
 
+    private static final long serialVersionUID = -2351997894084743784L;
     /**
      * Varargs of Scalar to sum up values from.
      */

--- a/src/main/java/org/cactoos/scalar/SumOfIntScalar.java
+++ b/src/main/java/org/cactoos/scalar/SumOfIntScalar.java
@@ -45,6 +45,7 @@ import org.cactoos.Scalar;
  */
 public final class SumOfIntScalar implements Scalar<Integer> {
 
+    private static final long serialVersionUID = 4070997367359063186L;
     /**
      * Varargs of Scalar to sum up values from.
      */

--- a/src/main/java/org/cactoos/scalar/SumOfLongScalar.java
+++ b/src/main/java/org/cactoos/scalar/SumOfLongScalar.java
@@ -44,6 +44,7 @@ import org.cactoos.Scalar;
  */
 public final class SumOfLongScalar implements Scalar<Long> {
 
+    private static final long serialVersionUID = 16928195585640649L;
     /**
      * Varargs of Scalar to sum up values from.
      */

--- a/src/main/java/org/cactoos/scalar/SumOfScalar.java
+++ b/src/main/java/org/cactoos/scalar/SumOfScalar.java
@@ -42,6 +42,7 @@ import org.cactoos.iterable.IterableOf;
  */
 final class SumOfScalar implements Scalar<SumOf> {
 
+    private static final long serialVersionUID = 2336606726918695888L;
     /**
      * Varargs of Scalar to sum up values from.
      */

--- a/src/main/java/org/cactoos/scalar/SyncScalar.java
+++ b/src/main/java/org/cactoos/scalar/SyncScalar.java
@@ -49,6 +49,7 @@ import org.cactoos.Scalar;
  */
 public final class SyncScalar<T> implements Scalar<T> {
 
+    private static final long serialVersionUID = 6213293404519312215L;
     /**
      * The scalar to cache.
      */

--- a/src/main/java/org/cactoos/scalar/Ternary.java
+++ b/src/main/java/org/cactoos/scalar/Ternary.java
@@ -51,6 +51,7 @@ import org.cactoos.Scalar;
  */
 public final class Ternary<T> implements Scalar<T> {
 
+    private static final long serialVersionUID = 3273631602484959369L;
     /**
      * The condition.
      */

--- a/src/main/java/org/cactoos/scalar/True.java
+++ b/src/main/java/org/cactoos/scalar/True.java
@@ -34,6 +34,8 @@ import org.cactoos.Scalar;
  */
 public final class True implements Scalar<Boolean> {
 
+    private static final long serialVersionUID = -55013507477336919L;
+
     @Override
     public Boolean value() {
         return true;

--- a/src/main/java/org/cactoos/scalar/UncheckedScalar.java
+++ b/src/main/java/org/cactoos/scalar/UncheckedScalar.java
@@ -37,6 +37,7 @@ import org.cactoos.Scalar;
  */
 public final class UncheckedScalar<T> implements Scalar<T> {
 
+    private static final long serialVersionUID = -67090681677875830L;
     /**
      * Original origin.
      */

--- a/src/main/java/org/cactoos/text/IsBlank.java
+++ b/src/main/java/org/cactoos/text/IsBlank.java
@@ -35,6 +35,7 @@ import org.cactoos.Text;
  */
 public final class IsBlank implements Scalar<Boolean> {
 
+    private static final long serialVersionUID = -303587862685229882L;
     /**
      * The text.
      */

--- a/src/main/java/org/cactoos/time/DateOf.java
+++ b/src/main/java/org/cactoos/time/DateOf.java
@@ -36,6 +36,7 @@ import org.cactoos.scalar.UncheckedScalar;
  */
 public final class DateOf implements Scalar<Date> {
 
+    private static final long serialVersionUID = -435491459384038668L;
     /**
      * The parsed date.
      */

--- a/src/main/java/org/cactoos/time/LocalDateTimeOf.java
+++ b/src/main/java/org/cactoos/time/LocalDateTimeOf.java
@@ -33,6 +33,7 @@ import org.cactoos.scalar.UncheckedScalar;
  * @since 0.27
  */
 public final class LocalDateTimeOf implements Scalar<LocalDateTime> {
+    private static final long serialVersionUID = 8592139601760284937L;
     /**
      * The parsed date.
      */

--- a/src/main/java/org/cactoos/time/OffsetDateTimeOf.java
+++ b/src/main/java/org/cactoos/time/OffsetDateTimeOf.java
@@ -35,6 +35,7 @@ import org.cactoos.scalar.UncheckedScalar;
  * @since 0.27
  */
 public final class OffsetDateTimeOf implements Scalar<OffsetDateTime> {
+    private static final long serialVersionUID = 7258334985164726580L;
     /**
      * The parsed date.
      */

--- a/src/main/java/org/cactoos/time/ZonedDateTimeOf.java
+++ b/src/main/java/org/cactoos/time/ZonedDateTimeOf.java
@@ -34,6 +34,7 @@ import org.cactoos.scalar.UncheckedScalar;
  * @since 0.27
  */
 public final class ZonedDateTimeOf implements Scalar<ZonedDateTime> {
+    private static final long serialVersionUID = 8182449320101445175L;
     /**
      * The parsed date.
      */

--- a/src/test/java/org/cactoos/scalar/NumberOfTest.java
+++ b/src/test/java/org/cactoos/scalar/NumberOfTest.java
@@ -23,7 +23,11 @@
  */
 package org.cactoos.scalar;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -94,5 +98,21 @@ public final class NumberOfTest {
     @Test(expected = RuntimeException.class)
     public void failsIfTextDoesNotRepresentADouble() throws IOException {
         new NumberOf("abfdsc").doubleValue();
+    }
+
+    @Test
+    public void serializes() throws IOException, ClassNotFoundException {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new ObjectOutputStream(
+            out
+        ).writeObject(
+            new NumberOf("1234")
+        );
+        MatcherAssert.assertThat(
+            (NumberOf) new ObjectInputStream(
+                new ByteArrayInputStream(out.toByteArray())
+            ).readObject(),
+            Matchers.equalTo(1234)
+        );
     }
 }


### PR DESCRIPTION
This PR fixes the issue that a non-serializable value is stored in a non-transient field of a serializable class

NumberOf extends Number.
Number is serializable
Therefore NumberOf is also serializable
However, NumberOf stores non-serializable values in non-transient fields.

So either
* *num members needs to be declared transient
* Or scalars need to be serializable

This PR makes scalars serializable


