### PR TITLE
(#884) Remove nulls from Async class

### DIFF
--- a/src/main/java/org/cactoos/func/Async.java
+++ b/src/main/java/org/cactoos/func/Async.java
@@ -45,11 +45,6 @@ import org.cactoos.Proc;
  * @param <X> Type of input
  * @param <Y> Type of output
  * @since 0.10
- * @todo #861:30min Avoid usage of null value in ctor(Proc, ExecutorService),
- *  ctor(Proc, ThreadFactory) and ctor(Proc) which is against design
- *  principles.
- *  Perhaps with a creation of AsyncProc or removal of this functionality?
- *  Please take a look on #551 and #843 for more details.
  */
 public final class Async<X, Y> implements Func<X, Future<Y>>, Proc<X> {
 
@@ -65,27 +60,10 @@ public final class Async<X, Y> implements Func<X, Future<Y>>, Proc<X> {
 
     /**
      * Ctor.
-     * @param proc The proc
-     */
-    public Async(final Proc<X> proc) {
-        this(new FuncOf<>(proc, null));
-    }
-
-    /**
-     * Ctor.
      * @param fnc The func
      */
     public Async(final Func<X, Y> fnc) {
         this(fnc, Executors.defaultThreadFactory());
-    }
-
-    /**
-     * Ctor.
-     * @param proc The proc
-     * @param fct Factory
-     */
-    public Async(final Proc<X> proc, final ThreadFactory fct) {
-        this(new FuncOf<>(proc, null), fct);
     }
 
     /**
@@ -95,16 +73,6 @@ public final class Async<X, Y> implements Func<X, Future<Y>>, Proc<X> {
      */
     public Async(final Func<X, Y> fnc, final ThreadFactory fct) {
         this(fnc, Executors.newSingleThreadExecutor(fct));
-    }
-
-    /**
-     * Ctor.
-     * @param proc The proc
-     * @param exec Executor Service
-     * @since 0.17
-     */
-    public Async(final Proc<X> proc, final ExecutorService exec) {
-        this(new FuncOf<>(proc, null), exec);
     }
 
     /**

--- a/src/test/java/org/cactoos/func/AsyncTest.java
+++ b/src/test/java/org/cactoos/func/AsyncTest.java
@@ -27,10 +27,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import org.cactoos.Proc;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.FuncApplies;
 import org.llorllale.cactoos.matchers.MatcherOf;
 
@@ -39,13 +38,14 @@ import org.llorllale.cactoos.matchers.MatcherOf;
  *
  * @since 0.10
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class AsyncTest {
     @Test
     public void runsInBackground() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't run in the background",
-            new Async<>(
+            () -> new Async<>(
                 input -> {
                     TimeUnit.DAYS.sleep(1L);
                     return "done!";
@@ -57,36 +57,34 @@ public final class AsyncTest {
                     future -> !future.isDone()
                 )
             )
-        );
+        ).affirm();
     }
 
     @Test
     public void runsAsProcInBackground() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't run proc in the background",
-            input -> {
+            () -> input -> {
                 final CountDownLatch latch = new CountDownLatch(1);
                 new Async<>(
-                    (Proc<Boolean>) ipt -> latch.countDown()
+                    new FuncOf<>(ipt -> latch.countDown(), true)
                 ).exec(input);
                 latch.await();
                 return true;
             },
             new FuncApplies<>(
-                true, Matchers.equalTo(true)
+                true, new IsEqual<>(true)
             )
-        );
+        ).affirm();
     }
 
     @Test
     public void runsInBackgroundWithoutFuture() {
         final CountDownLatch latch = new CountDownLatch(1);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't run in the background without us touching the Future",
-            new Async<>(
-                input -> {
-                    latch.countDown();
-                }
+            () -> new Async<>(
+                new FuncOf<>(input -> latch.countDown(), true)
             ),
             new FuncApplies<>(
                 true,
@@ -96,7 +94,7 @@ public final class AsyncTest {
                     }
                 )
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -104,17 +102,20 @@ public final class AsyncTest {
         final String name = "secret name for thread factory";
         final ThreadFactory factory = r -> new Thread(r, name);
         final CountDownLatch latch = new CountDownLatch(1);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't run in the background with specific thread factory",
-            new Async<>(
-                input -> {
-                    if (!input.equals(Thread.currentThread().getName())) {
-                        throw new IllegalStateException(
-                            "Another thread factory was used"
-                        );
-                    }
-                    latch.countDown();
-                },
+            () -> new Async<>(
+                new FuncOf<>(
+                    input -> {
+                        if (!input.equals(Thread.currentThread().getName())) {
+                            throw new IllegalStateException(
+                                "Another thread factory was used"
+                            );
+                        }
+                        latch.countDown();
+                    },
+                    true
+                ),
                 factory
             ),
             new FuncApplies<>(
@@ -126,7 +127,7 @@ public final class AsyncTest {
                     }
                 )
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -134,17 +135,20 @@ public final class AsyncTest {
         final String name = "secret name for thread executor";
         final ThreadFactory factory = r -> new Thread(r, name);
         final CountDownLatch latch = new CountDownLatch(1);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't run in the background with specific thread executor",
-            new Async<>(
-                input -> {
-                    if (!input.equals(Thread.currentThread().getName())) {
-                        throw new IllegalStateException(
-                            "Another thread executor was used"
-                        );
-                    }
-                    latch.countDown();
-                },
+            () -> new Async<>(
+                new FuncOf<>(
+                    input -> {
+                        if (!input.equals(Thread.currentThread().getName())) {
+                            throw new IllegalStateException(
+                                "Another thread executor was used"
+                            );
+                        }
+                        latch.countDown();
+                    },
+                    true
+                ),
                 Executors.newSingleThreadExecutor(factory)
             ),
             new FuncApplies<>(
@@ -156,6 +160,6 @@ public final class AsyncTest {
                     }
                 )
             )
-        );
+        ).affirm();
     }
 }


### PR DESCRIPTION
#884 : this removes null from `Async` and also update tests to illustrate its usage with `Proc` and `FuncOf` (as proposed by ARC here: https://github.com/yegor256/cactoos/issues/551#issuecomment-386879090).

I also updated the rests to use `Assertion` while I was at it