### PR TITLE
#1004 Text: Base64 classes new names

### DIFF
--- a/src/main/java/org/cactoos/text/Base64Decoded.java
+++ b/src/main/java/org/cactoos/text/Base64Decoded.java
@@ -24,24 +24,22 @@
 
 package org.cactoos.text;
 
-import org.cactoos.Scalar;
 import org.cactoos.Text;
-import org.cactoos.bytes.BytesBase64;
+import org.cactoos.bytes.Base64Bytes;
 import org.cactoos.io.BytesOf;
 
 /**
- * Encodes the origin text using the Base64 encoding scheme.
- *
+ * Decodes the origin text using the Base64 encoding scheme.
  * @since 0.20.2
  */
-public final class TextBase64 extends TextEnvelope {
+public final class Base64Decoded extends TextEnvelope {
 
     /**
      * Ctor.
      *
      * @param input The String
      */
-    public TextBase64(final String input) {
+    public Base64Decoded(final String input) {
         this(new TextOf(input));
     }
 
@@ -50,11 +48,11 @@ public final class TextBase64 extends TextEnvelope {
      *
      * @param origin Origin text
      */
-    public TextBase64(final Text origin) {
-        super((Scalar<String>) () -> new TextOf(
-            new BytesBase64(
+    public Base64Decoded(final Text origin) {
+        super(new TextOf(
+            new Base64Bytes(
                 new BytesOf(origin)
             )
-        ).asString());
+        ));
     }
 }

--- a/src/main/java/org/cactoos/text/Base64Encoded.java
+++ b/src/main/java/org/cactoos/text/Base64Encoded.java
@@ -24,32 +24,37 @@
 
 package org.cactoos.text;
 
-import java.io.IOException;
-import org.hamcrest.MatcherAssert;
-import org.junit.Test;
-import org.llorllale.cactoos.matchers.TextHasString;
+import org.cactoos.Scalar;
+import org.cactoos.Text;
+import org.cactoos.bytes.BytesBase64;
+import org.cactoos.io.BytesOf;
 
 /**
- * Test Case for {@link org.cactoos.text.Base64Text}.
+ * Encodes the origin text using the Base64 encoding scheme.
  *
  * @since 0.20.2
  */
-public final class Base64TextTest {
+public final class Base64Encoded extends TextEnvelope {
 
     /**
-     * Check text decodes using the Base64 encoding scheme.
-     * @throws IOException If fails.
+     * Ctor.
+     *
+     * @param input The String
      */
-    @Test
-    public void checkDecode() throws IOException {
-        MatcherAssert.assertThat(
-            "Can't decodes text using the Base64 encoding scheme",
-            new Base64Text(
-                "SGVsbG8h"
-            ),
-            new TextHasString(
-                "Hello!"
+    public Base64Encoded(final String input) {
+        this(new TextOf(input));
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param origin Origin text
+     */
+    public Base64Encoded(final Text origin) {
+        super((Scalar<String>) () -> new TextOf(
+            new BytesBase64(
+                new BytesOf(origin)
             )
-        );
+        ).asString());
     }
 }

--- a/src/test/java/org/cactoos/text/Base64DecodedTest.java
+++ b/src/test/java/org/cactoos/text/Base64DecodedTest.java
@@ -30,24 +30,25 @@ import org.junit.Test;
 import org.llorllale.cactoos.matchers.TextHasString;
 
 /**
- * Test case for  {@link org.cactoos.text.TextBase64}.
+ * Test Case for {@link Base64Decoded}.
+ *
  * @since 0.20.2
  */
-public final class TextBase64Test {
+public final class Base64DecodedTest {
 
     /**
-     * Check text encodes using the Base64 encoding scheme.
+     * Check text decodes using the Base64 encoding scheme.
      * @throws IOException If fails.
      */
     @Test
-    public void checkEncode() throws IOException {
+    public void checkDecode() throws IOException {
         MatcherAssert.assertThat(
-            "Can't encodes text using the Base64 encoding scheme",
-            new TextBase64(
-                "Hello!"
+            "Can't decodes text using the Base64 encoding scheme",
+            new Base64Decoded(
+                "SGVsbG8h"
             ),
             new TextHasString(
-                "SGVsbG8h"
+                "Hello!"
             )
         );
     }

--- a/src/test/java/org/cactoos/text/Base64EncodedTest.java
+++ b/src/test/java/org/cactoos/text/Base64EncodedTest.java
@@ -24,38 +24,31 @@
 
 package org.cactoos.text;
 
-import org.cactoos.Text;
-import org.cactoos.bytes.Base64Bytes;
-import org.cactoos.io.BytesOf;
+import java.io.IOException;
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+import org.llorllale.cactoos.matchers.TextHasString;
 
 /**
- * Decodes the origin text using the Base64 encoding scheme.
+ * Test case for  {@link Base64Encoded}.
  * @since 0.20.2
- * @todo #980:30min Define new name for Base64Text and TextBase64 in order to
- *  avoid compound names. These classes are using for decode/encode text using
- *  the radix-64 representation.
  */
-public final class Base64Text extends TextEnvelope {
+public final class Base64EncodedTest {
 
     /**
-     * Ctor.
-     *
-     * @param input The String
+     * Check text encodes using the Base64 encoding scheme.
+     * @throws IOException If fails.
      */
-    public Base64Text(final String input) {
-        this(new TextOf(input));
-    }
-
-    /**
-     * Ctor.
-     *
-     * @param origin Origin text
-     */
-    public Base64Text(final Text origin) {
-        super(new TextOf(
-            new Base64Bytes(
-                new BytesOf(origin)
+    @Test
+    public void checkEncode() throws IOException {
+        MatcherAssert.assertThat(
+            "Can't encodes text using the Base64 encoding scheme",
+            new Base64Encoded(
+                "Hello!"
+            ),
+            new TextHasString(
+                "SGVsbG8h"
             )
-        ));
+        );
     }
 }


### PR DESCRIPTION
As described in #1004. Two classes from text package were renamed.

- Base64Text to Base64Decoded as it encapsulates Base64 string and decode it

- Text64Base to Base64Encoded as it encapsulates any string and encode it to Base64