### PR TITLE
#1023 Update cactoos-matchers to 0.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@ The MIT License (MIT)
     <dependency>
       <groupId>org.llorllale</groupId>
       <artifactId>cactoos-matchers</artifactId>
-      <version>0.12</version>
+      <version>0.13</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/org/cactoos/TextTest.java
+++ b/src/test/java/org/cactoos/TextTest.java
@@ -34,6 +34,9 @@ import org.llorllale.cactoos.matchers.TextHasString;
 /**
  * Test case for {@link Text}.
  * @since 0.11
+ * @todo #1023:30min Replace all occurrences of @Rule ExpectedException
+ *  tests that use it should be refactored to use Throws class
+ *  introduced in cactoos-matchers 0.13.
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 public final class TextTest {

--- a/src/test/java/org/cactoos/io/BytesOfTest.java
+++ b/src/test/java/org/cactoos/io/BytesOfTest.java
@@ -180,14 +180,10 @@ public final class BytesOfTest {
                     )
                 )
             ),
-            new TextHasString(
-                Matchers.allOf(
-                    Matchers.containsString("java.io.IOException"),
-                    Matchers.containsString("doesn't work at all"),
-                    Matchers.containsString(
-                        "\tat org.cactoos.io.BytesOfTest"
-                    )
-                )
+            Matchers.allOf(
+                new TextHasString("java.io.IOException"),
+                new TextHasString("doesn't work at all"),
+                new TextHasString("\tat org.cactoos.io.BytesOfTest")
             )
         );
     }
@@ -201,9 +197,7 @@ public final class BytesOfTest {
                     new IOException("").getStackTrace()
                 )
             ),
-            new TextHasString(
-                Matchers.containsString("org.cactoos.io.BytesOfTest")
-            )
+            new TextHasString("org.cactoos.io.BytesOfTest")
         );
     }
 

--- a/src/test/java/org/cactoos/io/BytesOfTest.java
+++ b/src/test/java/org/cactoos/io/BytesOfTest.java
@@ -180,10 +180,12 @@ public final class BytesOfTest {
                     )
                 )
             ),
-            Matchers.allOf(
-                new TextHasString("java.io.IOException"),
-                new TextHasString("doesn't work at all"),
-                new TextHasString("\tat org.cactoos.io.BytesOfTest")
+            new TextHasString(
+                new JoinedText(
+                    System.lineSeparator(),
+                    "java.io.IOException: It doesn't work at all",
+                    "\tat org.cactoos.io.BytesOfTest"
+                )
             )
         );
     }

--- a/src/test/java/org/cactoos/io/HeadInputStreamTest.java
+++ b/src/test/java/org/cactoos/io/HeadInputStreamTest.java
@@ -27,7 +27,9 @@ import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.TextHasString;
+import org.llorllale.cactoos.matchers.TextIs;
 
 /**
  * Test cases for {@link HeadInputStream}.
@@ -35,6 +37,7 @@ import org.llorllale.cactoos.matchers.TextHasString;
  * @since 0.31
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle MagicNumberCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class HeadInputStreamTest {
 
@@ -45,11 +48,13 @@ public final class HeadInputStreamTest {
             5
         );
         stream.skip(3L);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Incorrect head of the input stream has been read",
-            new TextOf(stream),
+            () -> new TextOf(
+                new Sticky(() -> stream)
+            ),
             new TextHasString("tS")
-        );
+        ).affirm();
     }
 
     @Test
@@ -59,11 +64,12 @@ public final class HeadInputStreamTest {
             5
         );
         stream.skip(7L);
-        MatcherAssert.assertThat(
+        final String input = new TextOf(stream).asString();
+        new Assertion<>(
             "The result text wasn't empty",
-            new TextOf(stream),
-            new TextHasString("")
-        );
+            () -> new TextOf(input),
+            new TextIs("")
+        ).affirm();
     }
 
     @Test
@@ -74,11 +80,13 @@ public final class HeadInputStreamTest {
         );
         stream.skip(7L);
         stream.reset();
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Reset didn't change the state",
-            new TextOf(stream),
+            () -> new TextOf(
+                new Sticky(() -> stream)
+            ),
             new TextHasString("testR")
-        );
+        ).affirm();
     }
 
     @Test

--- a/src/test/java/org/cactoos/io/InputOfTest.java
+++ b/src/test/java/org/cactoos/io/InputOfTest.java
@@ -45,8 +45,10 @@ import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.llorllale.cactoos.matchers.EndsWith;
 import org.llorllale.cactoos.matchers.InputHasContent;
 import org.llorllale.cactoos.matchers.MatcherOf;
+import org.llorllale.cactoos.matchers.StartsWith;
 import org.llorllale.cactoos.matchers.TextHasString;
 import org.takes.http.FtRemote;
 import org.takes.tk.TkHtml;
@@ -78,7 +80,7 @@ public final class InputOfTest {
                     new InputOf(new TextOf("Alternative text!"))
                 )
             ),
-            new TextHasString(Matchers.endsWith("text!"))
+            new EndsWith("text!")
         );
     }
 
@@ -149,11 +151,9 @@ public final class InputOfTest {
                 new TextOf(
                     new InputOf(home)
                 ),
-                new TextHasString(
-                    Matchers.allOf(
-                        Matchers.startsWith("<html"),
-                        Matchers.endsWith("html>")
-                    )
+                Matchers.allOf(
+                    new StartsWith("<html"),
+                    new EndsWith("html>")
                 )
             )
         );
@@ -173,7 +173,7 @@ public final class InputOfTest {
                     )
                 )
             ),
-            new TextHasString(Matchers.containsString("Lorem ipsum"))
+            new TextHasString("Lorem ipsum")
         );
     }
 

--- a/src/test/java/org/cactoos/io/InputOfTest.java
+++ b/src/test/java/org/cactoos/io/InputOfTest.java
@@ -48,7 +48,7 @@ import org.junit.rules.TemporaryFolder;
 import org.llorllale.cactoos.matchers.EndsWith;
 import org.llorllale.cactoos.matchers.InputHasContent;
 import org.llorllale.cactoos.matchers.MatcherOf;
-import org.llorllale.cactoos.matchers.StartsWith;
+import org.llorllale.cactoos.matchers.MatchesRegex;
 import org.llorllale.cactoos.matchers.TextHasString;
 import org.takes.http.FtRemote;
 import org.takes.tk.TkHtml;
@@ -151,10 +151,7 @@ public final class InputOfTest {
                 new TextOf(
                     new InputOf(home)
                 ),
-                Matchers.allOf(
-                    new StartsWith("<html"),
-                    new EndsWith("html>")
-                )
+                new MatchesRegex("<html.*html>")
             )
         );
     }

--- a/src/test/java/org/cactoos/io/InputWithFallbackTest.java
+++ b/src/test/java/org/cactoos/io/InputWithFallbackTest.java
@@ -27,9 +27,8 @@ import java.io.File;
 import java.io.IOException;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.Test;
-import org.llorllale.cactoos.matchers.TextHasString;
+import org.llorllale.cactoos.matchers.EndsWith;
 
 /**
  * Test case for {@link InputWithFallback}.
@@ -51,7 +50,7 @@ public final class InputWithFallbackTest {
                     new InputOf("hello, world!")
                 )
             ),
-            new TextHasString(Matchers.endsWith("world!"))
+            new EndsWith("world!")
         );
     }
 
@@ -67,7 +66,7 @@ public final class InputWithFallbackTest {
                     new InputOf("it works!")
                 )
             ),
-            new TextHasString(Matchers.endsWith("works!"))
+            new EndsWith("works!")
         );
     }
 

--- a/src/test/java/org/cactoos/io/Md5DigestOfTest.java
+++ b/src/test/java/org/cactoos/io/Md5DigestOfTest.java
@@ -72,10 +72,12 @@ public final class Md5DigestOfTest {
             "Can't calculate the file's MD5 checksum",
             new HexOf(
                 new Md5DigestOf(
-                    new InputOf(
-                        new ResourceOf(
-                            "org/cactoos/digest-calculation.txt"
-                        ).stream()
+                    new Sticky(
+                        new InputOf(
+                            new ResourceOf(
+                                "org/cactoos/digest-calculation.txt"
+                            ).stream()
+                        )
                     )
                 )
             ),

--- a/src/test/java/org/cactoos/io/OutputStreamToTest.java
+++ b/src/test/java/org/cactoos/io/OutputStreamToTest.java
@@ -30,8 +30,7 @@ import org.hamcrest.MatcherAssert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.llorllale.cactoos.matchers.MatcherOf;
-import org.llorllale.cactoos.matchers.TextHasString;
+import org.llorllale.cactoos.matchers.TextIs;
 
 /**
  * Test case for {@link OutputStreamTo}.
@@ -54,17 +53,15 @@ public final class OutputStreamToTest {
         MatcherAssert.assertThat(
             "Can't copy Input to Output and return Input",
             new TextOf(
-                new TeeInput(
-                    new ResourceOf("org/cactoos/large-text.txt"),
-                    new OutputTo(new OutputStreamTo(temp))
+                new Sticky(
+                    new TeeInput(
+                        new ResourceOf("org/cactoos/large-text.txt"),
+                        new OutputTo(new OutputStreamTo(temp))
+                    )
                 )
             ),
-            new TextHasString(
-                new MatcherOf<>(
-                    str -> {
-                        return new TextOf(temp).asString().equals(str);
-                    }
-                )
+            new TextIs(
+                new TextOf(temp)
             )
         );
     }

--- a/src/test/java/org/cactoos/io/Sha1DigestOfTest.java
+++ b/src/test/java/org/cactoos/io/Sha1DigestOfTest.java
@@ -72,10 +72,12 @@ public final class Sha1DigestOfTest {
             "Can't calculate the file's SHA-1 checksum",
             new HexOf(
                 new Sha1DigestOf(
-                    new InputOf(
-                        new ResourceOf(
-                            "org/cactoos/digest-calculation.txt"
-                        ).stream()
+                    new Sticky(
+                        new InputOf(
+                            new ResourceOf(
+                                "org/cactoos/digest-calculation.txt"
+                            ).stream()
+                        )
                     )
                 )
             ),

--- a/src/test/java/org/cactoos/io/Sha256DigestOfTest.java
+++ b/src/test/java/org/cactoos/io/Sha256DigestOfTest.java
@@ -74,10 +74,12 @@ public final class Sha256DigestOfTest {
             "Can't calculate the file's SHA-256 checksum",
             new HexOf(
                 new Sha256DigestOf(
-                    new InputOf(
-                        new ResourceOf(
-                            "org/cactoos/digest-calculation.txt"
-                        ).stream()
+                    new Sticky(
+                        new InputOf(
+                            new ResourceOf(
+                                "org/cactoos/digest-calculation.txt"
+                            ).stream()
+                        )
                     )
                 )
             ),

--- a/src/test/java/org/cactoos/io/StickyTest.java
+++ b/src/test/java/org/cactoos/io/StickyTest.java
@@ -31,8 +31,8 @@ import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.EndsWith;
 import org.llorllale.cactoos.matchers.MatcherOf;
-import org.llorllale.cactoos.matchers.TextHasString;
 
 /**
  * Test case for {@link Sticky}.
@@ -77,9 +77,7 @@ public final class StickyTest {
                     )
                 )
             ),
-            new TextHasString(
-                Matchers.endsWith("est laborum.\n")
-            )
+            new EndsWith("est laborum.\n")
         );
     }
 

--- a/src/test/java/org/cactoos/io/TeeOutputTest.java
+++ b/src/test/java/org/cactoos/io/TeeOutputTest.java
@@ -31,8 +31,8 @@ import org.hamcrest.MatcherAssert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.llorllale.cactoos.matchers.MatcherOf;
-import org.llorllale.cactoos.matchers.TextHasString;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.TextIs;
 
 /**
  * Test case for {@link TeeOutput}.
@@ -50,83 +50,70 @@ public final class TeeOutputTest {
     @Test
     public void copiesContent() {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final ByteArrayOutputStream copy = new ByteArrayOutputStream();
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't copy Output to Output and return Input",
-            new TextOf(
-                new TeeInput(
-                    new InputOf("Hello, товарищ!"),
-                    new TeeOutput(
-                        new OutputTo(baos),
-                        new OutputTo(copy)
+            () -> new TextOf(
+                new Sticky(
+                    new TeeInput(
+                        new InputOf("Hello, товарищ!"),
+                            new TeeOutput(
+                            new OutputTo(baos),
+                            new OutputTo(new ByteArrayOutputStream())
+                        )
                     )
                 )
             ),
-            new TextHasString(
-                new MatcherOf<>(
-                    str -> {
-                        return new String(
-                            copy.toByteArray(), StandardCharsets.UTF_8
-                        ).equals(str);
-                    }
-                )
+            new TextIs(
+                new TextOf(baos::toByteArray, StandardCharsets.UTF_8)
             )
-        );
+        ).affirm();
     }
 
     @Test
     public void copiesWithWriter() {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final ByteArrayOutputStream copy = new ByteArrayOutputStream();
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't copy Output with writer",
-            new TextOf(
-                new TeeInput(
-                    new InputOf("Hello, товарищ! writer"),
-                    new TeeOutput(
-                        new OutputTo(baos),
-                        new WriterTo(copy)
+            () -> new TextOf(
+                new Sticky(
+                    new TeeInput(
+                        new InputOf("Hello, товарищ! writer"),
+                        new TeeOutput(
+                            new OutputTo(baos),
+                            new WriterTo(new ByteArrayOutputStream())
+                        )
                     )
                 )
             ),
-            new TextHasString(
-                new MatcherOf<>(
-                    str -> {
-                        return new String(
-                            copy.toByteArray(), StandardCharsets.UTF_8
-                        ).equals(str);
-                    }
-                )
+            new TextIs(
+                new TextOf(baos::toByteArray, StandardCharsets.UTF_8)
             )
-        );
+        ).affirm();
     }
 
     @Test
     public void copiesWithWriterAndCharset() {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final ByteArrayOutputStream copy = new ByteArrayOutputStream();
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't copy Output with writer and charset",
-            new TextOf(
-                new TeeInput(
-                    new InputOf("Hello, товарищ! writer and charset"),
-                    new TeeOutput(
-                        new OutputTo(baos),
-                        new WriterTo(copy),
-                        StandardCharsets.UTF_8
+            () -> new TextOf(
+                new Sticky(
+                    new TeeInput(
+                        new InputOf(
+                            "Hello, товарищ! writer and charset"
+                        ),
+                        new TeeOutput(
+                            new OutputTo(baos),
+                            new WriterTo(new ByteArrayOutputStream()),
+                            StandardCharsets.UTF_8
+                        )
                     )
                 )
             ),
-            new TextHasString(
-                new MatcherOf<>(
-                    str -> {
-                        return new String(
-                            copy.toByteArray(), StandardCharsets.UTF_8
-                        ).equals(str);
-                    }
-                )
+            new TextIs(
+                new TextOf(baos::toByteArray, StandardCharsets.UTF_8)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -144,14 +131,8 @@ public final class TeeOutputTest {
                     )
                 )
             ),
-            new TextHasString(
-                new MatcherOf<>(
-                    str -> {
-                        return new String(
-                            new TextOf(file.toPath()).asString()
-                        ).equals(str);
-                    }
-                )
+            new TextIs(
+                new TextOf(file.toPath())
             )
         );
     }
@@ -171,14 +152,8 @@ public final class TeeOutputTest {
                     )
                 )
             ),
-            new TextHasString(
-                new MatcherOf<>(
-                    str -> {
-                        return new String(
-                            new TextOf(file.toPath()).asString()
-                        ).equals(str);
-                    }
-                )
+            new TextIs(
+                new TextOf(file.toPath())
             )
         );
     }
@@ -186,28 +161,25 @@ public final class TeeOutputTest {
     @Test
     public void copiesWithOutputStream() {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final ByteArrayOutputStream copy = new ByteArrayOutputStream();
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't copy Output with output stream",
-            new TextOf(
-                new TeeInput(
-                    new InputOf("Hello, товарищ! with output stream"),
-                    new TeeOutput(
-                        new OutputTo(baos),
-                        copy
+            () -> new TextOf(
+                new Sticky(
+                    new TeeInput(
+                        new InputOf(
+                            "Hello, товарищ! with output stream"
+                        ),
+                        new TeeOutput(
+                            new OutputTo(baos),
+                            new ByteArrayOutputStream()
+                        )
                     )
                 )
             ),
-            new TextHasString(
-                new MatcherOf<>(
-                    str -> {
-                        return new String(
-                            copy.toByteArray(), StandardCharsets.UTF_8
-                        ).equals(str);
-                    }
-                )
+            new TextIs(
+                new TextOf(baos::toByteArray, StandardCharsets.UTF_8)
             )
-        );
+        ).affirm();
     }
 
 }

--- a/src/test/java/org/cactoos/io/WriterAsOutputStreamTest.java
+++ b/src/test/java/org/cactoos/io/WriterAsOutputStreamTest.java
@@ -36,9 +36,10 @@ import org.hamcrest.MatcherAssert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.MatcherOf;
 import org.llorllale.cactoos.matchers.ScalarHasValue;
-import org.llorllale.cactoos.matchers.TextHasString;
+import org.llorllale.cactoos.matchers.TextIs;
 
 /**
  * Test case for {@link WriterAsOutputStream}.
@@ -57,35 +58,31 @@ public final class WriterAsOutputStreamTest {
 
     @Test
     public void writesToByteArray() {
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final String content = "Hello, товарищ! How are you?";
-        MatcherAssert.assertThat(
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        new Assertion<>(
             "Can't copy Input to Writer",
-            new TextOf(
-                new TeeInput(
-                    new InputOf(content),
-                    new OutputTo(
-                        new WriterAsOutputStream(
-                            new OutputStreamWriter(
-                                baos, StandardCharsets.UTF_8
-                            ),
-                            StandardCharsets.UTF_8,
-                            // @checkstyle MagicNumber (1 line)
-                            13
+            () -> new TextOf(
+                new Sticky(
+                    new TeeInput(
+                        new InputOf(content),
+                        new OutputTo(
+                            new WriterAsOutputStream(
+                                new OutputStreamWriter(
+                                    baos, StandardCharsets.UTF_8
+                                ),
+                                StandardCharsets.UTF_8,
+                                // @checkstyle MagicNumber (1 line)
+                                13
+                            )
                         )
                     )
                 )
             ),
-            new TextHasString(
-                new MatcherOf<>(
-                    str -> {
-                        return new String(
-                            baos.toByteArray(), StandardCharsets.UTF_8
-                        ).equals(str);
-                    }
-                )
+            new TextIs(
+                new TextOf(baos::toByteArray, StandardCharsets.UTF_8)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -95,29 +92,27 @@ public final class WriterAsOutputStreamTest {
         try (final OutputStreamWriter writer = new OutputStreamWriter(
             new FileOutputStream(temp.toFile()), StandardCharsets.UTF_8
         )) {
-            MatcherAssert.assertThat(
+            new Assertion<>(
                 "Can't copy Input to Output and return Input",
-                new TextOf(
-                    new TeeInput(
-                        new ResourceOf("org/cactoos/large-text.txt"),
-                        new OutputTo(
-                            new WriterAsOutputStream(
-                                writer,
-                                StandardCharsets.UTF_8,
-                                // @checkstyle MagicNumber (1 line)
-                                345
+                () -> new TextOf(
+                    new Sticky(
+                        new TeeInput(
+                            new ResourceOf("org/cactoos/large-text.txt"),
+                            new OutputTo(
+                                new WriterAsOutputStream(
+                                    writer,
+                                    StandardCharsets.UTF_8,
+                                    // @checkstyle MagicNumber (1 line)
+                                    345
+                                )
                             )
                         )
                     )
                 ),
-                new TextHasString(
-                    new MatcherOf<>(
-                        str -> {
-                            return new TextOf(temp).asString().equals(str);
-                        }
-                    )
+                new TextIs(
+                    new TextOf(temp)
                 )
-            );
+            ).affirm();
         }
     }
 

--- a/src/test/java/org/cactoos/io/WriterAsOutputTest.java
+++ b/src/test/java/org/cactoos/io/WriterAsOutputTest.java
@@ -29,12 +29,11 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import org.cactoos.text.TextOf;
-import org.hamcrest.MatcherAssert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.llorllale.cactoos.matchers.MatcherOf;
-import org.llorllale.cactoos.matchers.TextHasString;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.TextIs;
 
 /**
  * Test case for {@link WriterAsOutput}.
@@ -57,22 +56,20 @@ public final class WriterAsOutputTest {
         try (final OutputStreamWriter writer = new OutputStreamWriter(
             new FileOutputStream(temp.toFile()), StandardCharsets.UTF_8
         )) {
-            MatcherAssert.assertThat(
+            new Assertion<>(
                 "Can't copy Input to Output and return Input",
-                new TextOf(
-                    new TeeInput(
-                        new ResourceOf("org/cactoos/large-text.txt"),
-                        new WriterAsOutput(writer)
+                () -> new TextOf(
+                    new Sticky(
+                        new TeeInput(
+                            new ResourceOf("org/cactoos/large-text.txt"),
+                            new WriterAsOutput(writer)
+                        )
                     )
                 ),
-                new TextHasString(
-                    new MatcherOf<>(
-                        str -> {
-                            return new TextOf(temp).asString().equals(str);
-                        }
-                    )
+                new TextIs(
+                    new TextOf(temp)
                 )
-            );
+            ).affirm();
         }
     }
 

--- a/src/test/java/org/cactoos/io/WriterToTest.java
+++ b/src/test/java/org/cactoos/io/WriterToTest.java
@@ -26,12 +26,11 @@ package org.cactoos.io;
 import java.io.IOException;
 import java.nio.file.Path;
 import org.cactoos.text.TextOf;
-import org.hamcrest.MatcherAssert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.llorllale.cactoos.matchers.MatcherOf;
-import org.llorllale.cactoos.matchers.TextHasString;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.TextIs;
 
 /**
  * Test case for {@link WriterTo}.
@@ -51,22 +50,20 @@ public final class WriterToTest {
     public void writesLargeContentToFile() throws IOException {
         final Path temp = this.folder.newFile("cactoos-1.txt-1")
             .toPath();
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't copy Input to Output and return Input",
-            new TextOf(
-                new TeeInput(
-                    new ResourceOf("org/cactoos/large-text.txt"),
-                    new WriterAsOutput(new WriterTo(temp))
+            () -> new TextOf(
+                new Sticky(
+                    new TeeInput(
+                        new ResourceOf("org/cactoos/large-text.txt"),
+                        new WriterAsOutput(new WriterTo(temp))
+                    )
                 )
             ),
-            new TextHasString(
-                new MatcherOf<>(
-                    str -> {
-                        return new TextOf(temp).asString().equals(str);
-                    }
-                )
+            new TextIs(
+                new TextOf(temp)
             )
-        );
+        ).affirm();
     }
 
 }

--- a/src/test/java/org/cactoos/text/TextOfTest.java
+++ b/src/test/java/org/cactoos/text/TextOfTest.java
@@ -33,7 +33,9 @@ import org.cactoos.io.InputOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.TextHasString;
+import org.llorllale.cactoos.matchers.TextIs;
 
 /**
  * Test case for {@link TextOf}.
@@ -95,11 +97,15 @@ public final class TextOfTest {
     @Test
     public void readsReaderIntoTextWithSmallBuffer() {
         final String text = "Hi there! with small buffer";
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't read text from Reader with a small reading buffer",
-            new TextOf(new StringReader(text), 2, StandardCharsets.UTF_8),
-            new TextHasString(text)
-        );
+            () -> new TextOf(text),
+            new TextIs(
+                new TextOf(
+                    new StringReader(text), 2, StandardCharsets.UTF_8
+                )
+            )
+        ).affirm();
     }
 
     @Test
@@ -219,14 +225,10 @@ public final class TextOfTest {
                     "It doesn't work at all"
                 )
             ),
-            new TextHasString(
-                Matchers.allOf(
-                    Matchers.containsString("java.io.IOException"),
-                    Matchers.containsString("doesn't work at all"),
-                    Matchers.containsString(
-                        "\tat org.cactoos.text.TextOfTest"
-                    )
-                )
+            Matchers.allOf(
+                new TextHasString("java.io.IOException"),
+                new TextHasString("doesn't work at all"),
+                new TextHasString("\tat org.cactoos.text.TextOfTest")
             )
         );
     }
@@ -306,9 +308,7 @@ public final class TextOfTest {
             new TextOf(
                 new IOException("").getStackTrace()
             ),
-            new TextHasString(
-                Matchers.containsString("org.cactoos.text.TextOfTest")
-            )
+            new TextHasString("org.cactoos.text.TextOfTest")
         );
     }
 }

--- a/src/test/java/org/cactoos/text/TextOfTest.java
+++ b/src/test/java/org/cactoos/text/TextOfTest.java
@@ -225,10 +225,12 @@ public final class TextOfTest {
                     "It doesn't work at all"
                 )
             ),
-            Matchers.allOf(
-                new TextHasString("java.io.IOException"),
-                new TextHasString("doesn't work at all"),
-                new TextHasString("\tat org.cactoos.text.TextOfTest")
+            new TextHasString(
+                new JoinedText(
+                    System.lineSeparator(),
+                    "java.io.IOException: It doesn't work at all",
+                    "\tat org.cactoos.text.TextOfTest"
+                )
             )
         );
     }


### PR DESCRIPTION
As described in #1023. This was match harder than expected. I had to refactor many tests from io package, because there were many usage of 
`new TextHasString(
                Matcher<>()
            )`
which is no longer available in 0.13. In many places I have replaced MatcherAssert.assertThat() with Assertion<>() as I had to refactor tests anyways.  I know that there are too many changes, but without all of them code will not even compile.
Puzzle was left to replace usage of @Rule ExpectedException with Throws class.