### PR TITLE
(#1064) Removed sticky decorators from io tests package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@ The MIT License (MIT)
     <dependency>
       <groupId>org.llorllale</groupId>
       <artifactId>cactoos-matchers</artifactId>
-      <version>0.13</version>
+      <version>0.14</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/org/cactoos/io/AppendToTest.java
+++ b/src/test/java/org/cactoos/io/AppendToTest.java
@@ -61,7 +61,7 @@ public final class AppendToTest {
         );
         new Assertion<>(
             "Can't throw exception with proper message",
-            () -> () -> new AppendTo(source).stream(),
+            () -> new AppendTo(source).stream(),
             new Throws<>(
                 source.getPath(),
                 NoSuchFileException.class

--- a/src/test/java/org/cactoos/io/HeadInputStreamTest.java
+++ b/src/test/java/org/cactoos/io/HeadInputStreamTest.java
@@ -28,7 +28,7 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 import org.llorllale.cactoos.matchers.Assertion;
-import org.llorllale.cactoos.matchers.TextHasString;
+import org.llorllale.cactoos.matchers.InputHasContent;
 import org.llorllale.cactoos.matchers.TextIs;
 
 /**
@@ -50,10 +50,8 @@ public final class HeadInputStreamTest {
         stream.skip(3L);
         new Assertion<>(
             "Incorrect head of the input stream has been read",
-            () -> new TextOf(
-                new Sticky(() -> stream)
-            ),
-            new TextHasString("tS")
+            () -> new InputOf(stream),
+            new InputHasContent("tS")
         ).affirm();
     }
 
@@ -82,10 +80,8 @@ public final class HeadInputStreamTest {
         stream.reset();
         new Assertion<>(
             "Reset didn't change the state",
-            () -> new TextOf(
-                new Sticky(() -> stream)
-            ),
-            new TextHasString("testR")
+            () -> new InputOf(stream),
+            new InputHasContent("testR")
         ).affirm();
     }
 

--- a/src/test/java/org/cactoos/io/LoggingInputStreamTest.java
+++ b/src/test/java/org/cactoos/io/LoggingInputStreamTest.java
@@ -53,7 +53,7 @@ public final class LoggingInputStreamTest {
         );
         new Assertion<>(
             "Read doesn't throw an the exception.",
-            () -> stream::read,
+            () -> stream.read(),
             new Throws<>(message, IOException.class)
         ).affirm();
     }

--- a/src/test/java/org/cactoos/io/TeeOutputTest.java
+++ b/src/test/java/org/cactoos/io/TeeOutputTest.java
@@ -32,6 +32,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.InputHasContent;
 import org.llorllale.cactoos.matchers.TextIs;
 
 /**
@@ -52,18 +53,14 @@ public final class TeeOutputTest {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         new Assertion<>(
             "Can't copy Output to Output and return Input",
-            () -> new TextOf(
-                new Sticky(
-                    new TeeInput(
-                        new InputOf("Hello, товарищ!"),
-                            new TeeOutput(
-                            new OutputTo(baos),
-                            new OutputTo(new ByteArrayOutputStream())
-                        )
+            () -> new TeeInput(
+                new InputOf("Hello, товарищ!"),
+                    new TeeOutput(
+                        new OutputTo(baos),
+                        new OutputTo(new ByteArrayOutputStream())
                     )
-                )
             ),
-            new TextIs(
+            new InputHasContent(
                 new TextOf(baos::toByteArray, StandardCharsets.UTF_8)
             )
         ).affirm();
@@ -74,18 +71,14 @@ public final class TeeOutputTest {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         new Assertion<>(
             "Can't copy Output with writer",
-            () -> new TextOf(
-                new Sticky(
-                    new TeeInput(
-                        new InputOf("Hello, товарищ! writer"),
-                        new TeeOutput(
-                            new OutputTo(baos),
-                            new WriterTo(new ByteArrayOutputStream())
-                        )
-                    )
+            () -> new TeeInput(
+                new InputOf("Hello, товарищ! writer"),
+                new TeeOutput(
+                    new OutputTo(baos),
+                    new WriterTo(new ByteArrayOutputStream())
                 )
             ),
-            new TextIs(
+            new InputHasContent(
                 new TextOf(baos::toByteArray, StandardCharsets.UTF_8)
             )
         ).affirm();
@@ -96,21 +89,17 @@ public final class TeeOutputTest {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         new Assertion<>(
             "Can't copy Output with writer and charset",
-            () -> new TextOf(
-                new Sticky(
-                    new TeeInput(
-                        new InputOf(
-                            "Hello, товарищ! writer and charset"
-                        ),
-                        new TeeOutput(
-                            new OutputTo(baos),
-                            new WriterTo(new ByteArrayOutputStream()),
-                            StandardCharsets.UTF_8
-                        )
-                    )
+            () -> new TeeInput(
+                new InputOf(
+                    "Hello, товарищ! writer and charset"
+                ),
+                new TeeOutput(
+                    new OutputTo(baos),
+                    new WriterTo(new ByteArrayOutputStream()),
+                    StandardCharsets.UTF_8
                 )
             ),
-            new TextIs(
+            new InputHasContent(
                 new TextOf(baos::toByteArray, StandardCharsets.UTF_8)
             )
         ).affirm();
@@ -163,20 +152,16 @@ public final class TeeOutputTest {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         new Assertion<>(
             "Can't copy Output with output stream",
-            () -> new TextOf(
-                new Sticky(
-                    new TeeInput(
-                        new InputOf(
-                            "Hello, товарищ! with output stream"
-                        ),
-                        new TeeOutput(
-                            new OutputTo(baos),
-                            new ByteArrayOutputStream()
-                        )
-                    )
+            () -> new TeeInput(
+                new InputOf(
+                    "Hello, товарищ! with output stream"
+                ),
+                new TeeOutput(
+                    new OutputTo(baos),
+                    new ByteArrayOutputStream()
                 )
             ),
-            new TextIs(
+            new InputHasContent(
                 new TextOf(baos::toByteArray, StandardCharsets.UTF_8)
             )
         ).affirm();

--- a/src/test/java/org/cactoos/io/WriterAsOutputStreamTest.java
+++ b/src/test/java/org/cactoos/io/WriterAsOutputStreamTest.java
@@ -37,9 +37,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.InputHasContent;
 import org.llorllale.cactoos.matchers.MatcherOf;
 import org.llorllale.cactoos.matchers.ScalarHasValue;
-import org.llorllale.cactoos.matchers.TextIs;
 
 /**
  * Test case for {@link WriterAsOutputStream}.
@@ -62,24 +62,20 @@ public final class WriterAsOutputStreamTest {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         new Assertion<>(
             "Can't copy Input to Writer",
-            () -> new TextOf(
-                new Sticky(
-                    new TeeInput(
-                        new InputOf(content),
-                        new OutputTo(
-                            new WriterAsOutputStream(
-                                new OutputStreamWriter(
-                                    baos, StandardCharsets.UTF_8
-                                ),
-                                StandardCharsets.UTF_8,
-                                // @checkstyle MagicNumber (1 line)
-                                13
-                            )
-                        )
+            () -> new TeeInput(
+                new InputOf(content),
+                new OutputTo(
+                    new WriterAsOutputStream(
+                        new OutputStreamWriter(
+                            baos, StandardCharsets.UTF_8
+                        ),
+                        StandardCharsets.UTF_8,
+                        // @checkstyle MagicNumber (1 line)
+                        13
                     )
                 )
             ),
-            new TextIs(
+            new InputHasContent(
                 new TextOf(baos::toByteArray, StandardCharsets.UTF_8)
             )
         ).affirm();
@@ -94,22 +90,18 @@ public final class WriterAsOutputStreamTest {
         )) {
             new Assertion<>(
                 "Can't copy Input to Output and return Input",
-                () -> new TextOf(
-                    new Sticky(
-                        new TeeInput(
-                            new ResourceOf("org/cactoos/large-text.txt"),
-                            new OutputTo(
-                                new WriterAsOutputStream(
-                                    writer,
-                                    StandardCharsets.UTF_8,
-                                    // @checkstyle MagicNumber (1 line)
-                                    345
-                                )
-                            )
+                () -> new TeeInput(
+                    new ResourceOf("org/cactoos/large-text.txt"),
+                    new OutputTo(
+                        new WriterAsOutputStream(
+                            writer,
+                            StandardCharsets.UTF_8,
+                            // @checkstyle MagicNumber (1 line)
+                            345
                         )
                     )
                 ),
-                new TextIs(
+                new InputHasContent(
                     new TextOf(temp)
                 )
             ).affirm();

--- a/src/test/java/org/cactoos/io/WriterAsOutputTest.java
+++ b/src/test/java/org/cactoos/io/WriterAsOutputTest.java
@@ -33,7 +33,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.llorllale.cactoos.matchers.Assertion;
-import org.llorllale.cactoos.matchers.TextIs;
+import org.llorllale.cactoos.matchers.InputHasContent;
 
 /**
  * Test case for {@link WriterAsOutput}.
@@ -58,15 +58,11 @@ public final class WriterAsOutputTest {
         )) {
             new Assertion<>(
                 "Can't copy Input to Output and return Input",
-                () -> new TextOf(
-                    new Sticky(
-                        new TeeInput(
-                            new ResourceOf("org/cactoos/large-text.txt"),
-                            new WriterAsOutput(writer)
-                        )
-                    )
+                () -> new TeeInput(
+                    new ResourceOf("org/cactoos/large-text.txt"),
+                    new WriterAsOutput(writer)
                 ),
-                new TextIs(
+                new InputHasContent(
                     new TextOf(temp)
                 )
             ).affirm();

--- a/src/test/java/org/cactoos/io/WriterToTest.java
+++ b/src/test/java/org/cactoos/io/WriterToTest.java
@@ -30,7 +30,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.llorllale.cactoos.matchers.Assertion;
-import org.llorllale.cactoos.matchers.TextIs;
+import org.llorllale.cactoos.matchers.InputHasContent;
 
 /**
  * Test case for {@link WriterTo}.
@@ -52,15 +52,11 @@ public final class WriterToTest {
             .toPath();
         new Assertion<>(
             "Can't copy Input to Output and return Input",
-            () -> new TextOf(
-                new Sticky(
-                    new TeeInput(
-                        new ResourceOf("org/cactoos/large-text.txt"),
-                        new WriterAsOutput(new WriterTo(temp))
-                    )
-                )
+            () -> new TeeInput(
+                new ResourceOf("org/cactoos/large-text.txt"),
+                new WriterAsOutput(new WriterTo(temp))
             ),
-            new TextIs(
+            new InputHasContent(
                 new TextOf(temp)
             )
         ).affirm();

--- a/src/test/java/org/cactoos/io/package-info.java
+++ b/src/test/java/org/cactoos/io/package-info.java
@@ -26,10 +26,5 @@
  * Input/Output, tests.
  *
  * @since 0.1
- * @todo #1005:30min Remove Sticky decorators from tests when:
- *  new cactoos-matchers will be released and updated as dependency.
- *  Right now, Assertion<>().affirm() is calling test twice.
- *  That is the reason why many tests in this package
- *  needs to be decorated with Sticky.
  */
 package org.cactoos.io;

--- a/src/test/java/org/cactoos/scalar/BinaryTest.java
+++ b/src/test/java/org/cactoos/scalar/BinaryTest.java
@@ -90,7 +90,7 @@ public final class BinaryTest {
         );
         new Assertion<>(
             "Binary has to throw exception",
-            () -> binary,
+            binary,
             new Throws<>(msg, IllegalArgumentException.class)
         ).affirm();
     }

--- a/src/test/java/org/cactoos/text/ReplacedTest.java
+++ b/src/test/java/org/cactoos/text/ReplacedTest.java
@@ -148,7 +148,7 @@ public final class ReplacedTest {
         final String regex = "invalid_regex{0,";
         new Assertion<>(
             "Doesn't throw proper exception",
-            () -> () -> new Replaced(
+            () -> new Replaced(
                 new TextOf("text"),
                 regex,
                 "error"


### PR DESCRIPTION
As described in #1064, sticky decorators were removed from io tests. In most of them TextOf and TextIs was replaced to InputOf and InputHasContent accordingly. It turns out that using `new TextOf(() -> input)` results in two calls to decorated input, which is the reason of tests failures.