### PR TITLE
(#901) Null-free ListIterator in list.NoNulls

### DIFF
--- a/src/main/java/org/cactoos/list/ListIteratorNoNulls.java
+++ b/src/main/java/org/cactoos/list/ListIteratorNoNulls.java
@@ -1,0 +1,106 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.cactoos.list;
+
+import java.util.ListIterator;
+
+/**
+ * A decorator of {@link ListIterator} that is immutable and tolerates no NULLs.
+ *
+ * <p>There is no thread-safety guarantee.</p>
+ *
+ * @param <T> Element type
+ * @since 0.39
+ */
+public final class ListIteratorNoNulls<T> implements ListIterator<T> {
+
+    /**
+     * ListIterator.
+     */
+    private final ListIterator<T> listiterator;
+
+    /**
+     * Ctor.
+     *
+     * @param src List iterator.
+     */
+    public ListIteratorNoNulls(final ListIterator<T> src) {
+        this.listiterator = new ListIteratorOf<>(src);
+    }
+
+    @Override
+    public boolean hasNext() {
+        return this.listiterator.hasNext();
+    }
+
+    @Override
+    public T next() {
+        final T next = this.listiterator.next();
+        if (next == null) {
+            throw new IllegalStateException("Next item is NULL");
+        }
+        return next;
+    }
+
+    @Override
+    public boolean hasPrevious() {
+        return this.listiterator.hasPrevious();
+    }
+
+    @Override
+    public T previous() {
+        final T next = this.listiterator.previous();
+        if (next == null) {
+            throw new IllegalStateException("Previous item is NULL");
+        }
+        return next;
+    }
+
+    @Override
+    public int nextIndex() {
+        return this.listiterator.nextIndex();
+    }
+
+    @Override
+    public int previousIndex() {
+        return this.listiterator.previousIndex();
+    }
+
+    @Override
+    public void remove() {
+        this.listiterator.remove();
+    }
+
+    @Override
+    public void set(final T item) {
+        this.listiterator.set(item);
+    }
+
+    @Override
+    public void add(final T item) {
+        this.listiterator.add(item);
+    }
+
+}

--- a/src/main/java/org/cactoos/list/NoNulls.java
+++ b/src/main/java/org/cactoos/list/NoNulls.java
@@ -229,12 +229,12 @@ public final class NoNulls<T> implements List<T> {
 
     @Override
     public ListIterator<T> listIterator() {
-        return this.list.listIterator();
+        return new ListIteratorNoNulls<>(this.list.listIterator());
     }
 
     @Override
     public ListIterator<T> listIterator(final int index) {
-        return this.list.listIterator(index);
+        return new ListIteratorNoNulls<>(this.list.listIterator(index));
     }
 
     @Override

--- a/src/test/java/org/cactoos/list/ListIteratorNoNullsTest.java
+++ b/src/test/java/org/cactoos/list/ListIteratorNoNullsTest.java
@@ -23,98 +23,27 @@
  */
 package org.cactoos.list;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.ListIterator;
 import org.junit.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.Throws;
 
 /**
- * Test cases for {@link NoNulls}.
+ * Test cases for {@link ListIteratorNoNulls}.
+ *
  * @since 0.35
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle MagicNumberCheck (500 lines)
  */
-public final class NoNullsTest {
+public final class ListIteratorNoNullsTest {
 
-    @Test
-    public void getThrowsErrorIfNull() {
-        new Assertion<>(
-            "must throw error if contains null",
-            () -> new NoNulls<>(
-                new ListOf<>(1, null, 3)
-            ).get(1),
-            new Throws<>(
-                "Item #1 of [1, null, 3] is NULL",
-                IllegalStateException.class
-            )
-        ).affirm();
-    }
-
-    @Test
-    public void setThrowsErrorIfArgumentNull() {
-        new Assertion<>(
-            "must throw error if set null",
-            () -> new NoNulls<>(
-                new ListOf<>(1, null, 3)
-            ).set(2, null),
-            new Throws<>(
-                "Item can't be NULL in #set(2,T)",
-                IllegalArgumentException.class
-            )
-        ).affirm();
-    }
-
-    @Test
-    public void setThrowsErrorIfPreviousValueNull() {
-        final ArrayList<Integer> list = new ArrayList<>(1);
-        list.add(null);
-        new Assertion<>(
-            "must throw error if previous value is null",
-            () -> new NoNulls<>(list).set(0, 2),
-            new Throws<>(
-                "Result of #set(0,T) is NULL",
-                IllegalStateException.class
-            )
-        ).affirm();
-    }
-
-    @Test
-    public void addThrowsErrorIfArgumentNull() {
-        new Assertion<>(
-            "must throw error if add null",
-            () -> {
-                new NoNulls<>(new ArrayList<>(1)).add(0, null);
-                return 0;
-            },
-            new Throws<>(
-                "Item can't be NULL in #add(0,T)",
-                IllegalArgumentException.class
-            )
-        ).affirm();
-    }
-
-    @Test
-    public void removeThrowsErrorIfValueNull() {
-        final ArrayList<Integer> list = new ArrayList<>(1);
-        list.add(null);
-        new Assertion<>(
-            "must throw error if removed value is null",
-            () -> new NoNulls<>(list).remove(0),
-            new Throws<>(
-                "Result of #remove(0) is NULL",
-                IllegalStateException.class
-            )
-        ).affirm();
-    }
     @Test
     public void getThrowsErrorIfListIteratorNextValueIsNullValue() {
         new Assertion<>(
-            "must throw error if removed value in iterator is null",
-            () -> new NoNulls<>(
-                new ListOf<>(null, 2, 3)
-            ).listIterator().next(),
+            "must throw error if removed value is null",
+            () -> new ListIteratorNoNulls<>(
+                new ListOf<>(null, 2, 3).listIterator()
+            ).next(),
             new Throws<>(
                 "Next item is NULL",
                 IllegalStateException.class
@@ -124,17 +53,12 @@ public final class NoNullsTest {
 
     @Test
     public void getThrowsErrorIfListIteratorPreviousValueIsNullValue() {
-        final List<Integer> list = new ArrayList<>(2);
-        list.add(1);
-        list.add(2);
-        final ListIterator<Integer> listiterator = new NoNulls<>(
-            list
-        ).listIterator();
+        final ListIterator<Integer> listiterator =
+            new ListOf<>(null, 2, 3).listIterator();
         listiterator.next();
-        list.set(0, null);
         new Assertion<>(
-            "must throw error if previous value in iterator is null",
-            () -> listiterator.previous(),
+            "must throw error if previous value is null",
+            () -> new ListIteratorNoNulls<>(listiterator).previous(),
             new Throws<>(
                 "Previous item is NULL",
                 IllegalStateException.class
@@ -147,7 +71,9 @@ public final class NoNullsTest {
         new Assertion<>(
             "must throw error if modified with add",
             () -> {
-                new NoNulls<>(new ListOf<>(1, 2, 3)).listIterator().add(4);
+                new ListIteratorNoNulls<>(
+                    new ListOf<>(1, 2, 3).listIterator()
+                ).add(4);
                 return 0;
             },
             new Throws<>(
@@ -162,7 +88,9 @@ public final class NoNullsTest {
         new Assertion<>(
             "must throw error if modified with remove",
             () -> {
-                new NoNulls<>(new ListOf<>(1, 2, 3)).listIterator().remove();
+                new ListIteratorNoNulls<>(
+                    new ListOf<>(1, 2, 3).listIterator()
+                ).remove();
                 return 0;
             },
             new Throws<>(
@@ -175,9 +103,11 @@ public final class NoNullsTest {
     @Test
     public void setThrowsErrorForImmutableListIterator() {
         new Assertion<>(
-            "must throw error if modified if set",
+            "must throw error if modified with set",
             () -> {
-                new NoNulls<>(new ListOf<>(1, 2, 3)).listIterator().set(4);
+                new ListIteratorNoNulls<>(
+                    new ListOf<>(1, 2, 3).listIterator()
+                ).set(4);
                 return 0;
             },
             new Throws<>(


### PR DESCRIPTION
This if for #901.

This introduces a `ListIteratorNoNulls` that is immutable (via delegation to `ListIteratorOf`) and does not tolerate nulls.

Note that I reused most of the code from #1071 but simplified it in some places, not sure why the PR was closed...