### PR TITLE
LoggingInputStream.read() empty stream should return -1

### DIFF
--- a/src/main/java/org/cactoos/io/LoggingInputStream.java
+++ b/src/main/java/org/cactoos/io/LoggingInputStream.java
@@ -121,8 +121,13 @@ public final class LoggingInputStream extends InputStream {
     @Override
     public int read() throws IOException {
         final byte[] buf = new byte[1];
-        this.read(buf);
-        return Byte.toUnsignedInt(buf[0]);
+        final int size;
+        if (this.read(buf) == -1) {
+            size = -1;
+        } else {
+            size = Byte.toUnsignedInt(buf[0]);
+        }
+        return size;
     }
 
     @Override

--- a/src/test/java/org/cactoos/io/LoggingInputStreamTest.java
+++ b/src/test/java/org/cactoos/io/LoggingInputStreamTest.java
@@ -1,0 +1,57 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.io;
+
+import java.io.ByteArrayInputStream;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.Test;
+
+/**
+ * Test case for {@link LoggingInputStream}.
+ *
+ * @since 0.39
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class LoggingInputStreamTest {
+
+    @Test
+    public void readEmptyStream() throws Exception {
+        final LoggingInputStream stream = new LoggingInputStream(
+            new ByteArrayInputStream(
+                "".getBytes()
+            ),
+            this.getClass().getSimpleName()
+        );
+        MatcherAssert.assertThat(
+            "read empty stream behavior is the same as of JDK",
+            stream.read(),
+            new IsEqual<>(
+                new ByteArrayInputStream(
+                    "".getBytes()
+                ).read()
+            )
+        );
+    }
+}

--- a/src/test/java/org/cactoos/io/LoggingInputStreamTest.java
+++ b/src/test/java/org/cactoos/io/LoggingInputStreamTest.java
@@ -37,6 +37,7 @@ import org.llorllale.cactoos.matchers.Assertion;
  *
  * @since 0.39
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle MagicNumberCheck (500 lines)
  */
 public final class LoggingInputStreamTest {
 
@@ -67,13 +68,37 @@ public final class LoggingInputStreamTest {
             this.getClass().getSimpleName()
         );
         new Assertion<>(
-            "Can't read correctly an logged empty stream",
+            "Empty stream did not return -1",
             stream::read,
-            new IsEqual<>(
-                new ByteArrayInputStream(
-                    "".getBytes()
-                ).read()
-            )
+            new IsEqual<>(-1)
+        ).affirm();
+    }
+
+    @Test
+    public void readByteByByte() {
+        final LoggingInputStream stream = new LoggingInputStream(
+            new ByteArrayInputStream(
+                new byte[] {
+                    (byte) 20,
+                    (byte) 10,
+                }
+            ),
+            this.getClass().getSimpleName()
+        );
+        new Assertion<>(
+            "First byte is not 20",
+            stream::read,
+            new IsEqual<>(20)
+        ).affirm();
+        new Assertion<>(
+            "Second byte is not 10",
+            stream::read,
+            new IsEqual<>(10)
+        ).affirm();
+        new Assertion<>(
+            "End of stream is not -1",
+            stream::read,
+            new IsEqual<>(-1)
         ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/io/LoggingInputStreamTest.java
+++ b/src/test/java/org/cactoos/io/LoggingInputStreamTest.java
@@ -27,7 +27,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNull;
 import org.junit.Test;
@@ -87,13 +86,19 @@ public final class LoggingInputStreamTest {
             this.getClass().getSimpleName()
         );
         new Assertion<>(
-            "Byte sequence does not match the source",
+            "First byte was not 20",
             stream::read,
-            Matchers.allOf(
-                new IsEqual<>(20),
-                new IsEqual<>(10),
-                new IsEqual<>(-1)
-            )
+            new IsEqual<>(20)
+        ).affirm();
+        new Assertion<>(
+            "Second byte was not 10",
+            stream::read,
+            new IsEqual<>(10)
+        ).affirm();
+        new Assertion<>(
+            "When stream is exhausted it didn't return -1",
+            stream::read,
+            new IsEqual<>(-1)
         ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/io/LoggingInputStreamTest.java
+++ b/src/test/java/org/cactoos/io/LoggingInputStreamTest.java
@@ -27,6 +27,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNull;
 import org.junit.Test;
@@ -86,19 +87,13 @@ public final class LoggingInputStreamTest {
             this.getClass().getSimpleName()
         );
         new Assertion<>(
-            "First byte is not 20",
+            "Byte sequence does not match the source",
             stream::read,
-            new IsEqual<>(20)
-        ).affirm();
-        new Assertion<>(
-            "Second byte is not 10",
-            stream::read,
-            new IsEqual<>(10)
-        ).affirm();
-        new Assertion<>(
-            "End of stream is not -1",
-            stream::read,
-            new IsEqual<>(-1)
+            Matchers.allOf(
+                new IsEqual<>(20),
+                new IsEqual<>(10),
+                new IsEqual<>(-1)
+            )
         ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/io/LoggingInputStreamTest.java
+++ b/src/test/java/org/cactoos/io/LoggingInputStreamTest.java
@@ -24,8 +24,11 @@
 package org.cactoos.io;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNull;
 import org.junit.Test;
 
 /**
@@ -35,6 +38,24 @@ import org.junit.Test;
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 public final class LoggingInputStreamTest {
+
+    @Test(expected = IOException.class)
+    public void reThrowsException() throws Exception {
+        final LoggingInputStream stream = new LoggingInputStream(
+            new InputStream() {
+                @Override
+                public int read() throws IOException {
+                    throw new IOException("some read exception");
+                }
+            },
+            this.getClass().getSimpleName()
+        );
+        MatcherAssert.assertThat(
+            "Exception will be thrown so the value is ignored",
+            stream.read(),
+            new IsNull<>()
+        );
+    }
 
     @Test
     public void readEmptyStream() throws Exception {

--- a/src/test/java/org/cactoos/io/LoggingInputStreamTest.java
+++ b/src/test/java/org/cactoos/io/LoggingInputStreamTest.java
@@ -45,7 +45,7 @@ public final class LoggingInputStreamTest {
             this.getClass().getSimpleName()
         );
         MatcherAssert.assertThat(
-            "read empty stream behavior is the same as of JDK",
+            "Read empty stream behavior is the same as of JDK",
             stream.read(),
             new IsEqual<>(
                 new ByteArrayInputStream(

--- a/src/test/java/org/cactoos/io/LoggingInputStreamTest.java
+++ b/src/test/java/org/cactoos/io/LoggingInputStreamTest.java
@@ -45,7 +45,7 @@ public final class LoggingInputStreamTest {
             new InputStream() {
                 @Override
                 public int read() throws IOException {
-                    throw new IOException("some read exception");
+                    throw new IOException("Some read exception");
                 }
             },
             this.getClass().getSimpleName()

--- a/src/test/java/org/cactoos/io/LoggingInputStreamTest.java
+++ b/src/test/java/org/cactoos/io/LoggingInputStreamTest.java
@@ -67,7 +67,7 @@ public final class LoggingInputStreamTest {
             this.getClass().getSimpleName()
         );
         new Assertion<>(
-            "Read empty stream behavior is the same as of JDK",
+            "Can't read correctly an logged empty stream",
             stream::read,
             new IsEqual<>(
                 new ByteArrayInputStream(

--- a/src/test/java/org/cactoos/io/LoggingInputStreamTest.java
+++ b/src/test/java/org/cactoos/io/LoggingInputStreamTest.java
@@ -30,6 +30,7 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNull;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 
 /**
  * Test case for {@link LoggingInputStream}.
@@ -39,8 +40,8 @@ import org.junit.Test;
  */
 public final class LoggingInputStreamTest {
 
-    @Test(expected = IOException.class)
-    public void reThrowsException() throws Exception {
+    @Test(expected = Exception.class)
+    public void reThrowsException() throws IOException {
         final LoggingInputStream stream = new LoggingInputStream(
             new InputStream() {
                 @Override
@@ -51,28 +52,28 @@ public final class LoggingInputStreamTest {
             this.getClass().getSimpleName()
         );
         MatcherAssert.assertThat(
-            "Exception will be thrown so the value is ignored",
+            "Read doesn't throw an the exception",
             stream.read(),
             new IsNull<>()
         );
     }
 
     @Test
-    public void readEmptyStream() throws Exception {
+    public void readEmptyStream() {
         final LoggingInputStream stream = new LoggingInputStream(
             new ByteArrayInputStream(
                 "".getBytes()
             ),
             this.getClass().getSimpleName()
         );
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Read empty stream behavior is the same as of JDK",
-            stream.read(),
+            stream::read,
             new IsEqual<>(
                 new ByteArrayInputStream(
                     "".getBytes()
                 ).read()
             )
-        );
+        ).affirm();
     }
 }


### PR DESCRIPTION
Currently, read() on empty stream returns 0 while according to JDK it should return -1
This PR:
* adds a unit test
* fixes the issue

