### PR TITLE
(#1065) Applied new naming convention in text package

### DIFF
--- a/src/main/java/org/cactoos/io/TempFolder.java
+++ b/src/main/java/org/cactoos/io/TempFolder.java
@@ -33,7 +33,7 @@ import org.cactoos.Scalar;
 import org.cactoos.Text;
 import org.cactoos.scalar.IoCheckedScalar;
 import org.cactoos.scalar.StickyScalar;
-import org.cactoos.text.JoinedText;
+import org.cactoos.text.Joined;
 import org.cactoos.text.Randomized;
 import org.cactoos.text.TextOf;
 
@@ -59,7 +59,7 @@ public final class TempFolder implements Scalar<Path>, Closeable {
      */
     public TempFolder() {
         this(
-            new JoinedText(
+            new Joined(
                 new TextOf(""),
                 new TextOf("tmp"),
                 new Randomized(
@@ -98,7 +98,7 @@ public final class TempFolder implements Scalar<Path>, Closeable {
             new StickyScalar<>(
                 () -> Files.createDirectory(
                     Paths.get(
-                        new JoinedText(
+                        new Joined(
                             File.separator,
                             System.getProperty("java.io.tmpdir"),
                             path.asString()

--- a/src/main/java/org/cactoos/text/Joined.java
+++ b/src/main/java/org/cactoos/text/Joined.java
@@ -36,14 +36,14 @@ import org.cactoos.iterable.Mapped;
  *
  * @since 0.9
  */
-public final class JoinedText extends TextEnvelope {
+public final class Joined extends TextEnvelope {
 
     /**
      * Ctor.
      * @param delimit Delimit among strings
      * @param strs Strings to be joined
      */
-    public JoinedText(final String delimit, final String... strs) {
+    public Joined(final String delimit, final String... strs) {
         this(delimit, new IterableOf<>(strs));
     }
 
@@ -52,7 +52,7 @@ public final class JoinedText extends TextEnvelope {
      * @param delimit Delimit among strings
      * @param strs Strings to be joined
      */
-    public JoinedText(final String delimit, final Iterable<String> strs) {
+    public Joined(final String delimit, final Iterable<String> strs) {
         this(
             new TextOf(delimit),
             new Mapped<>(TextOf::new, strs)
@@ -64,7 +64,7 @@ public final class JoinedText extends TextEnvelope {
      * @param delimit Delimit among texts
      * @param txts Texts to be joined
      */
-    public JoinedText(final Text delimit, final Text... txts) {
+    public Joined(final Text delimit, final Text... txts) {
         this(delimit, new IterableOf<>(txts));
     }
 
@@ -73,7 +73,7 @@ public final class JoinedText extends TextEnvelope {
      * @param delimit Delimit among texts
      * @param txts Texts to be joined
      */
-    public JoinedText(final Text delimit, final Iterable<? extends Text> txts) {
+    public Joined(final Text delimit, final Iterable<? extends Text> txts) {
         super((Scalar<String>) () -> {
             final StringJoiner joint =
                 new StringJoiner(delimit.asString());

--- a/src/main/java/org/cactoos/text/Normalized.java
+++ b/src/main/java/org/cactoos/text/Normalized.java
@@ -23,33 +23,37 @@
  */
 package org.cactoos.text;
 
+import org.cactoos.Scalar;
 import org.cactoos.Text;
 
 /**
- * Text without control characters (char &lt;= 32) from both ends.
+ * Normalize (replace sequences of whitespace characters by a single space)
+ * a Text.
  *
- * <p>There is no thread-safety guarantee.
- *
- * @since 0.1
+ * @since 0.9
  */
-public final class TrimmedText implements Text {
-
-    /**
-     * The text.
-     */
-    private final Text origin;
+public final class Normalized extends TextEnvelope {
 
     /**
      * Ctor.
-     * @param text The text
+     * @param text A Text
      */
-    public TrimmedText(final Text text) {
-        this.origin = text;
+    public Normalized(final String text) {
+        this(new TextOf(text));
     }
 
-    @Override
-    public String asString() throws Exception {
-        return this.origin.asString().trim();
+    /**
+     * Ctor.
+     * @param text A Text
+     */
+    public Normalized(final Text text) {
+        super(
+            (Scalar<String>) () -> new Replaced(
+                new Trimmed(text),
+                "\\s+",
+                " "
+            ).asString()
+        );
     }
-
 }
+

--- a/src/main/java/org/cactoos/text/PaddedStartText.java
+++ b/src/main/java/org/cactoos/text/PaddedStartText.java
@@ -45,7 +45,7 @@ public final class PaddedStartText extends TextEnvelope {
         final Text text, final int length, final char symbol) {
         super((Scalar<String>) () -> {
             final String original = text.asString();
-            return new JoinedText(
+            return new Joined(
                 new TextOf(""),
                 new Repeated(
                     new TextOf(symbol), length - original.length()

--- a/src/main/java/org/cactoos/text/TextOf.java
+++ b/src/main/java/org/cactoos/text/TextOf.java
@@ -330,7 +330,7 @@ public final class TextOf extends TextEnvelope {
      */
     public TextOf(final Iterable<?> iterable) {
         this(
-            () -> new JoinedText(
+            () -> new Joined(
                 ", ",
                 new Mapped<>(
                     Object::toString,

--- a/src/main/java/org/cactoos/text/Trimmed.java
+++ b/src/main/java/org/cactoos/text/Trimmed.java
@@ -23,32 +23,33 @@
  */
 package org.cactoos.text;
 
-import org.hamcrest.MatcherAssert;
-import org.junit.Test;
-import org.llorllale.cactoos.matchers.TextHasString;
+import org.cactoos.Text;
 
 /**
- * Test case for {@link TrimmedText}.
+ * Text without control characters (char &lt;= 32) from both ends.
+ *
+ * <p>There is no thread-safety guarantee.
+ *
  * @since 0.1
- * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class TrimmedTextTest {
+public final class Trimmed implements Text {
 
-    @Test
-    public void convertsText() {
-        MatcherAssert.assertThat(
-            "Can't trim a text",
-            new TrimmedText(new TextOf("  Hello!   \t ")),
-            new TextHasString("Hello!")
-        );
+    /**
+     * The text.
+     */
+    private final Text origin;
+
+    /**
+     * Ctor.
+     * @param text The text
+     */
+    public Trimmed(final Text text) {
+        this.origin = text;
     }
 
-    @Test
-    public void trimmedBlankTextIsEmptyText() {
-        MatcherAssert.assertThat(
-            "Can't trim a blank text",
-            new TrimmedText(new TextOf("  \t ")),
-            new TextHasString("")
-        );
+    @Override
+    public String asString() throws Exception {
+        return this.origin.asString().trim();
     }
+
 }

--- a/src/main/java/org/cactoos/text/package-info.java
+++ b/src/main/java/org/cactoos/text/package-info.java
@@ -26,9 +26,9 @@
  * Text.
  *
  * @since 0.1
- * @todo #1005:30min Continue applying the new class naming convention:
- *  avoid compound names for decorators. Continue renaming classes implementing
- *  the {@link org.cactoos.Text}. More details you can find here
+ * @todo #1065:30min Continue applying the new class naming convention:
+ *  avoid compound names for decorators. Continue renaming of classes
+ *  implementing the {@link org.cactoos.Text}. More details you can find here
  *  https://github.com/yegor256/cactoos/issues/913#issuecomment-402332247.
  */
 package org.cactoos.text;

--- a/src/test/java/org/cactoos/io/AppendToTest.java
+++ b/src/test/java/org/cactoos/io/AppendToTest.java
@@ -26,7 +26,7 @@ package org.cactoos.io;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.NoSuchFileException;
-import org.cactoos.text.JoinedText;
+import org.cactoos.text.Joined;
 import org.cactoos.text.Randomized;
 import org.junit.Rule;
 import org.junit.Test;
@@ -83,7 +83,7 @@ public final class AppendToTest {
         new Assertion<>(
             "Does not contain expected text",
             () -> new InputOf(source),
-            new InputHasContent(new JoinedText("", first, second))
+            new InputHasContent(new Joined("", first, second))
         ).affirm();
     }
 
@@ -105,7 +105,7 @@ public final class AppendToTest {
         new Assertion<>(
             "Can't find expected unicode text content",
             () -> new InputOf(source),
-            new InputHasContent(new JoinedText("", first, second))
+            new InputHasContent(new Joined("", first, second))
         ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/io/BytesOfTest.java
+++ b/src/test/java/org/cactoos/io/BytesOfTest.java
@@ -32,7 +32,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.cactoos.Text;
 import org.cactoos.iterable.Endless;
 import org.cactoos.iterable.HeadOf;
-import org.cactoos.text.JoinedText;
+import org.cactoos.text.Joined;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -57,7 +57,7 @@ public final class BytesOfTest {
             "Can't read large content from in-memory Input",
             new BytesOf(
                 new InputOf(
-                    new JoinedText(
+                    new Joined(
                         "",
                         new HeadOf<>(
                             multiplier, new Endless<>(body)
@@ -181,7 +181,7 @@ public final class BytesOfTest {
                 )
             ),
             new TextHasString(
-                new JoinedText(
+                new Joined(
                     System.lineSeparator(),
                     "java.io.IOException: It doesn't work at all",
                     "\tat org.cactoos.io.BytesOfTest"

--- a/src/test/java/org/cactoos/io/FakeHandler.java
+++ b/src/test/java/org/cactoos/io/FakeHandler.java
@@ -27,7 +27,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Handler;
 import java.util.logging.LogRecord;
-import org.cactoos.text.JoinedText;
+import org.cactoos.text.Joined;
 import org.cactoos.text.UncheckedText;
 
 /**
@@ -64,7 +64,7 @@ public final class FakeHandler extends Handler {
     @Override
     public String toString() {
         return new UncheckedText(
-            new JoinedText(
+            new Joined(
                 System.lineSeparator(),
                 this.entries
             )

--- a/src/test/java/org/cactoos/iterable/ReversedTest.java
+++ b/src/test/java/org/cactoos/iterable/ReversedTest.java
@@ -23,7 +23,7 @@
  */
 package org.cactoos.iterable;
 
-import org.cactoos.text.JoinedText;
+import org.cactoos.text.Joined;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 import org.llorllale.cactoos.matchers.TextHasString;
@@ -39,7 +39,7 @@ public final class ReversedTest {
     public void reversesIterable() {
         MatcherAssert.assertThat(
             "Can't reverse an iterable",
-            new JoinedText(
+            new Joined(
                 " ",
                 new Reversed<>(
                     new IterableOf<>(

--- a/src/test/java/org/cactoos/text/JoinedTest.java
+++ b/src/test/java/org/cactoos/text/JoinedTest.java
@@ -23,9 +23,8 @@
  */
 package org.cactoos.text;
 
-import java.io.IOException;
-import org.hamcrest.MatcherAssert;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.TextHasString;
 
 /**
@@ -36,25 +35,25 @@ import org.llorllale.cactoos.matchers.TextHasString;
 public final class JoinedTest {
 
     @Test
-    public void joinsStrings() throws IOException {
-        MatcherAssert.assertThat(
+    public void joinsStrings() {
+        new Assertion<>(
             "Can't join strings",
-            new Joined(" ", "hello", "world"),
+            () -> new Joined(" ", "hello", "world"),
             new TextHasString("hello world")
-        );
+        ).affirm();
     }
 
     @Test
-    public void joinsTexts() throws IOException {
-        MatcherAssert.assertThat(
+    public void joinsTexts() {
+        new Assertion<>(
             "Can't join texts",
-            new Joined(
+            () -> new Joined(
                 new TextOf(" "),
                 new TextOf("foo"),
                 new TextOf("bar")
             ),
             new TextHasString("foo bar")
-        );
+        ).affirm();
     }
 
 }

--- a/src/test/java/org/cactoos/text/JoinedTest.java
+++ b/src/test/java/org/cactoos/text/JoinedTest.java
@@ -23,37 +23,38 @@
  */
 package org.cactoos.text;
 
-import org.cactoos.Scalar;
-import org.cactoos.Text;
+import java.io.IOException;
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+import org.llorllale.cactoos.matchers.TextHasString;
 
 /**
- * Normalize (replace sequences of whitespace characters by a single space)
- * a Text.
- *
+ * Test case for {@link Joined}.
  * @since 0.9
+ * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class NormalizedText extends TextEnvelope {
+public final class JoinedTest {
 
-    /**
-     * Ctor.
-     * @param text A Text
-     */
-    public NormalizedText(final String text) {
-        this(new TextOf(text));
-    }
-
-    /**
-     * Ctor.
-     * @param text A Text
-     */
-    public NormalizedText(final Text text) {
-        super(
-            (Scalar<String>) () -> new Replaced(
-                new TrimmedText(text),
-                "\\s+",
-                " "
-            ).asString()
+    @Test
+    public void joinsStrings() throws IOException {
+        MatcherAssert.assertThat(
+            "Can't join strings",
+            new Joined(" ", "hello", "world"),
+            new TextHasString("hello world")
         );
     }
-}
 
+    @Test
+    public void joinsTexts() throws IOException {
+        MatcherAssert.assertThat(
+            "Can't join texts",
+            new Joined(
+                new TextOf(" "),
+                new TextOf("foo"),
+                new TextOf("bar")
+            ),
+            new TextHasString("foo bar")
+        );
+    }
+
+}

--- a/src/test/java/org/cactoos/text/NormalizedTest.java
+++ b/src/test/java/org/cactoos/text/NormalizedTest.java
@@ -29,31 +29,18 @@ import org.junit.Test;
 import org.llorllale.cactoos.matchers.TextHasString;
 
 /**
- * Test case for {@link JoinedText}.
+ * Test case for {@link Normalized}.
  * @since 0.9
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class JoinedTextTest {
+public final class NormalizedTest {
 
     @Test
-    public void joinsStrings() throws IOException {
+    public void normalizesText() throws IOException {
         MatcherAssert.assertThat(
-            "Can't join strings",
-            new JoinedText(" ", "hello", "world"),
+            "Can't normalize a text",
+            new Normalized(" \t hello  \t\tworld   \t"),
             new TextHasString("hello world")
-        );
-    }
-
-    @Test
-    public void joinsTexts() throws IOException {
-        MatcherAssert.assertThat(
-            "Can't join texts",
-            new JoinedText(
-                new TextOf(" "),
-                new TextOf("foo"),
-                new TextOf("bar")
-            ),
-            new TextHasString("foo bar")
         );
     }
 

--- a/src/test/java/org/cactoos/text/NormalizedTest.java
+++ b/src/test/java/org/cactoos/text/NormalizedTest.java
@@ -23,9 +23,8 @@
  */
 package org.cactoos.text;
 
-import java.io.IOException;
-import org.hamcrest.MatcherAssert;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.TextHasString;
 
 /**
@@ -36,12 +35,12 @@ import org.llorllale.cactoos.matchers.TextHasString;
 public final class NormalizedTest {
 
     @Test
-    public void normalizesText() throws IOException {
-        MatcherAssert.assertThat(
+    public void normalizesText() {
+        new Assertion<>(
             "Can't normalize a text",
-            new Normalized(" \t hello  \t\tworld   \t"),
+            () -> new Normalized(" \t hello  \t\tworld   \t"),
             new TextHasString("hello world")
-        );
+        ).affirm();
     }
 
 }

--- a/src/test/java/org/cactoos/text/TextEnvelopeTest.java
+++ b/src/test/java/org/cactoos/text/TextEnvelopeTest.java
@@ -68,7 +68,7 @@ public final class TextEnvelopeTest {
     /**
      * Test for {@link TextEnvelope#equals(Object)} method. Must assert
      * that the envelope value is equal another text representing the same
-     * value (in this case a {@link JoinedText}).
+     * value (in this case a {@link Joined}).
      */
     @Test
     public void testEqualsOtherText() {
@@ -76,7 +76,7 @@ public final class TextEnvelopeTest {
             "Envelope does not match another text representing the same value",
             new TextEnvelopeDummy("isequaltoanothertext"),
             new IsEqual<>(
-                new JoinedText("", "is", "equal", "to", "another", "text")
+                new Joined("", "is", "equal", "to", "another", "text")
             )
         );
     }

--- a/src/test/java/org/cactoos/text/TextOfTest.java
+++ b/src/test/java/org/cactoos/text/TextOfTest.java
@@ -233,7 +233,7 @@ public final class TextOfTest {
                 )
             ),
             new TextHasString(
-                new JoinedText(
+                new Joined(
                     System.lineSeparator(),
                     "java.io.IOException: It doesn't work at all",
                     "\tat org.cactoos.text.TextOfTest"

--- a/src/test/java/org/cactoos/text/TrimmedTest.java
+++ b/src/test/java/org/cactoos/text/TrimmedTest.java
@@ -23,25 +23,32 @@
  */
 package org.cactoos.text;
 
-import java.io.IOException;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 import org.llorllale.cactoos.matchers.TextHasString;
 
 /**
- * Test case for {@link NormalizedText}.
- * @since 0.9
+ * Test case for {@link Trimmed}.
+ * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class NormalizedTextTest {
+public final class TrimmedTest {
 
     @Test
-    public void normalizesText() throws IOException {
+    public void convertsText() {
         MatcherAssert.assertThat(
-            "Can't normalize a text",
-            new NormalizedText(" \t hello  \t\tworld   \t"),
-            new TextHasString("hello world")
+            "Can't trim a text",
+            new Trimmed(new TextOf("  Hello!   \t ")),
+            new TextHasString("Hello!")
         );
     }
 
+    @Test
+    public void trimmedBlankTextIsEmptyText() {
+        MatcherAssert.assertThat(
+            "Can't trim a blank text",
+            new Trimmed(new TextOf("  \t ")),
+            new TextHasString("")
+        );
+    }
 }

--- a/src/test/java/org/cactoos/text/TrimmedTest.java
+++ b/src/test/java/org/cactoos/text/TrimmedTest.java
@@ -23,8 +23,8 @@
  */
 package org.cactoos.text;
 
-import org.hamcrest.MatcherAssert;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.TextHasString;
 
 /**
@@ -36,19 +36,19 @@ public final class TrimmedTest {
 
     @Test
     public void convertsText() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't trim a text",
-            new Trimmed(new TextOf("  Hello!   \t ")),
+            () -> new Trimmed(new TextOf("  Hello!   \t ")),
             new TextHasString("Hello!")
-        );
+        ).affirm();
     }
 
     @Test
     public void trimmedBlankTextIsEmptyText() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't trim a blank text",
-            new Trimmed(new TextOf("  \t ")),
+            () -> new Trimmed(new TextOf("  \t ")),
             new TextHasString("")
-        );
+        ).affirm();
     }
 }


### PR DESCRIPTION
As described in #1065. New naming convention was applied to Joined, Normalized and Trimmed. Puzzle were updated to continue.