### PR TITLE
(#891) findbugs should be enabled in qulice

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,16 @@ The MIT License (MIT)
             <configuration>
               <excludes combine.children="append">
                 <exclude>checkstyle:/src/site/resources/.*</exclude>
-                <exclude>findbugs:.*</exclude>
+                <exclude>findbugs:org.cactoos.text.TextEnvelopeTest</exclude>
+                <exclude>findbugs:org.cactoos.text.ComparableText</exclude>
+                <exclude>findbugs:org.cactoos.collection.CollectionEnvelope</exclude>
+                <exclude>findbugs:org.cactoos.map.MapEnvelope</exclude>
+                <exclude>findbugs:org.cactoos.text.TextEnvelope</exclude>
+                <exclude>findbugs:org.cactoos.map.MapEntry</exclude>
+                <exclude>findbugs:org.cactoos.scalar.NumberOf</exclude>
+                <exclude>findbugs:org.cactoos.text.TextEnvelopeTest</exclude>
+                <exclude>findbugs:org.cactoos.iterator.Cycled</exclude>
+                <exclude>findbugs:org.cactoos.iterator.Endless</exclude>
               </excludes>
             </configuration>
           </plugin>

--- a/src/main/java/org/cactoos/list/ListEnvelope.java
+++ b/src/main/java/org/cactoos/list/ListEnvelope.java
@@ -100,14 +100,14 @@ abstract class ListEnvelope<T> extends CollectionEnvelope<T> implements
 
     @Override
     public final ListIterator<T> listIterator() {
-        return new org.cactoos.list.ListIterator<>(
+        return new ListIteratorOf<>(
             this.list.value().listIterator()
         );
     }
 
     @Override
     public final ListIterator<T> listIterator(final int index) {
-        return new org.cactoos.list.ListIterator<>(
+        return new ListIteratorOf<>(
             this.list.value().listIterator(index)
         );
     }

--- a/src/main/java/org/cactoos/list/ListIteratorOf.java
+++ b/src/main/java/org/cactoos/list/ListIteratorOf.java
@@ -24,6 +24,7 @@
 package org.cactoos.list;
 
 import java.util.List;
+import java.util.ListIterator;
 import org.cactoos.Scalar;
 import org.cactoos.scalar.StickyScalar;
 import org.cactoos.scalar.UncheckedScalar;
@@ -36,18 +37,18 @@ import org.cactoos.scalar.UncheckedScalar;
  * @param <T> Items type
  * @since 0.35
  */
-public final class ListIterator<T> implements java.util.ListIterator<T> {
+public final class ListIteratorOf<T> implements ListIterator<T> {
 
     /**
      * Original list iterator.
      */
-    private final UncheckedScalar<java.util.ListIterator<T>> origin;
+    private final UncheckedScalar<ListIterator<T>> origin;
 
     /**
      * Ctor.
      * @param list List that will be called to get a list iterator.
      */
-    public ListIterator(final List<T> list) {
+    public ListIteratorOf(final List<T> list) {
         this(list::listIterator);
     }
 
@@ -56,7 +57,7 @@ public final class ListIterator<T> implements java.util.ListIterator<T> {
      * @param list List that will be called to get a list iterator.
      * @param index Start index for a newly created list iterator.
      */
-    public ListIterator(final List<T> list, final int index) {
+    public ListIteratorOf(final List<T> list, final int index) {
         this(() -> list.listIterator(index));
     }
 
@@ -64,7 +65,7 @@ public final class ListIterator<T> implements java.util.ListIterator<T> {
      * Ctor.
      * @param iter Original list iterator.
      */
-    public ListIterator(final java.util.ListIterator<T> iter) {
+    public ListIteratorOf(final ListIterator<T> iter) {
         this(() -> iter);
     }
 
@@ -72,7 +73,7 @@ public final class ListIterator<T> implements java.util.ListIterator<T> {
      * Ctor.
      * @param orig Original list iterator.
      */
-    public ListIterator(final Scalar<java.util.ListIterator<T>> orig) {
+    public ListIteratorOf(final Scalar<ListIterator<T>> orig) {
         this.origin = new UncheckedScalar<>(new StickyScalar<>(orig));
     }
 

--- a/src/test/java/org/cactoos/list/ListEnvelopeTest.java
+++ b/src/test/java/org/cactoos/list/ListEnvelopeTest.java
@@ -88,7 +88,7 @@ public final class ListEnvelopeTest {
     public void getsPreviousIndex() {
         MatcherAssert.assertThat(
             "List iterator returns incorrect previous index",
-            new org.cactoos.list.ListIterator<>(
+            new ListIteratorOf<>(
                 new ListOf<>(1)
             ).previousIndex(),
             new IsEqual<>(-1)
@@ -99,7 +99,7 @@ public final class ListEnvelopeTest {
     public void getsPrevious() {
         MatcherAssert.assertThat(
             "List iterator returns incorrect previous item",
-            new org.cactoos.list.ListIterator<>(
+            new ListIteratorOf<>(
                 new ListOf<>(3, 7),
                 1
             ).previous(),
@@ -111,7 +111,7 @@ public final class ListEnvelopeTest {
     public void getsNextIndex() {
         MatcherAssert.assertThat(
             "List iterator returns incorrect next index",
-            new org.cactoos.list.ListIterator<>(
+            new ListIteratorOf<>(
                 new ListOf<>(1)
             ).nextIndex(),
             new IsEqual<>(0)
@@ -122,7 +122,7 @@ public final class ListEnvelopeTest {
     public void getsNext() {
         MatcherAssert.assertThat(
             "List iterator returns incorrect next item",
-            new org.cactoos.list.ListIterator<>(
+            new ListIteratorOf<>(
                 new ListOf<>(5, 11, 13),
                 1
             ).next(),


### PR DESCRIPTION
This PR:
Enables FindBugs (#891)  - 
Since external dependencies [are not allowed](https://github.com/yegor256/cactoos/pull/1020#issuecomment-457833335), the exclusion of the check can only be done on per-class basis in pom.xml