### PR TITLE
Consistent Skipped constructors API (#930)

### DIFF
--- a/src/main/java/org/cactoos/collection/Skipped.java
+++ b/src/main/java/org/cactoos/collection/Skipped.java
@@ -43,26 +43,26 @@ public final class Skipped<T> extends CollectionEnvelope<T> {
      */
     @SafeVarargs
     public Skipped(final int skip, final T... src) {
-        this(new IterableOf<>(src), skip);
+        this(skip, new IterableOf<>(src));
     }
 
     /**
      * Ctor.
+     * @param skip How many to skip
      * @param src Source iterable
-     * @param skip How many to skip
      */
-    public Skipped(final Iterable<T> src, final int skip) {
-        this(new CollectionOf<T>(src), skip);
+    public Skipped(final int skip, final Iterable<T> src) {
+        this(skip, new CollectionOf<>(src));
     }
 
     /**
      * Ctor.
-     * @param src Source collection
      * @param skip How many to skip
+     * @param src Source collection
      */
-    public Skipped(final Collection<T> src, final int skip) {
-        super(() -> new CollectionOf<T>(
-            new org.cactoos.iterable.Skipped<T>(src, skip)
+    public Skipped(final int skip, final Collection<T> src) {
+        super(() -> new CollectionOf<>(
+            new org.cactoos.iterable.Skipped<>(skip, src)
         ));
     }
 }

--- a/src/main/java/org/cactoos/iterable/Skipped.java
+++ b/src/main/java/org/cactoos/iterable/Skipped.java
@@ -40,15 +40,15 @@ public final class Skipped<T> extends IterableEnvelope<T> {
      */
     @SafeVarargs
     public Skipped(final int skip, final T... src) {
-        this(new IterableOf<>(src), skip);
+        this(skip, new IterableOf<>(src));
     }
 
     /**
      * Ctor.
-     * @param iterable Decorated iterable
      * @param skip Count skip elements
+     * @param iterable Decorated iterable
      */
-    public Skipped(final Iterable<T> iterable, final int skip) {
+    public Skipped(final int skip, final Iterable<T> iterable) {
         super(() -> () -> new org.cactoos.iterator.Skipped<>(
             iterable.iterator(),
             skip

--- a/src/test/java/org/cactoos/collection/SkippedTest.java
+++ b/src/test/java/org/cactoos/collection/SkippedTest.java
@@ -44,8 +44,8 @@ public final class SkippedTest {
         MatcherAssert.assertThat(
             "Can't skip elements in iterable",
             new Skipped<>(
-                new IterableOf<>("one", "two", "three", "four"),
-                2
+                2,
+                new IterableOf<>("one", "two", "three", "four")
             ),
             Matchers.contains(
                 "three",
@@ -76,8 +76,8 @@ public final class SkippedTest {
         MatcherAssert.assertThat(
             "Can't skip elements in collection",
             new Skipped<>(
-                new CollectionOf<>("one", "two", "three", "four"),
-                2
+                2,
+                new CollectionOf<>("one", "two", "three", "four")
             ),
             Matchers.contains(
                 "three",


### PR DESCRIPTION
As described in #930 this API is not consistent. In both, collection.Skipped and iterable.Skipped first ctor argument is now always a skip (int). 