### PR TITLE
Continue applying the new class naming convention

### DIFF
--- a/src/main/java/org/cactoos/Scalar.java
+++ b/src/main/java/org/cactoos/Scalar.java
@@ -23,28 +23,28 @@
  */
 package org.cactoos;
 
-import org.cactoos.scalar.IoCheckedScalar;
-import org.cactoos.scalar.StickyScalar;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.IoChecked;
+import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Scalar.
  *
  * <p>If you don't want to have any checked exceptions being thrown
  * out of your {@link Scalar}, you can use
- * {@link UncheckedScalar} decorator. Also
- * you may try {@link IoCheckedScalar}.</p>
+ * {@link Unchecked} decorator. Also
+ * you may try {@link IoChecked}.</p>
  *
  * <p>If you want to cache the result of the {@link Scalar} and
  * make sure it doesn't calculate anything twice, you can use
- * {@link StickyScalar} decorator.</p>
+ * {@link Sticky} decorator.</p>
  *
  * <p>There is no thread-safety guarantee.
  *
  * @param <T> Type of result
- * @see StickyScalar
- * @see UncheckedScalar
- * @see IoCheckedScalar
+ * @see Sticky
+ * @see Unchecked
+ * @see IoChecked
  * @since 0.1
  */
 public interface Scalar<T> {

--- a/src/main/java/org/cactoos/collection/CollectionEnvelope.java
+++ b/src/main/java/org/cactoos/collection/CollectionEnvelope.java
@@ -29,8 +29,8 @@ import org.cactoos.Scalar;
 import org.cactoos.iterator.Immutable;
 import org.cactoos.scalar.And;
 import org.cactoos.scalar.Folded;
-import org.cactoos.scalar.SumOfIntScalar;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.SumOfInt;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Base collection.
@@ -51,14 +51,14 @@ public abstract class CollectionEnvelope<X> implements Collection<X> {
     /**
      * Shuffled one.
      */
-    private final UncheckedScalar<Collection<X>> col;
+    private final Unchecked<Collection<X>> col;
 
     /**
      * Ctor.
      * @param slr The scalar
      */
     public CollectionEnvelope(final Scalar<Collection<X>> slr) {
-        this.col = new UncheckedScalar<>(slr);
+        this.col = new Unchecked<>(slr);
     }
 
     @Override
@@ -147,7 +147,7 @@ public abstract class CollectionEnvelope<X> implements Collection<X> {
 
     @Override
     public final boolean equals(final Object other) {
-        return new UncheckedScalar<>(
+        return new Unchecked<>(
             new And(
                 () -> other != null,
                 () -> Collection.class.isAssignableFrom(other.getClass()),
@@ -158,7 +158,7 @@ public abstract class CollectionEnvelope<X> implements Collection<X> {
                 () -> {
                     final Iterable<?> compared = (Iterable<?>) other;
                     final Iterator<?> iterator = compared.iterator();
-                    return new UncheckedScalar<>(
+                    return new Unchecked<>(
                         new And(
                             (X input) -> input.equals(iterator.next()),
                             this
@@ -172,10 +172,10 @@ public abstract class CollectionEnvelope<X> implements Collection<X> {
     // @checkstyle MagicNumberCheck (30 lines)
     @Override
     public final int hashCode() {
-        return new UncheckedScalar<>(
+        return new Unchecked<>(
             new Folded<>(
                 42,
-                (hash, entry) -> new SumOfIntScalar(
+                (hash, entry) -> new SumOfInt(
                     () -> 37 * hash,
                     entry::hashCode
                 ).value(),

--- a/src/main/java/org/cactoos/collection/Solid.java
+++ b/src/main/java/org/cactoos/collection/Solid.java
@@ -26,7 +26,6 @@ package org.cactoos.collection;
 import java.util.Collection;
 import java.util.Iterator;
 import org.cactoos.iterable.IterableOf;
-import org.cactoos.scalar.SolidScalar;
 
 /**
  * A {@link Collection} that is both synchronized and sticky.
@@ -70,7 +69,7 @@ public final class Solid<T> extends CollectionEnvelope<T> {
      */
     public Solid(final Collection<T> src) {
         super(
-            new SolidScalar<Collection<T>>(
+            new org.cactoos.scalar.Solid<Collection<T>>(
                 () -> new Synced<T>(new Sticky<>(src))
             )
         );

--- a/src/main/java/org/cactoos/collection/Sticky.java
+++ b/src/main/java/org/cactoos/collection/Sticky.java
@@ -28,7 +28,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import org.cactoos.iterable.IterableOf;
-import org.cactoos.scalar.StickyScalar;
 
 /**
  * Collection decorator that goes through the list only once.
@@ -72,7 +71,7 @@ public final class Sticky<E> extends CollectionEnvelope<E> {
      */
     public Sticky(final Collection<E> list) {
         super(
-            new StickyScalar<>(
+            new org.cactoos.scalar.Sticky<>(
                 () -> {
                     final Collection<E> temp = new ArrayList<>(list.size());
                     temp.addAll(list);

--- a/src/main/java/org/cactoos/collection/Synced.java
+++ b/src/main/java/org/cactoos/collection/Synced.java
@@ -28,7 +28,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import org.cactoos.iterable.IterableOf;
-import org.cactoos.scalar.SyncScalar;
 
 /**
  * Iterable as {@link Collection}.
@@ -79,7 +78,7 @@ public final class Synced<T> extends CollectionEnvelope<T> {
      */
     public Synced(final Collection<T> src) {
         super(
-            new SyncScalar<>(
+            new org.cactoos.scalar.Synced<>(
                 () -> {
                     final Collection<T> temp = new LinkedList<>();
                     temp.addAll(src);

--- a/src/main/java/org/cactoos/func/IoCheckedBiFunc.java
+++ b/src/main/java/org/cactoos/func/IoCheckedBiFunc.java
@@ -25,7 +25,7 @@ package org.cactoos.func;
 
 import java.io.IOException;
 import org.cactoos.BiFunc;
-import org.cactoos.scalar.IoCheckedScalar;
+import org.cactoos.scalar.IoChecked;
 
 /**
  * Func that doesn't throw checked {@link Exception}, but throws
@@ -54,7 +54,7 @@ public final class IoCheckedBiFunc<X, Y, Z> implements BiFunc<X, Y, Z> {
 
     @Override
     public Z apply(final X first, final Y second) throws IOException {
-        return new IoCheckedScalar<>(
+        return new IoChecked<>(
             () -> this.func.apply(first, second)
         ).value();
     }

--- a/src/main/java/org/cactoos/func/IoCheckedFunc.java
+++ b/src/main/java/org/cactoos/func/IoCheckedFunc.java
@@ -25,7 +25,7 @@ package org.cactoos.func;
 
 import java.io.IOException;
 import org.cactoos.Func;
-import org.cactoos.scalar.IoCheckedScalar;
+import org.cactoos.scalar.IoChecked;
 
 /**
  * Func that doesn't throw checked {@link Exception}, but throws
@@ -54,7 +54,7 @@ public final class IoCheckedFunc<X, Y> implements Func<X, Y> {
 
     @Override
     public Y apply(final X input) throws IOException {
-        return new IoCheckedScalar<>(() -> this.func.apply(input)).value();
+        return new IoChecked<>(() -> this.func.apply(input)).value();
     }
 
 }

--- a/src/main/java/org/cactoos/func/StickyBiFunc.java
+++ b/src/main/java/org/cactoos/func/StickyBiFunc.java
@@ -27,7 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import org.cactoos.BiFunc;
 import org.cactoos.map.MapEntry;
-import org.cactoos.scalar.StickyScalar;
+import org.cactoos.scalar.Sticky;
 
 /**
  * Func that accepts two arguments and caches previously calculated values
@@ -43,7 +43,7 @@ import org.cactoos.scalar.StickyScalar;
  * @param <X> Type of input
  * @param <Y> Type of input
  * @param <Z> Type of output
- * @see StickyScalar
+ * @see Sticky
  * @since 0.13
  */
 public final class StickyBiFunc<X, Y, Z> implements BiFunc<X, Y, Z> {

--- a/src/main/java/org/cactoos/func/StickyFunc.java
+++ b/src/main/java/org/cactoos/func/StickyFunc.java
@@ -25,7 +25,7 @@ package org.cactoos.func;
 
 import org.cactoos.BiFunc;
 import org.cactoos.Func;
-import org.cactoos.scalar.StickyScalar;
+import org.cactoos.scalar.Sticky;
 
 /**
  * Func that caches previously calculated values and doesn't
@@ -41,7 +41,7 @@ import org.cactoos.scalar.StickyScalar;
  *
  * @param <X> Type of input
  * @param <Y> Type of output
- * @see StickyScalar
+ * @see Sticky
  * @since 0.1
  */
 public final class StickyFunc<X, Y> implements Func<X, Y> {

--- a/src/main/java/org/cactoos/func/Timed.java
+++ b/src/main/java/org/cactoos/func/Timed.java
@@ -35,7 +35,7 @@ import org.cactoos.Func;
  * @param <Y> Type of output
  * @since 0.29.3
  */
-public final class TimedFunc<X, Y> implements Func<X, Y> {
+public final class Timed<X, Y> implements Func<X, Y> {
 
     /**
      * Origin function.
@@ -52,7 +52,7 @@ public final class TimedFunc<X, Y> implements Func<X, Y> {
      * @param function Origin function
      * @param milliseconds Milliseconds
      */
-    public TimedFunc(final Func<X, Y> function, final long milliseconds) {
+    public Timed(final Func<X, Y> function, final long milliseconds) {
         this(milliseconds, new Async<>(function));
     }
 
@@ -61,7 +61,7 @@ public final class TimedFunc<X, Y> implements Func<X, Y> {
      * @param async Async function
      * @param milliseconds Milliseconds
      */
-    public TimedFunc(final long milliseconds, final Func<X, Future<Y>> async) {
+    public Timed(final long milliseconds, final Func<X, Future<Y>> async) {
         this.func = async;
         this.time = milliseconds;
     }

--- a/src/main/java/org/cactoos/func/UncheckedFunc.java
+++ b/src/main/java/org/cactoos/func/UncheckedFunc.java
@@ -24,7 +24,7 @@
 package org.cactoos.func;
 
 import org.cactoos.Func;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Func that doesn't throw checked {@link Exception}.
@@ -52,7 +52,7 @@ public final class UncheckedFunc<X, Y> implements Func<X, Y> {
 
     @Override
     public Y apply(final X input) {
-        return new UncheckedScalar<>(
+        return new Unchecked<>(
             () -> this.func.apply(input)
         ).value();
     }

--- a/src/main/java/org/cactoos/io/InputOf.java
+++ b/src/main/java/org/cactoos/io/InputOf.java
@@ -36,8 +36,8 @@ import org.cactoos.Bytes;
 import org.cactoos.Input;
 import org.cactoos.Scalar;
 import org.cactoos.Text;
-import org.cactoos.scalar.IoCheckedScalar;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.IoChecked;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * An {@link Input} that encapsulates other sources of data.
@@ -62,7 +62,7 @@ public final class InputOf implements Input {
     public InputOf(final File file) {
         this(
             () -> new FileInputStream(
-                new UncheckedScalar<>(() -> file).value()
+                new Unchecked<>(() -> file).value()
             )
         );
     }
@@ -100,7 +100,7 @@ public final class InputOf implements Input {
      * @param scalar The url
      */
     public InputOf(final Scalar<URL> scalar) {
-        this(() -> new IoCheckedScalar<>(scalar).value().openStream());
+        this(() -> new IoChecked<>(scalar).value().openStream());
     }
 
     /**
@@ -282,7 +282,7 @@ public final class InputOf implements Input {
      */
     public InputOf(final Bytes src) {
         this(
-            () -> new IoCheckedScalar<InputStream>(
+            () -> new IoChecked<InputStream>(
                 () -> new ByteArrayInputStream(src.asBytes())
             ).value()
         );

--- a/src/main/java/org/cactoos/io/InputStreamOf.java
+++ b/src/main/java/org/cactoos/io/InputStreamOf.java
@@ -36,8 +36,8 @@ import org.cactoos.Bytes;
 import org.cactoos.Input;
 import org.cactoos.Scalar;
 import org.cactoos.Text;
-import org.cactoos.scalar.StickyScalar;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * An {@link InputStream} that encapsulates other sources of data.
@@ -51,7 +51,7 @@ public final class InputStreamOf extends InputStream {
     /**
      * The source.
      */
-    private final UncheckedScalar<InputStream> source;
+    private final Unchecked<InputStream> source;
 
     /**
      * Ctor.
@@ -229,7 +229,7 @@ public final class InputStreamOf extends InputStream {
      */
     private InputStreamOf(final Scalar<InputStream> src) {
         super();
-        this.source = new UncheckedScalar<>(new StickyScalar<>(src));
+        this.source = new Unchecked<>(new Sticky<>(src));
     }
 
     @Override

--- a/src/main/java/org/cactoos/io/LoggingInputStream.java
+++ b/src/main/java/org/cactoos/io/LoggingInputStream.java
@@ -30,8 +30,8 @@ import java.time.Instant;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.cactoos.scalar.StickyScalar;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Unchecked;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.UncheckedText;
 
@@ -73,7 +73,7 @@ public final class LoggingInputStream extends InputStream {
     /**
      * Logger level.
      */
-    private final UncheckedScalar<Level> level;
+    private final Unchecked<Level> level;
 
     /**
      * Ctor.
@@ -99,8 +99,8 @@ public final class LoggingInputStream extends InputStream {
         this.origin = input;
         this.source = src;
         this.logger = lgr;
-        this.level = new UncheckedScalar<>(
-            new StickyScalar<>(
+        this.level = new Unchecked<>(
+            new Sticky<>(
                 () -> {
                     Level lvl = lgr.getLevel();
                     if (lvl == null) {

--- a/src/main/java/org/cactoos/io/OutputStreamTo.java
+++ b/src/main/java/org/cactoos/io/OutputStreamTo.java
@@ -33,8 +33,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import org.cactoos.Output;
 import org.cactoos.Scalar;
-import org.cactoos.scalar.StickyScalar;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * An {@link OutputStream} that encapsulates other destination for the data.
@@ -48,7 +48,7 @@ public final class OutputStreamTo extends OutputStream {
     /**
      * The target.
      */
-    private final UncheckedScalar<OutputStream> target;
+    private final Unchecked<OutputStream> target;
 
     /**
      * Ctor.
@@ -144,8 +144,8 @@ public final class OutputStreamTo extends OutputStream {
      */
     private OutputStreamTo(final Scalar<OutputStream> tgt) {
         super();
-        this.target = new UncheckedScalar<>(
-            new StickyScalar<>(tgt)
+        this.target = new Unchecked<>(
+            new Sticky<>(tgt)
         );
     }
 

--- a/src/main/java/org/cactoos/io/ReaderOf.java
+++ b/src/main/java/org/cactoos/io/ReaderOf.java
@@ -39,8 +39,8 @@ import org.cactoos.Bytes;
 import org.cactoos.Input;
 import org.cactoos.Scalar;
 import org.cactoos.Text;
-import org.cactoos.scalar.StickyScalar;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * A {@link Reader} that encapsulates other sources of data.
@@ -54,7 +54,7 @@ public final class ReaderOf extends Reader {
     /**
      * The source.
      */
-    private final UncheckedScalar<Reader> source;
+    private final Unchecked<Reader> source;
 
     /**
      * Ctor.
@@ -288,8 +288,8 @@ public final class ReaderOf extends Reader {
      */
     private ReaderOf(final Scalar<Reader> src) {
         super();
-        this.source = new UncheckedScalar<>(
-            new StickyScalar<>(src)
+        this.source = new Unchecked<>(
+            new Sticky<>(src)
         );
     }
 

--- a/src/main/java/org/cactoos/io/Sticky.java
+++ b/src/main/java/org/cactoos/io/Sticky.java
@@ -28,9 +28,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import org.cactoos.Input;
 import org.cactoos.Scalar;
-import org.cactoos.scalar.IoCheckedScalar;
+import org.cactoos.scalar.IoChecked;
 import org.cactoos.scalar.LengthOf;
-import org.cactoos.scalar.StickyScalar;
 
 /**
  * Input that reads only once.
@@ -54,7 +53,7 @@ public final class Sticky implements Input {
      * @param input The input
      */
     public Sticky(final Input input) {
-        this.cache = new StickyScalar<>(
+        this.cache = new org.cactoos.scalar.Sticky<>(
             () -> {
                 final ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 new LengthOf(
@@ -68,7 +67,7 @@ public final class Sticky implements Input {
     @Override
     public InputStream stream() throws Exception {
         return new ByteArrayInputStream(
-            new IoCheckedScalar<>(this.cache).value()
+            new IoChecked<>(this.cache).value()
         );
     }
 

--- a/src/main/java/org/cactoos/io/TempFile.java
+++ b/src/main/java/org/cactoos/io/TempFile.java
@@ -30,8 +30,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.cactoos.Scalar;
 import org.cactoos.Text;
-import org.cactoos.scalar.IoCheckedScalar;
-import org.cactoos.scalar.StickyScalar;
+import org.cactoos.scalar.IoChecked;
+import org.cactoos.scalar.Sticky;
 import org.cactoos.text.TextOf;
 
 /**
@@ -114,7 +114,7 @@ public final class TempFile implements Scalar<Path>, Closeable {
         final Text prefix,
         final Text suffix) {
         this(
-            new StickyScalar<>(
+            new Sticky<>(
                 () -> Files.createTempFile(
                     dir.value(),
                     prefix.asString(),
@@ -145,7 +145,7 @@ public final class TempFile implements Scalar<Path>, Closeable {
      */
     @Override
     public void close() throws IOException {
-        Files.delete(new IoCheckedScalar<>(this).value());
+        Files.delete(new IoChecked<>(this).value());
     }
 
 }

--- a/src/main/java/org/cactoos/io/TempFolder.java
+++ b/src/main/java/org/cactoos/io/TempFolder.java
@@ -31,8 +31,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.cactoos.Scalar;
 import org.cactoos.Text;
-import org.cactoos.scalar.IoCheckedScalar;
-import org.cactoos.scalar.StickyScalar;
+import org.cactoos.scalar.IoChecked;
+import org.cactoos.scalar.Sticky;
 import org.cactoos.text.Joined;
 import org.cactoos.text.Randomized;
 import org.cactoos.text.TextOf;
@@ -95,7 +95,7 @@ public final class TempFolder implements Scalar<Path>, Closeable {
      */
     public TempFolder(final Text path) {
         this(
-            new StickyScalar<>(
+            new Sticky<>(
                 () -> Files.createDirectory(
                     Paths.get(
                         new Joined(
@@ -125,6 +125,6 @@ public final class TempFolder implements Scalar<Path>, Closeable {
 
     @Override
     public void close() throws IOException {
-        Files.delete(new IoCheckedScalar<>(this).value());
+        Files.delete(new IoChecked<>(this).value());
     }
 }

--- a/src/main/java/org/cactoos/io/UncheckedInput.java
+++ b/src/main/java/org/cactoos/io/UncheckedInput.java
@@ -25,7 +25,7 @@ package org.cactoos.io;
 
 import java.io.InputStream;
 import org.cactoos.Input;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Input that doesn't throw checked {@link Exception}.
@@ -51,7 +51,7 @@ public final class UncheckedInput implements Input {
 
     @Override
     public InputStream stream() {
-        return new UncheckedScalar<>(this.input::stream).value();
+        return new Unchecked<>(this.input::stream).value();
     }
 
 }

--- a/src/main/java/org/cactoos/io/UncheckedOutput.java
+++ b/src/main/java/org/cactoos/io/UncheckedOutput.java
@@ -25,7 +25,7 @@ package org.cactoos.io;
 
 import java.io.OutputStream;
 import org.cactoos.Output;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Input that doesn't throw checked {@link Exception}.
@@ -51,7 +51,7 @@ public final class UncheckedOutput implements Output {
 
     @Override
     public OutputStream stream() {
-        return new UncheckedScalar<>(this.output::stream).value();
+        return new Unchecked<>(this.output::stream).value();
     }
 
 }

--- a/src/main/java/org/cactoos/io/WriterTo.java
+++ b/src/main/java/org/cactoos/io/WriterTo.java
@@ -34,8 +34,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import org.cactoos.Output;
 import org.cactoos.Scalar;
-import org.cactoos.scalar.StickyScalar;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * A {@link Writer} that encapsulates other destination for the data.
@@ -49,7 +49,7 @@ public final class WriterTo extends Writer {
     /**
      * The target.
      */
-    private final UncheckedScalar<Writer> target;
+    private final Unchecked<Writer> target;
 
     /**
      * Ctor.
@@ -117,8 +117,8 @@ public final class WriterTo extends Writer {
      */
     private WriterTo(final Scalar<Writer> tgt) {
         super();
-        this.target = new UncheckedScalar<>(
-            new StickyScalar<>(tgt)
+        this.target = new Unchecked<>(
+            new Sticky<>(tgt)
         );
     }
 

--- a/src/main/java/org/cactoos/iterable/IterableEnvelope.java
+++ b/src/main/java/org/cactoos/iterable/IterableEnvelope.java
@@ -26,7 +26,7 @@ package org.cactoos.iterable;
 import java.util.Iterator;
 import org.cactoos.Scalar;
 import org.cactoos.iterator.Immutable;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Iterable envelope.
@@ -43,14 +43,14 @@ public abstract class IterableEnvelope<X> implements Iterable<X> {
     /**
      * The iterable.
      */
-    private final UncheckedScalar<Iterable<X>> iterable;
+    private final Unchecked<Iterable<X>> iterable;
 
     /**
      * Ctor.
      * @param scalar The source
      */
     public IterableEnvelope(final Scalar<Iterable<X>> scalar) {
-        this.iterable = new UncheckedScalar<>(scalar);
+        this.iterable = new Unchecked<>(scalar);
     }
 
     @Override

--- a/src/main/java/org/cactoos/iterable/IterableOf.java
+++ b/src/main/java/org/cactoos/iterable/IterableOf.java
@@ -30,8 +30,8 @@ import org.cactoos.Func;
 import org.cactoos.Scalar;
 import org.cactoos.func.UncheckedFunc;
 import org.cactoos.iterator.IteratorOf;
-import org.cactoos.scalar.StickyScalar;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Array as iterable.
@@ -90,8 +90,8 @@ public final class IterableOf<X> extends IterableEnvelope<X> {
         // @checkstyle AnonInnerLengthCheck (30 lines)
         this(
             () -> new Iterator<X>() {
-                private UncheckedScalar<I> current = new UncheckedScalar<>(
-                    new StickyScalar<>(first)
+                private Unchecked<I> current = new Unchecked<>(
+                    new Sticky<>(first)
                 );
                 private final UncheckedFunc<I, I> subsequent =
                     new UncheckedFunc<>(next);
@@ -102,8 +102,8 @@ public final class IterableOf<X> extends IterableEnvelope<X> {
                         final I next = this.subsequent.apply(
                             this.current.value()
                         );
-                        this.current = new UncheckedScalar<>(
-                            new StickyScalar<>(() -> next)
+                        this.current = new Unchecked<>(
+                            new Sticky<>(() -> next)
                         );
                     }
                     return this.current.value().hasNext();
@@ -125,7 +125,7 @@ public final class IterableOf<X> extends IterableEnvelope<X> {
      * @param sclr The encapsulated iterator of x
      */
     private IterableOf(final Scalar<Iterator<X>> sclr) {
-        super(() -> () -> new UncheckedScalar<>(sclr).value());
+        super(() -> () -> new Unchecked<>(sclr).value());
     }
 
 }

--- a/src/main/java/org/cactoos/iterable/Matched.java
+++ b/src/main/java/org/cactoos/iterable/Matched.java
@@ -29,7 +29,7 @@ import java.util.LinkedList;
 import java.util.List;
 import org.cactoos.BiFunc;
 import org.cactoos.Scalar;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Unchecked;
 import org.cactoos.text.FormattedText;
 
 /**
@@ -47,7 +47,7 @@ public final class Matched<X> implements Iterable<X> {
     /**
      * The matched iterator.
      */
-    private final UncheckedScalar<Iterator<X>> mtr;
+    private final Unchecked<Iterator<X>> mtr;
 
     /**
      * Ctor.
@@ -111,7 +111,7 @@ public final class Matched<X> implements Iterable<X> {
      * @param mtr The matched iterator.
      */
     private Matched(final Scalar<Iterator<X>> mtr) {
-        this.mtr = new UncheckedScalar<>(mtr);
+        this.mtr = new Unchecked<>(mtr);
     }
 
     @Override

--- a/src/main/java/org/cactoos/iterable/Repeated.java
+++ b/src/main/java/org/cactoos/iterable/Repeated.java
@@ -24,7 +24,7 @@
 package org.cactoos.iterable;
 
 import org.cactoos.Scalar;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Repeat an element.
@@ -51,7 +51,7 @@ public final class Repeated<T> extends IterableEnvelope<T> {
      * @param elm The element to repeat
      */
     public Repeated(final int total, final Scalar<T> elm) {
-        this(total, new UncheckedScalar<T>(elm));
+        this(total, new Unchecked<T>(elm));
     }
 
     /**
@@ -59,7 +59,7 @@ public final class Repeated<T> extends IterableEnvelope<T> {
      * @param total The total number of repetitions
      * @param item The element to repeat
      */
-    public Repeated(final int total, final UncheckedScalar<T> item) {
+    public Repeated(final int total, final Unchecked<T> item) {
         super(() -> () -> new org.cactoos.iterator.Repeated<>(
             total, item
         ));

--- a/src/main/java/org/cactoos/iterable/Solid.java
+++ b/src/main/java/org/cactoos/iterable/Solid.java
@@ -24,7 +24,6 @@
 package org.cactoos.iterable;
 
 import org.cactoos.scalar.NoNulls;
-import org.cactoos.scalar.SolidScalar;
 
 /**
  * An {@link Iterable} that is both synchronized and sticky.
@@ -52,7 +51,7 @@ public final class Solid<X> extends IterableEnvelope<X> {
     public Solid(final Iterable<X> iterable) {
         super(
             new NoNulls<>(
-                new SolidScalar<>(
+                new org.cactoos.scalar.Solid<>(
                     () -> new Synced<>(new Sticky<>(iterable))
                 )
             )

--- a/src/main/java/org/cactoos/iterable/Sticky.java
+++ b/src/main/java/org/cactoos/iterable/Sticky.java
@@ -25,7 +25,6 @@ package org.cactoos.iterable;
 
 import java.util.Collection;
 import java.util.LinkedList;
-import org.cactoos.scalar.StickyScalar;
 
 /**
  * Iterable that returns the same set of elements, always.
@@ -52,7 +51,7 @@ public final class Sticky<X> extends IterableEnvelope<X> {
      */
     public Sticky(final Iterable<X> iterable) {
         super(
-            new StickyScalar<>(
+            new org.cactoos.scalar.Sticky<>(
                 () -> {
                     final Collection<X> temp = new LinkedList<>();
                     for (final X item : iterable) {

--- a/src/main/java/org/cactoos/iterator/Endless.java
+++ b/src/main/java/org/cactoos/iterator/Endless.java
@@ -25,7 +25,7 @@ package org.cactoos.iterator;
 
 import java.util.Iterator;
 import org.cactoos.Scalar;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Iterator that never ends.
@@ -41,7 +41,7 @@ public final class Endless<T> implements Iterator<T> {
     /**
      * The element to repeat.
      */
-    private final UncheckedScalar<T> origin;
+    private final Unchecked<T> origin;
 
     /**
      * Ctor.
@@ -56,14 +56,14 @@ public final class Endless<T> implements Iterator<T> {
      * @param scalar Scalar to repeat
      */
     public Endless(final Scalar<T> scalar) {
-        this(new UncheckedScalar<>(scalar));
+        this(new Unchecked<>(scalar));
     }
 
     /**
      * Ctor.
      * @param scalar Scalar to repeat
      */
-    public Endless(final UncheckedScalar<T> scalar) {
+    public Endless(final Unchecked<T> scalar) {
         this.origin = scalar;
     }
 

--- a/src/main/java/org/cactoos/iterator/Repeated.java
+++ b/src/main/java/org/cactoos/iterator/Repeated.java
@@ -26,7 +26,7 @@ package org.cactoos.iterator;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import org.cactoos.Scalar;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Repeat an element.
@@ -41,7 +41,7 @@ public final class Repeated<T> implements Iterator<T> {
     /**
      * The element to repeat.
      */
-    private final UncheckedScalar<T> elm;
+    private final Unchecked<T> elm;
 
     /**
      * How many more repeats will happen.
@@ -63,7 +63,7 @@ public final class Repeated<T> implements Iterator<T> {
      * @param scalar Scalar to repeat
      */
     public Repeated(final int max, final Scalar<T> scalar) {
-        this(max, new UncheckedScalar<T>(scalar));
+        this(max, new Unchecked<T>(scalar));
     }
 
     /**
@@ -71,7 +71,7 @@ public final class Repeated<T> implements Iterator<T> {
      * @param max How many times to repeat
      * @param scalar Scalar to repeat
      */
-    public Repeated(final int max, final UncheckedScalar<T> scalar) {
+    public Repeated(final int max, final Unchecked<T> scalar) {
         this.elm = scalar;
         this.repeat = max;
     }

--- a/src/main/java/org/cactoos/iterator/Shuffled.java
+++ b/src/main/java/org/cactoos/iterator/Shuffled.java
@@ -27,8 +27,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import org.cactoos.scalar.StickyScalar;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Shuffled iterator.
@@ -43,15 +43,15 @@ public final class Shuffled<T> implements Iterator<T> {
     /**
      * Shuffled scalar.
      */
-    private final UncheckedScalar<Iterator<T>> scalar;
+    private final Unchecked<Iterator<T>> scalar;
 
     /**
      * Ctor.
      * @param iterator The original iterator
      */
     public Shuffled(final Iterator<T> iterator) {
-        this.scalar = new UncheckedScalar<>(
-            new StickyScalar<>(
+        this.scalar = new Unchecked<>(
+            new Sticky<>(
                 () -> {
                     final List<T> items = new LinkedList<>();
                     while (iterator.hasNext()) {

--- a/src/main/java/org/cactoos/iterator/Sorted.java
+++ b/src/main/java/org/cactoos/iterator/Sorted.java
@@ -27,8 +27,8 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import org.cactoos.scalar.StickyScalar;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Sorted iterator.
@@ -43,7 +43,7 @@ public final class Sorted<T> implements Iterator<T> {
     /**
      * Sorted one.
      */
-    private final UncheckedScalar<Iterator<T>> scalar;
+    private final Unchecked<Iterator<T>> scalar;
 
     /**
      * Ctor.
@@ -65,8 +65,8 @@ public final class Sorted<T> implements Iterator<T> {
      * @param comparator The comparator
      */
     public Sorted(final Comparator<T> comparator, final Iterator<T> iterator) {
-        this.scalar = new UncheckedScalar<>(
-            new StickyScalar<>(
+        this.scalar = new Unchecked<>(
+            new Sticky<>(
                 () -> {
                     final List<T> items = new LinkedList<>();
                     while (iterator.hasNext()) {

--- a/src/main/java/org/cactoos/iterator/Synced.java
+++ b/src/main/java/org/cactoos/iterator/Synced.java
@@ -33,8 +33,8 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * {@link ReentrantReadWriteLock}.
  *
  * <p>The {@link ReadWriteLock} is used to synchronize read calls to
- * {@link SyncIterator#hasNext()} against write calls to
- * {@link SyncIterator#next()} and write calls to any other read or write
+ * {@link Synced#hasNext()} against write calls to
+ * {@link Synced#next()} and write calls to any other read or write
  * calls.</p>
  *
  * <p>Objects of this class are thread-safe.</p>
@@ -42,7 +42,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * @param <T> The type of the iterator.
  * @since 1.0
  */
-public final class SyncIterator<T> implements Iterator<T> {
+public final class Synced<T> implements Iterator<T> {
     /**
      * The original iterator.
      */
@@ -56,7 +56,7 @@ public final class SyncIterator<T> implements Iterator<T> {
      * Ctor.
      * @param iterator The iterator to synchronize access to.
      */
-    public SyncIterator(final Iterator<T> iterator) {
+    public Synced(final Iterator<T> iterator) {
         this(iterator, new ReentrantReadWriteLock());
     }
 
@@ -65,7 +65,7 @@ public final class SyncIterator<T> implements Iterator<T> {
      * @param iterator The iterator to synchronize access to.
      * @param lock The lock to use for synchronization.
      */
-    public SyncIterator(final Iterator<T> iterator, final ReadWriteLock lock) {
+    public Synced(final Iterator<T> iterator, final ReadWriteLock lock) {
         this.iterator = iterator;
         this.lock = lock;
     }

--- a/src/main/java/org/cactoos/list/ListEnvelope.java
+++ b/src/main/java/org/cactoos/list/ListEnvelope.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.ListIterator;
 import org.cactoos.Scalar;
 import org.cactoos.collection.CollectionEnvelope;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * List envelope.
@@ -51,7 +51,7 @@ abstract class ListEnvelope<T> extends CollectionEnvelope<T> implements
     /**
      * Encapsulated list.
      */
-    private final UncheckedScalar<List<T>> list;
+    private final Unchecked<List<T>> list;
 
     /**
      * Ctor.
@@ -59,7 +59,7 @@ abstract class ListEnvelope<T> extends CollectionEnvelope<T> implements
      */
     ListEnvelope(final Scalar<List<T>> src) {
         super(src::value);
-        this.list = new UncheckedScalar<>(src);
+        this.list = new Unchecked<>(src);
     }
 
     @Override

--- a/src/main/java/org/cactoos/list/ListIteratorOf.java
+++ b/src/main/java/org/cactoos/list/ListIteratorOf.java
@@ -26,8 +26,8 @@ package org.cactoos.list;
 import java.util.List;
 import java.util.ListIterator;
 import org.cactoos.Scalar;
-import org.cactoos.scalar.StickyScalar;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Iterator of the list.
@@ -42,7 +42,7 @@ public final class ListIteratorOf<T> implements ListIterator<T> {
     /**
      * Original list iterator.
      */
-    private final UncheckedScalar<ListIterator<T>> origin;
+    private final Unchecked<ListIterator<T>> origin;
 
     /**
      * Ctor.
@@ -74,7 +74,7 @@ public final class ListIteratorOf<T> implements ListIterator<T> {
      * @param orig Original list iterator.
      */
     public ListIteratorOf(final Scalar<ListIterator<T>> orig) {
-        this.origin = new UncheckedScalar<>(new StickyScalar<>(orig));
+        this.origin = new Unchecked<>(new Sticky<>(orig));
     }
 
     @Override

--- a/src/main/java/org/cactoos/list/Solid.java
+++ b/src/main/java/org/cactoos/list/Solid.java
@@ -27,7 +27,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import org.cactoos.collection.CollectionOf;
 import org.cactoos.iterable.IterableOf;
-import org.cactoos.scalar.SolidScalar;
 
 /**
  * A {@link java.util.List} that is both synchronized and sticky.
@@ -71,7 +70,7 @@ public final class Solid<X> extends ListEnvelope<X> {
      */
     public Solid(final Collection<X> list) {
         super(
-            new SolidScalar<>(
+            new org.cactoos.scalar.Solid<>(
                 () -> new Synced<>(new Sticky<>(list))
             )
         );

--- a/src/main/java/org/cactoos/list/Sticky.java
+++ b/src/main/java/org/cactoos/list/Sticky.java
@@ -29,7 +29,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import org.cactoos.iterable.IterableOf;
-import org.cactoos.scalar.StickyScalar;
 
 /**
  * List decorator that goes through the list only once.
@@ -75,7 +74,7 @@ public final class Sticky<X> extends ListEnvelope<X> {
      */
     public Sticky(final Collection<X> list) {
         super(
-            new StickyScalar<>(
+            new org.cactoos.scalar.Sticky<>(
                 () -> {
                     final List<X> temp = new LinkedList<>();
                     temp.addAll(list);

--- a/src/main/java/org/cactoos/list/Synced.java
+++ b/src/main/java/org/cactoos/list/Synced.java
@@ -29,7 +29,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import org.cactoos.iterable.IterableOf;
-import org.cactoos.scalar.SyncScalar;
 
 /**
  * Synchronized list.
@@ -82,7 +81,7 @@ public final class Synced<X> extends ListEnvelope<X> {
      */
     public Synced(final Collection<X> list) {
         super(
-            new SyncScalar<>(
+            new org.cactoos.scalar.Synced<>(
                 () -> {
                     final List<X> temp = new LinkedList<>();
                     temp.addAll(list);

--- a/src/main/java/org/cactoos/map/MapEnvelope.java
+++ b/src/main/java/org/cactoos/map/MapEnvelope.java
@@ -30,8 +30,8 @@ import org.cactoos.Scalar;
 import org.cactoos.scalar.And;
 import org.cactoos.scalar.Folded;
 import org.cactoos.scalar.Or;
-import org.cactoos.scalar.SumOfIntScalar;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.SumOfInt;
+import org.cactoos.scalar.Unchecked;
 import org.cactoos.text.TextOf;
 
 /**
@@ -56,14 +56,14 @@ public abstract class MapEnvelope<X, Y> implements Map<X, Y> {
     /**
      * The map.
      */
-    private final UncheckedScalar<Map<X, Y>> map;
+    private final Unchecked<Map<X, Y>> map;
 
     /**
      * Ctor.
      * @param scalar The scalar
      */
     public MapEnvelope(final Scalar<Map<X, Y>> scalar) {
-        this.map = new UncheckedScalar<>(scalar);
+        this.map = new Unchecked<>(scalar);
     }
 
     @Override
@@ -145,7 +145,7 @@ public abstract class MapEnvelope<X, Y> implements Map<X, Y> {
 
     @Override
     public final boolean equals(final Object other) {
-        return new UncheckedScalar<>(
+        return new Unchecked<>(
             new Or(
                 () -> this == other,
                 new And(
@@ -160,15 +160,15 @@ public abstract class MapEnvelope<X, Y> implements Map<X, Y> {
     // @checkstyle MagicNumberCheck (30 lines)
     @Override
     public final int hashCode() {
-        return new UncheckedScalar<>(
+        return new Unchecked<>(
             new Folded<>(
                 42,
                 (hash, entry) -> {
-                    final int keys = new SumOfIntScalar(
+                    final int keys = new SumOfInt(
                         () -> 37 * hash,
                         () -> entry.getKey().hashCode()
                     ).value();
-                    return new SumOfIntScalar(
+                    return new SumOfInt(
                         () -> 37 * keys,
                         () -> entry.getValue().hashCode()
                     ).value();
@@ -185,7 +185,7 @@ public abstract class MapEnvelope<X, Y> implements Map<X, Y> {
      * @return True if contents are equal false otherwise
      */
     private Boolean contentsEqual(final Map<?, ?> other) {
-        return new UncheckedScalar<>(
+        return new Unchecked<>(
             new And(
                 (entry) -> {
                     final X key = entry.getKey();

--- a/src/main/java/org/cactoos/map/Solid.java
+++ b/src/main/java/org/cactoos/map/Solid.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import org.cactoos.Func;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.Mapped;
-import org.cactoos.scalar.SolidScalar;
 
 /**
  * A {@link Map} that is both synchronized and sticky.
@@ -158,7 +157,7 @@ public final class Solid<X, Y> extends MapEnvelope<X, Y> {
      */
     public Solid(final Map<X, Y> map) {
         super(
-            new SolidScalar<Map<X, Y>>(
+            new org.cactoos.scalar.Solid<Map<X, Y>>(
                 () -> new Synced<>(new Sticky<X, Y>(map))
             )
         );

--- a/src/main/java/org/cactoos/map/Sticky.java
+++ b/src/main/java/org/cactoos/map/Sticky.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import org.cactoos.Func;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.Mapped;
-import org.cactoos.scalar.StickyScalar;
 
 /**
  * Map decorator that goes through the map only once.
@@ -169,7 +168,7 @@ public final class Sticky<X, Y> extends MapEnvelope<X, Y> {
      */
     public Sticky(final Map<X, Y> map) {
         super(
-            new StickyScalar<>(
+            new org.cactoos.scalar.Sticky<>(
                 () -> {
                     final Map<X, Y> temp = new HashMap<>(0);
                     temp.putAll(map);

--- a/src/main/java/org/cactoos/map/Synced.java
+++ b/src/main/java/org/cactoos/map/Synced.java
@@ -29,7 +29,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.cactoos.Func;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.Mapped;
-import org.cactoos.scalar.SyncScalar;
 
 /**
  * Map decorator that goes through the map only once.
@@ -160,7 +159,7 @@ public final class Synced<X, Y> extends MapEnvelope<X, Y> {
      */
     public Synced(final Map<X, Y> map) {
         super(
-            new SyncScalar<>(
+            new org.cactoos.scalar.Synced<>(
                 () -> {
                     final Map<X, Y> temp = new ConcurrentHashMap<>(0);
                     temp.putAll(map);

--- a/src/main/java/org/cactoos/scalar/And.java
+++ b/src/main/java/org/cactoos/scalar/And.java
@@ -70,13 +70,13 @@ import org.cactoos.iterable.Mapped;
  * <p>This class implements {@link Scalar}, which throws a checked
  * {@link Exception}. This may not be convenient in many cases. To make
  * it more convenient and get rid of the checked exception you can
- * use the {@link UncheckedScalar} decorator. Or you may use
- * {@link IoCheckedScalar} to wrap it in an IOException.</p>
+ * use the {@link Unchecked} decorator. Or you may use
+ * {@link IoChecked} to wrap it in an IOException.</p>
  *
  * <p>There is no thread-safety guarantee.
  *
- * @see UncheckedScalar
- * @see IoCheckedScalar
+ * @see Unchecked
+ * @see IoChecked
  * @since 0.8
  */
 public final class And implements Scalar<Boolean> {

--- a/src/main/java/org/cactoos/scalar/AndInThreads.java
+++ b/src/main/java/org/cactoos/scalar/AndInThreads.java
@@ -45,13 +45,13 @@ import org.cactoos.text.FormattedText;
  * <p>This class implements {@link Scalar}, which throws a checked
  * {@link Exception}. This may not be convenient in many cases. To make
  * it more convenient and get rid of the checked exception you can
- * use the {@link UncheckedScalar} decorator. Or you may use
- * {@link IoCheckedScalar} to wrap it in an IOException.</p>
+ * use the {@link Unchecked} decorator. Or you may use
+ * {@link IoChecked} to wrap it in an IOException.</p>
  *
  * <p>There is no thread-safety guarantee.
  *
- * @see UncheckedScalar
- * @see IoCheckedScalar
+ * @see Unchecked
+ * @see IoChecked
  * @since 0.25
  */
 public final class AndInThreads implements Scalar<Boolean> {

--- a/src/main/java/org/cactoos/scalar/AndWithIndex.java
+++ b/src/main/java/org/cactoos/scalar/AndWithIndex.java
@@ -56,8 +56,8 @@ import org.cactoos.iterable.Mapped;
  * <p>This class implements {@link Scalar}, which throws a checked
  * {@link Exception}. This may not be convenient in many cases. To make
  * it more convenient and get rid of the checked exception you can
- * use the {@link UncheckedScalar} decorator. Or you may use
- * {@link IoCheckedScalar} to wrap it in an IOException.</p>
+ * use the {@link Unchecked} decorator. Or you may use
+ * {@link IoChecked} to wrap it in an IOException.</p>
  *
  * <p>There is no thread-safety guarantee.
  *

--- a/src/main/java/org/cactoos/scalar/AvgOf.java
+++ b/src/main/java/org/cactoos/scalar/AvgOf.java
@@ -44,8 +44,8 @@ import org.cactoos.iterable.Mapped;
  * <p>This class implements {@link Scalar}, which throws a checked
  * {@link Exception}. This may not be convenient in many cases. To make
  * it more convenient and get rid of the checked exception you can
- * use the {@link UncheckedScalar} decorator. Or you may use
- * {@link IoCheckedScalar} to wrap it in an IOException.</p>
+ * use the {@link Unchecked} decorator. Or you may use
+ * {@link IoChecked} to wrap it in an IOException.</p>
  *
  * <p>There is no thread-safety guarantee.
  *

--- a/src/main/java/org/cactoos/scalar/Binary.java
+++ b/src/main/java/org/cactoos/scalar/Binary.java
@@ -35,8 +35,8 @@ import org.cactoos.func.ProcOf;
  * <p>This class implements {@link Scalar}, which throws a checked
  * {@link Exception}. This may not be convenient in many cases. To make
  * it more convenient and get rid of the checked exception you can
- * use the {@link UncheckedScalar} decorator. Or you may use
- * {@link IoCheckedScalar} to wrap it in an IOException.</p>
+ * use the {@link Unchecked} decorator. Or you may use
+ * {@link IoChecked} to wrap it in an IOException.</p>
  *
  * <pre>{@code
  * final AtomicInteger counter = new AtomicInteger();

--- a/src/main/java/org/cactoos/scalar/Constant.java
+++ b/src/main/java/org/cactoos/scalar/Constant.java
@@ -30,7 +30,7 @@ import org.cactoos.Scalar;
  *
  * <p>This {@link Scalar} represents a constant value which never changes.</p>
  *
- * <p>Contrary to {@link StickyScalar} this constant is always
+ * <p>Contrary to {@link Sticky} this constant is always
  * pre-computed.</p>
  *
  * <p>This class implements {@link Scalar}, which throws a checked
@@ -47,7 +47,7 @@ import org.cactoos.Scalar;
  * <p>This class is thread-safe.</p>
  *
  * @param <T> Type of result
- * @see StickyScalar
+ * @see Sticky
  * @since 0.30
  */
 public final class Constant<T> implements Scalar<T> {

--- a/src/main/java/org/cactoos/scalar/DivisionOf.java
+++ b/src/main/java/org/cactoos/scalar/DivisionOf.java
@@ -33,8 +33,8 @@ import org.cactoos.Scalar;
  * <p>This class implements {@link Scalar}, which throws a checked
  * {@link Exception}. This may not be convenient in many cases. To make
  * it more convenient and get rid of the checked exception you can
- * use the {@link UncheckedScalar} decorator. Or you may use
- * {@link IoCheckedScalar} to wrap it in an IOException.</p>
+ * use the {@link Unchecked} decorator. Or you may use
+ * {@link IoChecked} to wrap it in an IOException.</p>
  *
  * <p>There is no thread-safety guarantee.
  *

--- a/src/main/java/org/cactoos/scalar/Equals.java
+++ b/src/main/java/org/cactoos/scalar/Equals.java
@@ -33,8 +33,8 @@ import org.cactoos.Scalar;
  * <p>This class implements {@link Scalar}, which throws a checked
  * {@link Exception}. This may not be convenient in many cases. To make
  * it more convenient and get rid of the checked exception you can
- * use the {@link UncheckedScalar} decorator. Or you may use
- * {@link IoCheckedScalar} to wrap it in an IOException.</p>
+ * use the {@link Unchecked} decorator. Or you may use
+ * {@link IoChecked} to wrap it in an IOException.</p>
  *
  * @param <T> Type of object to compare
  * @since 0.9

--- a/src/main/java/org/cactoos/scalar/HashCode.java
+++ b/src/main/java/org/cactoos/scalar/HashCode.java
@@ -60,7 +60,7 @@ public final class HashCode implements Scalar<Integer> {
     /**
      * Hash code.
      */
-    private final UncheckedScalar<Integer> origin;
+    private final Unchecked<Integer> origin;
 
     /**
      * Ctor.
@@ -97,7 +97,7 @@ public final class HashCode implements Scalar<Integer> {
      * @param hash Hashcode
      */
     private HashCode(final Scalar<Integer> hash) {
-        this.origin = new UncheckedScalar<>(hash);
+        this.origin = new Unchecked<>(hash);
     }
 
     @Override

--- a/src/main/java/org/cactoos/scalar/HighestOf.java
+++ b/src/main/java/org/cactoos/scalar/HighestOf.java
@@ -46,14 +46,14 @@ import org.cactoos.iterable.Mapped;
  * <p>This class implements {@link Scalar}, which throws a checked
  * {@link Exception}. This may not be convenient in many cases. To make
  * it more convenient and get rid of the checked exception you can
- * use the {@link UncheckedScalar} decorator. Or you may use
- * {@link IoCheckedScalar} to wrap it in an IOException.</p>
+ * use the {@link Unchecked} decorator. Or you may use
+ * {@link IoChecked} to wrap it in an IOException.</p>
  *
  * <p>There is no thread-safety guarantee.
  *
  * @param <T> Scalar type
- * @see UncheckedScalar
- * @see IoCheckedScalar
+ * @see Unchecked
+ * @see IoChecked
  * @since 0.29
  */
 public final class HighestOf<T extends Comparable<T>> implements Scalar<T> {

--- a/src/main/java/org/cactoos/scalar/IoChecked.java
+++ b/src/main/java/org/cactoos/scalar/IoChecked.java
@@ -21,40 +21,46 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.cactoos.func;
+package org.cactoos.scalar;
 
-import org.cactoos.BiFunc;
-import org.cactoos.scalar.Unchecked;
+import java.io.IOException;
+import org.cactoos.Scalar;
 
 /**
- * BiFunc that doesn't throw checked {@link Exception}.
+ * Scalar that doesn't throw {@link Exception}, but throws
+ * {@link IOException} instead.
  *
  * <p>There is no thread-safety guarantee.
  *
- * @param <X> Type of input
- * @param <Y> Type of input
- * @param <Z> Type of output
- * @since 0.13
+ * <p>This class implements {@link Scalar}, which throws a checked
+ * {@link IOException}. This may not be convenient in many cases. To make
+ * it more convenient and get rid of the checked exception you can
+ * use the {@link Unchecked} decorator.</p>
+ *
+ * @param <T> Type of result
+ * @since 0.4
  */
-public final class UncheckedBiFunc<X, Y, Z> implements BiFunc<X, Y, Z> {
+public final class IoChecked<T> implements Scalar<T> {
 
     /**
-     * Original func.
+     * Original scalar.
      */
-    private final BiFunc<X, Y, Z> func;
+    private final Scalar<T> origin;
 
     /**
      * Ctor.
-     * @param fnc Encapsulated func
+     * @param scalar Encapsulated scalar
      */
-    public UncheckedBiFunc(final BiFunc<X, Y, Z> fnc) {
-        this.func = fnc;
+    public IoChecked(final Scalar<T> scalar) {
+        this.origin = scalar;
     }
 
     @Override
-    public Z apply(final X first, final Y second) {
-        return new Unchecked<>(
-            () -> this.func.apply(first, second)
+    public T value() throws IOException {
+        return new Checked<>(
+            this.origin,
+            IOException::new
         ).value();
     }
+
 }

--- a/src/main/java/org/cactoos/scalar/ItemAt.java
+++ b/src/main/java/org/cactoos/scalar/ItemAt.java
@@ -41,7 +41,7 @@ import org.cactoos.text.FormattedText;
 public final class ItemAt<T> implements Scalar<T> {
 
     /**
-     * {@link StickyScalar} that holds the value of the iterator
+     * {@link Sticky} that holds the value of the iterator
      *  at the position specified in the constructor.
      */
     private final Scalar<T> saved;
@@ -127,7 +127,7 @@ public final class ItemAt<T> implements Scalar<T> {
         final int position,
         final Func<Iterable<T>, T> fallback
     ) {
-        this(new StickyScalar<>(source::iterator), position, fallback);
+        this(new Sticky<>(source::iterator), position, fallback);
     }
 
     /**
@@ -200,7 +200,7 @@ public final class ItemAt<T> implements Scalar<T> {
         final int position,
         final Func<Iterable<T>, T> fallback
     ) {
-        this(new StickyScalar<>(() -> iterator), position, fallback);
+        this(new Sticky<>(() -> iterator), position, fallback);
     }
 
     /**
@@ -215,7 +215,7 @@ public final class ItemAt<T> implements Scalar<T> {
         final int position,
         final Func<Iterable<T>, T> fallback
     ) {
-        this.saved = new StickyScalar<T>(
+        this.saved = new Sticky<T>(
             () -> {
                 final T ret;
                 if (position < 0) {

--- a/src/main/java/org/cactoos/scalar/LowestOf.java
+++ b/src/main/java/org/cactoos/scalar/LowestOf.java
@@ -46,14 +46,14 @@ import org.cactoos.iterable.Mapped;
  * <p>This class implements {@link Scalar}, which throws a checked
  * {@link Exception}. This may not be convenient in many cases. To make
  * it more convenient and get rid of the checked exception you can
- * use the {@link UncheckedScalar} decorator. Or you may use
- * {@link IoCheckedScalar} to wrap it in an IOException.</p>
+ * use the {@link Unchecked} decorator. Or you may use
+ * {@link IoChecked} to wrap it in an IOException.</p>
  *
  * <p>There is no thread-safety guarantee.
  *
  * @param <T> Scalar type
- * @see UncheckedScalar
- * @see IoCheckedScalar
+ * @see Unchecked
+ * @see IoChecked
  * @since 0.29
  */
 public final class LowestOf<T extends Comparable<T>> implements Scalar<T> {

--- a/src/main/java/org/cactoos/scalar/MaxOf.java
+++ b/src/main/java/org/cactoos/scalar/MaxOf.java
@@ -40,13 +40,13 @@ import org.cactoos.Scalar;
  * <p>This class implements {@link Scalar}, which throws a checked
  * {@link Exception}. This may not be convenient in many cases. To make
  * it more convenient and get rid of the checked exception you can
- * use the {@link UncheckedScalar} decorator. Or you may use
- * {@link IoCheckedScalar} to wrap it in an IOException.</p>
+ * use the {@link Unchecked} decorator. Or you may use
+ * {@link IoChecked} to wrap it in an IOException.</p>
  *
  * <p>There is no thread-safety guarantee.
  *
- * @see UncheckedScalar
- * @see IoCheckedScalar
+ * @see Unchecked
+ * @see IoChecked
  * @since 0.24
  */
 @SuppressWarnings(

--- a/src/main/java/org/cactoos/scalar/MinOf.java
+++ b/src/main/java/org/cactoos/scalar/MinOf.java
@@ -42,8 +42,8 @@ import org.cactoos.Scalar;
  * <p>This class implements {@link Scalar}, which throws a checked
  * {@link Exception}. This may not be convenient in many cases. To make
  * it more convenient and get rid of the checked exception you can
- * use the {@link UncheckedScalar} decorator. Or you may use
- * {@link IoCheckedScalar} to wrap it in an IOException.</p>
+ * use the {@link Unchecked} decorator. Or you may use
+ * {@link IoChecked} to wrap it in an IOException.</p>
  *
  * @since 0.24
  */

--- a/src/main/java/org/cactoos/scalar/MultiplicationOf.java
+++ b/src/main/java/org/cactoos/scalar/MultiplicationOf.java
@@ -44,8 +44,8 @@ import org.cactoos.iterable.Mapped;
  * <p>This class implements {@link Scalar}, which throws a checked
  * {@link Exception}. This may not be convenient in many cases. To make
  * it more convenient and get rid of the checked exception you can
- * use the {@link UncheckedScalar} decorator. Or you may use
- * {@link IoCheckedScalar} to wrap it in an IOException.</p>
+ * use the {@link Unchecked} decorator. Or you may use
+ * {@link IoChecked} to wrap it in an IOException.</p>
  *
  * <p>There is no thread-safety guarantee.
  *

--- a/src/main/java/org/cactoos/scalar/Not.java
+++ b/src/main/java/org/cactoos/scalar/Not.java
@@ -33,8 +33,8 @@ import org.cactoos.Scalar;
  * <p>This class implements {@link Scalar}, which throws a checked
  * {@link Exception}. This may not be convenient in many cases. To make
  * it more convenient and get rid of the checked exception you can
- * use the {@link UncheckedScalar} decorator. Or you may use
- * {@link IoCheckedScalar} to wrap it in an IOException.</p>
+ * use the {@link Unchecked} decorator. Or you may use
+ * {@link IoChecked} to wrap it in an IOException.</p>
  *
  * @since 0.7
  */

--- a/src/main/java/org/cactoos/scalar/NumberEnvelope.java
+++ b/src/main/java/org/cactoos/scalar/NumberEnvelope.java
@@ -93,22 +93,22 @@ public abstract class NumberEnvelope extends Number implements Scalar<Double> {
 
     @Override
     public final int intValue() {
-        return new UncheckedScalar<>(this.inum).value();
+        return new Unchecked<>(this.inum).value();
     }
 
     @Override
     public final long longValue() {
-        return new UncheckedScalar<>(this.lnum).value();
+        return new Unchecked<>(this.lnum).value();
     }
 
     @Override
     public final float floatValue() {
-        return new UncheckedScalar<>(this.fnum).value();
+        return new Unchecked<>(this.fnum).value();
     }
 
     @Override
     public final double doubleValue() {
-        return new UncheckedScalar<>(this.dnum).value();
+        return new Unchecked<>(this.dnum).value();
     }
 
     @Override

--- a/src/main/java/org/cactoos/scalar/NumberOf.java
+++ b/src/main/java/org/cactoos/scalar/NumberOf.java
@@ -41,8 +41,8 @@ import org.cactoos.text.TextOf;
  * <p>This class implements {@link Scalar}, which throws a checked
  * {@link Exception}. This may not be convenient in many cases. To make
  * it more convenient and get rid of the checked exception you can
- * use the {@link UncheckedScalar} decorator. Or you may use
- * {@link IoCheckedScalar} to wrap it in an IOException.</p>
+ * use the {@link Unchecked} decorator. Or you may use
+ * {@link IoChecked} to wrap it in an IOException.</p>
  *
  * @since 0.2
  */
@@ -89,16 +89,16 @@ public final class NumberOf extends Number implements Scalar<Number> {
      */
     public NumberOf(final Text text) {
         super();
-        this.lnum = new StickyScalar<>(
+        this.lnum = new Sticky<>(
             () -> Long.parseLong(text.asString())
         );
-        this.inum = new StickyScalar<>(
+        this.inum = new Sticky<>(
             () -> Integer.parseInt(text.asString())
         );
-        this.fnum = new StickyScalar<>(
+        this.fnum = new Sticky<>(
             () -> Float.parseFloat(text.asString())
         );
-        this.dnum = new StickyScalar<>(
+        this.dnum = new Sticky<>(
             () -> Double.parseDouble(text.asString())
         );
     }
@@ -110,21 +110,21 @@ public final class NumberOf extends Number implements Scalar<Number> {
 
     @Override
     public int intValue() {
-        return new UncheckedScalar<>(this.inum).value();
+        return new Unchecked<>(this.inum).value();
     }
 
     @Override
     public long longValue() {
-        return new UncheckedScalar<>(this.lnum).value();
+        return new Unchecked<>(this.lnum).value();
     }
 
     @Override
     public float floatValue() {
-        return new UncheckedScalar<>(this.fnum).value();
+        return new Unchecked<>(this.fnum).value();
     }
 
     @Override
     public double doubleValue() {
-        return new UncheckedScalar<>(this.dnum).value();
+        return new Unchecked<>(this.dnum).value();
     }
 }

--- a/src/main/java/org/cactoos/scalar/Or.java
+++ b/src/main/java/org/cactoos/scalar/Or.java
@@ -72,8 +72,8 @@ import org.cactoos.iterable.Mapped;
  * <p>This class implements {@link Scalar}, which throws a checked
  * {@link Exception}. This may not be convenient in many cases. To make
  * it more convenient and get rid of the checked exception you can
- * use the {@link UncheckedScalar} decorator. Or you may use
- * {@link IoCheckedScalar} to wrap it in an IOException.</p>
+ * use the {@link Unchecked} decorator. Or you may use
+ * {@link IoChecked} to wrap it in an IOException.</p>
  *
  * @since 0.8
  */

--- a/src/main/java/org/cactoos/scalar/PropertiesOf.java
+++ b/src/main/java/org/cactoos/scalar/PropertiesOf.java
@@ -50,7 +50,7 @@ public final class PropertiesOf implements Scalar<Properties> {
     /**
      * The underlying properties.
      */
-    private final IoCheckedScalar<Properties> scalar;
+    private final IoChecked<Properties> scalar;
 
     /**
      * Ctor.
@@ -134,7 +134,7 @@ public final class PropertiesOf implements Scalar<Properties> {
      * @param sclr The underlying properties
      */
     private PropertiesOf(final Scalar<Properties> sclr) {
-        this.scalar = new IoCheckedScalar<>(sclr);
+        this.scalar = new IoChecked<>(sclr);
     }
 
     @Override

--- a/src/main/java/org/cactoos/scalar/Reduced.java
+++ b/src/main/java/org/cactoos/scalar/Reduced.java
@@ -66,8 +66,8 @@ import org.cactoos.iterable.Mapped;
  * <p>This class implements {@link Scalar}, which throws a checked
  * {@link Exception}. This may not be convenient in many cases. To make
  * it more convenient and get rid of the checked exception you can
- * use the {@link UncheckedScalar} decorator. Or you may use
- * {@link IoCheckedScalar} to wrap it in an IOException.</p>
+ * use the {@link Unchecked} decorator. Or you may use
+ * {@link IoChecked} to wrap it in an IOException.</p>
  *
  * @param <T> Scalar type
  * @since 0.30

--- a/src/main/java/org/cactoos/scalar/Sticky.java
+++ b/src/main/java/org/cactoos/scalar/Sticky.java
@@ -23,64 +23,59 @@
  */
 package org.cactoos.scalar;
 
+import org.cactoos.Func;
 import org.cactoos.Scalar;
+import org.cactoos.func.StickyFunc;
 
 /**
- * Scalar that is thread-safe.
+ * Cached version of a Scalar.
+ *
+ * <p>This {@link Scalar} decorator technically is an in-memory
+ * cache.</p>
+ *
+ * <p>Pay attention that this class is not thread-safe. It is highly
+ * recommended to always decorate it with {@link Synced}.</p>
  *
  * <p>This class implements {@link Scalar}, which throws a checked
  * {@link Exception}. This may not be convenient in many cases. To make
  * it more convenient and get rid of the checked exception you can
- * use the {@link UncheckedScalar} decorator. Or you may use
- * {@link IoCheckedScalar} to wrap it in an IOException.</p>
+ * use the {@link Unchecked} decorator. Or you may use
+ * {@link IoChecked} to wrap it in an IOException.</p>
  *
  * <pre>{@code
- * final List<Integer> list = new LinkedList<>();
- * final int threads = 100;
- * new RunsInThreads<>(
- *     new SyncScalar<>(() -> list.add(1)), threads
- * ); // list.size() will be equal to threads value
+ * final Scalar<Integer> scalar = new StickyScalar<>(
+ *     () -> {
+ *         System.out.println("Will be printed only once");
+ *         return new SecureRandom().nextInt();
+ *     }
+ * ).value()
  * }</pre>
  *
- * <p>Objects of this class are thread-safe.</p>
+ * <p>There is no thread-safety guarantee.
  *
  * @param <T> Type of result
+ * @see StickyFunc
  * @since 0.3
  */
-public final class SyncScalar<T> implements Scalar<T> {
+public final class Sticky<T> implements Scalar<T> {
 
     /**
-     * The scalar to cache.
+     * Func.
      */
-    private final Scalar<T> origin;
-
-    /**
-     * Sync lock.
-     */
-    private final Object mutex;
-
-    /**
-     * Ctor.
-     * @param src The Scalar to cache
-     */
-    public SyncScalar(final Scalar<T> src) {
-        this(src, src);
-    }
+    private final Func<Boolean, T> func;
 
     /**
      * Ctor.
      * @param scalar The Scalar to cache
-     * @param lock Sync lock
      */
-    public SyncScalar(final Scalar<T> scalar, final Object lock) {
-        this.origin = scalar;
-        this.mutex = lock;
+    public Sticky(final Scalar<T> scalar) {
+        this.func = new StickyFunc<>(
+            input -> scalar.value()
+        );
     }
 
     @Override
     public T value() throws Exception {
-        synchronized (this.mutex) {
-            return this.origin.value();
-        }
+        return this.func.apply(true);
     }
 }

--- a/src/main/java/org/cactoos/scalar/SumOf.java
+++ b/src/main/java/org/cactoos/scalar/SumOf.java
@@ -43,8 +43,8 @@ import org.cactoos.iterable.Mapped;
  * <p>This class implements {@link Scalar}, which throws a checked
  * {@link Exception}. This may not be convenient in many cases. To make
  * it more convenient and get rid of the checked exception you can
- * use the {@link UncheckedScalar} decorator. Or you may use
- * {@link IoCheckedScalar} to wrap it in an IOException.</p>
+ * use the {@link Unchecked} decorator. Or you may use
+ * {@link IoChecked} to wrap it in an IOException.</p>
  *
  * <p>There is no thread-safety guarantee.
  *

--- a/src/main/java/org/cactoos/scalar/SumOfDouble.java
+++ b/src/main/java/org/cactoos/scalar/SumOfDouble.java
@@ -23,41 +23,44 @@
  */
 package org.cactoos.scalar;
 
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsEqual;
-import org.junit.Test;
+import org.cactoos.Scalar;
 
 /**
- * Test case for {@link SumOfDoubleScalar}.
+ * Double Scalar which sums up the values of other Scalars of the same type.
+ *
+ * <p>Here is how you can use it to summarize double numbers:</p>
+ *
+ * <pre>{@code
+ * double sum = new SumOfDoubleScalar(() -> 1.1,() -> 2.1, () -> 3.1).value();
+ * }</pre>
+ *
+ * <p>This class implements {@link Scalar}, which throws a checked
+ * {@link Exception}. Despite that this class does NOT throw a checked
+ * exception.</p>
+ *
+ * <p>There is no thread-safety guarantee.
  *
  * @since 0.30
- * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle MagicNumberCheck (500 lines)
  */
-public final class SumOfDoubleScalarTest {
+public final class SumOfDouble implements Scalar<Double> {
 
-    @Test
-    public void withListOfScalarsInt() {
-        MatcherAssert.assertThat(
-            new SumOfDoubleScalar(() -> 1.1, () -> 2.1, () -> 3.1)
-                .value(),
-            new IsEqual<>(6.3)
-        );
+    /**
+     * Varargs of Scalar to sum up values from.
+     */
+    private final Scalar<Double>[] scalars;
+
+    /**
+     * Ctor.
+     * @param src Varargs of Scalar to sum up values from
+     * @since 0.30
+     */
+    @SafeVarargs
+    public SumOfDouble(final Scalar<Double>... src) {
+        this.scalars = src;
     }
 
-    @Test
-    public void withEmptyList() {
-        MatcherAssert.assertThat(
-            new SumOfDoubleScalar().value(),
-            new IsEqual<>(0.0)
-        );
-    }
-
-    @Test
-    public void withListOfOneElement() {
-        MatcherAssert.assertThat(
-            new SumOfDoubleScalar(() -> 5.1).value(),
-            new IsEqual<>(5.1)
-        );
+    @Override
+    public Double value() {
+        return new SumOfScalar(this.scalars).value().doubleValue();
     }
 }

--- a/src/main/java/org/cactoos/scalar/SumOfFloat.java
+++ b/src/main/java/org/cactoos/scalar/SumOfFloat.java
@@ -23,41 +23,44 @@
  */
 package org.cactoos.scalar;
 
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsEqual;
-import org.junit.Test;
+import org.cactoos.Scalar;
 
 /**
- * Test case for {@link SumOfIntScalar}.
+ * Float Scalar which sums up the values of other Scalars of the same type
+ *
+ * <p>Here is how you can use it to summarize float numbers:</p>
+ *
+ * <pre>{@code
+ * float sum = new SumOfFloatScalar(() -> 1f,() -> 2f, () -> 3f).value();
+ * }</pre>
+ *
+ * <p>This class implements {@link Scalar}, which throws a checked
+ * {@link Exception}. Despite that this class does NOT throw a checked
+ * exception.</p>
+ *
+ * <p>There is no thread-safety guarantee.
  *
  * @since 0.30
- * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle MagicNumberCheck (500 lines)
  */
-public final class SumOfIntScalarTest {
+public final class SumOfFloat implements Scalar<Float> {
 
-    @Test
-    public void withListOfScalarsInt() {
-        MatcherAssert.assertThat(
-            new SumOfIntScalar(() -> 1, () -> 2, () -> 3)
-                .value(),
-            new IsEqual<>(6)
-        );
+    /**
+     * Varargs of Scalar to sum up values from.
+     */
+    private final Scalar<Float>[] scalars;
+
+    /**
+     * Ctor.
+     * @param src Varargs of Scalar to sum up values from
+     * @since 0.30
+     */
+    @SafeVarargs
+    public SumOfFloat(final Scalar<Float>... src) {
+        this.scalars = src;
     }
 
-    @Test
-    public void withEmptyList() {
-        MatcherAssert.assertThat(
-            new SumOfIntScalar().value(),
-            new IsEqual<>(0)
-        );
-    }
-
-    @Test
-    public void withListOfOneElement() {
-        MatcherAssert.assertThat(
-            new SumOfIntScalar(() -> 5).value(),
-            new IsEqual<>(5)
-        );
+    @Override
+    public Float value() {
+        return new SumOfScalar(this.scalars).value().floatValue();
     }
 }

--- a/src/main/java/org/cactoos/scalar/SumOfInt.java
+++ b/src/main/java/org/cactoos/scalar/SumOfInt.java
@@ -23,59 +23,45 @@
  */
 package org.cactoos.scalar;
 
-import org.cactoos.Func;
 import org.cactoos.Scalar;
-import org.cactoos.func.StickyFunc;
 
 /**
- * Cached version of a Scalar.
+ * Integer Scalar which sums up the values of other Scalars of the same type
  *
- * <p>This {@link Scalar} decorator technically is an in-memory
- * cache.</p>
- *
- * <p>Pay attention that this class is not thread-safe. It is highly
- * recommended to always decorate it with {@link SyncScalar}.</p>
- *
- * <p>This class implements {@link Scalar}, which throws a checked
- * {@link Exception}. This may not be convenient in many cases. To make
- * it more convenient and get rid of the checked exception you can
- * use the {@link UncheckedScalar} decorator. Or you may use
- * {@link IoCheckedScalar} to wrap it in an IOException.</p>
+ * <p>Here is how you can use it to summarize numbers:</p>
  *
  * <pre>{@code
- * final Scalar<Integer> scalar = new StickyScalar<>(
- *     () -> {
- *         System.out.println("Will be printed only once");
- *         return new SecureRandom().nextInt();
- *     }
- * ).value()
+ * int sum = new SumOfIntScalar(() -> 1,() -> 2, () -> 3).value();
+ * // sum equal to 6
  * }</pre>
+ *
+ * <p>This class implements {@link Scalar}, which throws a checked
+ * {@link Exception}. Despite that this class does NOT throw a checked
+ * exception.</p>
  *
  * <p>There is no thread-safety guarantee.
  *
- * @param <T> Type of result
- * @see StickyFunc
- * @since 0.3
+ * @since 0.30
  */
-public final class StickyScalar<T> implements Scalar<T> {
+public final class SumOfInt implements Scalar<Integer> {
 
     /**
-     * Func.
+     * Varargs of Scalar to sum up values from.
      */
-    private final Func<Boolean, T> func;
+    private final Scalar<Integer>[] scalars;
 
     /**
      * Ctor.
-     * @param scalar The Scalar to cache
+     * @param src Varargs of Scalar to sum up values from
+     * @since 0.30
      */
-    public StickyScalar(final Scalar<T> scalar) {
-        this.func = new StickyFunc<>(
-            input -> scalar.value()
-        );
+    @SafeVarargs
+    public SumOfInt(final Scalar<Integer>... src) {
+        this.scalars = src;
     }
 
     @Override
-    public T value() throws Exception {
-        return this.func.apply(true);
+    public Integer value() {
+        return new SumOfScalar(this.scalars).value().intValue();
     }
 }

--- a/src/main/java/org/cactoos/scalar/SumOfLong.java
+++ b/src/main/java/org/cactoos/scalar/SumOfLong.java
@@ -26,12 +26,12 @@ package org.cactoos.scalar;
 import org.cactoos.Scalar;
 
 /**
- * Double Scalar which sums up the values of other Scalars of the same type.
+ * Long Scalar which sums up the values of other Scalars of the same type
  *
- * <p>Here is how you can use it to summarize double numbers:</p>
+ * <p>Here is how you can use it to summarize numbers:</p>
  *
  * <pre>{@code
- * double sum = new SumOfDoubleScalar(() -> 1.1,() -> 2.1, () -> 3.1).value();
+ * long sum = new SumOfLongScalar(() -> 1,() -> 2, () -> 3).value();
  * }</pre>
  *
  * <p>This class implements {@link Scalar}, which throws a checked
@@ -42,12 +42,12 @@ import org.cactoos.Scalar;
  *
  * @since 0.30
  */
-public final class SumOfDoubleScalar implements Scalar<Double> {
+public final class SumOfLong implements Scalar<Long> {
 
     /**
      * Varargs of Scalar to sum up values from.
      */
-    private final Scalar<Double>[] scalars;
+    private final Scalar<Long>[] scalars;
 
     /**
      * Ctor.
@@ -55,12 +55,12 @@ public final class SumOfDoubleScalar implements Scalar<Double> {
      * @since 0.30
      */
     @SafeVarargs
-    public SumOfDoubleScalar(final Scalar<Double>... src) {
+    public SumOfLong(final Scalar<Long>... src) {
         this.scalars = src;
     }
 
     @Override
-    public Double value() {
-        return new SumOfScalar(this.scalars).value().doubleValue();
+    public Long value() {
+        return new SumOfScalar(this.scalars).value().longValue();
     }
 }

--- a/src/main/java/org/cactoos/scalar/SumOfScalar.java
+++ b/src/main/java/org/cactoos/scalar/SumOfScalar.java
@@ -64,7 +64,7 @@ final class SumOfScalar implements Scalar<SumOf> {
                 new CollectionOf<>(this.scalars)
                     .stream()
                     .map(
-                        scalar -> new UncheckedScalar<>(scalar).value()
+                        scalar -> new Unchecked<>(scalar).value()
                     ).collect(Collectors.toList())
             )
         );

--- a/src/main/java/org/cactoos/scalar/Ternary.java
+++ b/src/main/java/org/cactoos/scalar/Ternary.java
@@ -34,8 +34,8 @@ import org.cactoos.Scalar;
  * <p>This class implements {@link Scalar}, which throws a checked
  * {@link Exception}. This may not be convenient in many cases. To make
  * it more convenient and get rid of the checked exception you can
- * use the {@link UncheckedScalar} decorator. Or you may use
- * {@link IoCheckedScalar} to wrap it in an IOException.</p>
+ * use the {@link Unchecked} decorator. Or you may use
+ * {@link IoChecked} to wrap it in an IOException.</p>
  *
  * <pre>{@code
  * new Ternary<>(

--- a/src/main/java/org/cactoos/scalar/Unchecked.java
+++ b/src/main/java/org/cactoos/scalar/Unchecked.java
@@ -24,43 +24,39 @@
 package org.cactoos.scalar;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import org.cactoos.Scalar;
 
 /**
- * Scalar that doesn't throw {@link Exception}, but throws
- * {@link IOException} instead.
+ * Scalar that doesn't throw checked {@link Exception}.
  *
  * <p>There is no thread-safety guarantee.
  *
- * <p>This class implements {@link Scalar}, which throws a checked
- * {@link IOException}. This may not be convenient in many cases. To make
- * it more convenient and get rid of the checked exception you can
- * use the {@link UncheckedScalar} decorator.</p>
- *
  * @param <T> Type of result
- * @since 0.4
+ * @since 0.3
  */
-public final class IoCheckedScalar<T> implements Scalar<T> {
+public final class Unchecked<T> implements Scalar<T> {
 
     /**
-     * Original scalar.
+     * Original origin.
      */
     private final Scalar<T> origin;
 
     /**
      * Ctor.
-     * @param scalar Encapsulated scalar
+     * @param scalar Encapsulated origin
      */
-    public IoCheckedScalar(final Scalar<T> scalar) {
+    public Unchecked(final Scalar<T> scalar) {
         this.origin = scalar;
     }
 
     @Override
-    public T value() throws IOException {
-        return new Checked<>(
-            this.origin,
-            IOException::new
-        ).value();
+    public T value() {
+        try {
+            return new IoChecked<>(this.origin).value();
+        } catch (final IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
     }
 
 }

--- a/src/main/java/org/cactoos/scalar/UncheckedScalar.java
+++ b/src/main/java/org/cactoos/scalar/UncheckedScalar.java
@@ -23,8 +23,6 @@
  */
 package org.cactoos.scalar;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import org.cactoos.Scalar;
 
 /**
@@ -32,31 +30,32 @@ import org.cactoos.Scalar;
  *
  * <p>There is no thread-safety guarantee.
  *
+ * @deprecated Use {@link Unchecked} instead
  * @param <T> Type of result
  * @since 0.3
+ * @todo #1081:30min Remove once the dependency cactoos-matchers has been
+ *  updated to latest version of cactoos and use {@link Unchecked} instead
+ *  of {@link UncheckedScalar}.
  */
+@Deprecated
 public final class UncheckedScalar<T> implements Scalar<T> {
 
     /**
-     * Original origin.
+     * Unchecked origin.
      */
-    private final Scalar<T> origin;
+    private final Unchecked<T> origin;
 
     /**
      * Ctor.
      * @param scalar Encapsulated origin
      */
     public UncheckedScalar(final Scalar<T> scalar) {
-        this.origin = scalar;
+        this.origin = new Unchecked<>(scalar);
     }
 
     @Override
     public T value() {
-        try {
-            return new IoCheckedScalar<>(this.origin).value();
-        } catch (final IOException ex) {
-            throw new UncheckedIOException(ex);
-        }
+        return this.origin.value();
     }
 
 }

--- a/src/main/java/org/cactoos/scalar/package-info.java
+++ b/src/main/java/org/cactoos/scalar/package-info.java
@@ -26,9 +26,5 @@
  * Scalars.
  *
  * @since 0.12
- * @todo #1007:30min Continue applying the new class naming convention:
- *  avoid compound names for decorators. Continue renaming classes implementing
- *  the {@link org.cactoos.Scalar}. More details you can find here
- *  https://github.com/yegor256/cactoos/issues/913#issuecomment-402332247.
  */
 package org.cactoos.scalar;

--- a/src/main/java/org/cactoos/set/package-info.java
+++ b/src/main/java/org/cactoos/set/package-info.java
@@ -26,9 +26,5 @@
  * Sets.
  *
  * @since 0.49.2
- * @todo #980:30min Continue applying the new class naming convention in effect:
- *  avoid compound names for decorators. Continue renaming classes implementing
- *  the {@link java.util.Set}. More details you can find here
- *  https://github.com/yegor256/cactoos/issues/913#issuecomment-402332247.
  */
 package org.cactoos.set;

--- a/src/main/java/org/cactoos/text/ComparableText.java
+++ b/src/main/java/org/cactoos/text/ComparableText.java
@@ -24,7 +24,7 @@
 package org.cactoos.text;
 
 import org.cactoos.Text;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Text implementing Comparable.<br>
@@ -55,7 +55,7 @@ public final class ComparableText extends TextEnvelope
 
     @Override
     public int compareTo(final Text other) {
-        return new UncheckedScalar<>(
+        return new Unchecked<>(
             () -> this.asString().compareTo(other.asString())
         ).value();
     }

--- a/src/main/java/org/cactoos/text/Randomized.java
+++ b/src/main/java/org/cactoos/text/Randomized.java
@@ -29,7 +29,7 @@ import java.util.Random;
 import org.cactoos.Scalar;
 import org.cactoos.Text;
 import org.cactoos.list.ListOf;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Randomized text.
@@ -164,7 +164,7 @@ public final class Randomized implements Text {
 
     @Override
     public String asString() {
-        final int len = new UncheckedScalar<>(this.length).value();
+        final int len = new Unchecked<>(this.length).value();
         final StringBuilder builder = new StringBuilder(len);
         final int bound = this.characters.size();
         for (int index = 0; index < len; index = index + 1) {

--- a/src/main/java/org/cactoos/text/Replaced.java
+++ b/src/main/java/org/cactoos/text/Replaced.java
@@ -31,7 +31,7 @@ import org.cactoos.Func;
 import org.cactoos.Scalar;
 import org.cactoos.Text;
 import org.cactoos.func.IoCheckedFunc;
-import org.cactoos.scalar.IoCheckedScalar;
+import org.cactoos.scalar.IoChecked;
 
 /**
  * Replace the Text.
@@ -86,7 +86,7 @@ public final class Replaced extends TextEnvelope {
         final Func<Matcher, String> func) {
         super((Scalar<String>) () -> {
             final StringBuffer buffer = new StringBuffer();
-            final Matcher matcher = new IoCheckedScalar<>(regex)
+            final Matcher matcher = new IoChecked<>(regex)
                 .value()
                 .matcher(text.asString());
             final IoCheckedFunc<Matcher, String> safe =

--- a/src/main/java/org/cactoos/text/Sub.java
+++ b/src/main/java/org/cactoos/text/Sub.java
@@ -25,7 +25,7 @@ package org.cactoos.text;
 
 import org.cactoos.Scalar;
 import org.cactoos.Text;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Extract a substring from a Text.
@@ -81,7 +81,7 @@ public final class Sub extends TextEnvelope {
      */
     public Sub(final Text text, final Scalar<Integer> strt,
         final Scalar<Integer> finish) {
-        this(text, new UncheckedScalar<>(strt), new UncheckedScalar<>(finish));
+        this(text, new Unchecked<>(strt), new Unchecked<>(finish));
     }
 
     /**
@@ -92,8 +92,8 @@ public final class Sub extends TextEnvelope {
      */
     @SuppressWarnings({"PMD.CallSuperInConstructor",
         "PMD.ConstructorOnlyInitializesOrCallOtherConstructors"})
-    public Sub(final Text text, final UncheckedScalar<Integer> start,
-        final UncheckedScalar<Integer> end) {
+    public Sub(final Text text, final Unchecked<Integer> start,
+        final Unchecked<Integer> end) {
         super((Scalar<String>) () -> {
             int begin = start.value();
             if (begin < 0) {

--- a/src/main/java/org/cactoos/text/TextEnvelope.java
+++ b/src/main/java/org/cactoos/text/TextEnvelope.java
@@ -27,9 +27,9 @@ import java.io.IOException;
 import org.cactoos.Scalar;
 import org.cactoos.Text;
 import org.cactoos.scalar.And;
-import org.cactoos.scalar.IoCheckedScalar;
+import org.cactoos.scalar.IoChecked;
 import org.cactoos.scalar.Or;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Text envelope that provides {@link #equals(Object)} and {@link #hashCode()}
@@ -42,14 +42,14 @@ public abstract class TextEnvelope implements Text {
     /**
      * String value of the envelope.
      */
-    private final IoCheckedScalar<String> origin;
+    private final IoChecked<String> origin;
 
     /**
      * Ctor.
      * @param text Text representing the text value.
      */
     public TextEnvelope(final Text text) {
-        this(new IoCheckedScalar<>(text::asString));
+        this(new IoChecked<>(text::asString));
     }
 
     /**
@@ -57,7 +57,7 @@ public abstract class TextEnvelope implements Text {
      * @param scalar Scalar representing the text value.
      */
     public TextEnvelope(final Scalar<String> scalar) {
-        this.origin = new IoCheckedScalar<>(scalar);
+        this.origin = new IoChecked<>(scalar);
     }
 
     @Override
@@ -72,12 +72,12 @@ public abstract class TextEnvelope implements Text {
 
     @Override
     public final int hashCode() {
-        return new UncheckedScalar<>(this.origin).value().hashCode();
+        return new Unchecked<>(this.origin).value().hashCode();
     }
 
     @Override
     public final boolean equals(final Object obj) {
-        return new UncheckedScalar<>(
+        return new Unchecked<>(
             new Or(
                 () -> this == obj,
                 new And(

--- a/src/main/java/org/cactoos/text/TextOf.java
+++ b/src/main/java/org/cactoos/text/TextOf.java
@@ -44,7 +44,7 @@ import org.cactoos.Scalar;
 import org.cactoos.io.BytesOf;
 import org.cactoos.io.InputOf;
 import org.cactoos.iterable.Mapped;
-import org.cactoos.scalar.StickyScalar;
+import org.cactoos.scalar.Sticky;
 import org.cactoos.time.Iso;
 
 /**
@@ -389,7 +389,7 @@ public final class TextOf extends TextEnvelope {
      */
     public TextOf(final LocalDate date, final DateTimeFormatter formatter) {
         this(
-            new StickyScalar<>(
+            new Sticky<>(
                 () -> formatter.format(
                     ZonedDateTime.of(
                         date, LocalTime.MIN, ZoneId.systemDefault()

--- a/src/main/java/org/cactoos/time/DateOf.java
+++ b/src/main/java/org/cactoos/time/DateOf.java
@@ -28,7 +28,7 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import org.cactoos.Scalar;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Parser for {@link Date} instances.
@@ -39,7 +39,7 @@ public final class DateOf implements Scalar<Date> {
     /**
      * The parsed date.
      */
-    private final UncheckedScalar<Date> parsed;
+    private final Unchecked<Date> parsed;
 
     /**
      * Parses the provided date as ISO formatted.
@@ -64,7 +64,7 @@ public final class DateOf implements Scalar<Date> {
      * @param formatter The formatter to use.
      */
     public DateOf(final CharSequence date, final DateTimeFormatter formatter) {
-        this.parsed = new UncheckedScalar<>(
+        this.parsed = new Unchecked<>(
             () -> Date.from(
                 LocalDateTime.from(
                     formatter.parse(date)

--- a/src/main/java/org/cactoos/time/LocalDateTimeOf.java
+++ b/src/main/java/org/cactoos/time/LocalDateTimeOf.java
@@ -26,7 +26,7 @@ package org.cactoos.time;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import org.cactoos.Scalar;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Parser for {@link LocalDateTime} instances.
@@ -36,7 +36,7 @@ public final class LocalDateTimeOf implements Scalar<LocalDateTime> {
     /**
      * The parsed date.
      */
-    private final UncheckedScalar<LocalDateTime> parsed;
+    private final Unchecked<LocalDateTime> parsed;
 
     /**
      * Parses ISO date to create {@link LocalDateTime} instances.
@@ -64,7 +64,7 @@ public final class LocalDateTimeOf implements Scalar<LocalDateTime> {
      */
     public LocalDateTimeOf(final CharSequence date,
         final DateTimeFormatter formatter) {
-        this.parsed = new UncheckedScalar<>(
+        this.parsed = new Unchecked<>(
             () -> LocalDateTime.from(formatter.parse(date))
         );
     }

--- a/src/main/java/org/cactoos/time/OffsetDateTimeOf.java
+++ b/src/main/java/org/cactoos/time/OffsetDateTimeOf.java
@@ -28,7 +28,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import org.cactoos.Scalar;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Parser for {@link OffsetDateTime} instances.
@@ -38,7 +38,7 @@ public final class OffsetDateTimeOf implements Scalar<OffsetDateTime> {
     /**
      * The parsed date.
      */
-    private final UncheckedScalar<OffsetDateTime> parsed;
+    private final Unchecked<OffsetDateTime> parsed;
 
     /**
      * Parses ISO date to create {@link OffsetDateTime} instances.
@@ -70,7 +70,7 @@ public final class OffsetDateTimeOf implements Scalar<OffsetDateTime> {
      */
     public OffsetDateTimeOf(final CharSequence date,
         final DateTimeFormatter formatter) {
-        this.parsed = new UncheckedScalar<>(
+        this.parsed = new Unchecked<>(
             () -> ZonedDateTime.from(formatter.parse(date)).toOffsetDateTime()
         );
     }

--- a/src/main/java/org/cactoos/time/ZonedDateTimeOf.java
+++ b/src/main/java/org/cactoos/time/ZonedDateTimeOf.java
@@ -27,7 +27,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import org.cactoos.Scalar;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Parser for {@link ZonedDateTime} instances.
@@ -37,7 +37,7 @@ public final class ZonedDateTimeOf implements Scalar<ZonedDateTime> {
     /**
      * The parsed date.
      */
-    private final UncheckedScalar<ZonedDateTime> parsed;
+    private final Unchecked<ZonedDateTime> parsed;
 
     /**
      * Parses date to create {@link ZonedDateTime} instances.
@@ -67,7 +67,7 @@ public final class ZonedDateTimeOf implements Scalar<ZonedDateTime> {
      */
     public ZonedDateTimeOf(final CharSequence date,
         final DateTimeFormatter formatter) {
-        this.parsed = new UncheckedScalar<>(
+        this.parsed = new Unchecked<>(
             () -> ZonedDateTime.from(formatter.parse(date))
         );
     }

--- a/src/test/java/org/cactoos/experimental/ThreadsTest.java
+++ b/src/test/java/org/cactoos/experimental/ThreadsTest.java
@@ -34,7 +34,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.cactoos.Proc;
 import org.cactoos.func.Repeated;
-import org.cactoos.func.TimedFunc;
+import org.cactoos.func.Timed;
 import org.cactoos.func.UncheckedFunc;
 import org.cactoos.list.ListOf;
 import org.cactoos.list.Mapped;
@@ -199,7 +199,7 @@ public final class ThreadsTest {
         MatcherAssert.assertThat(
             new UncheckedFunc<>(
                 new Repeated<>(
-                    new TimedFunc<Boolean, Boolean>(
+                    new Timed<Boolean, Boolean>(
                         input -> {
                             test.exec(null);
                             return true;

--- a/src/test/java/org/cactoos/func/TimedFuncTest.java
+++ b/src/test/java/org/cactoos/func/TimedFuncTest.java
@@ -33,7 +33,7 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
- * Test case for {@link TimedFunc}.
+ * Test case for {@link Timed}.
  * @since 0.29.3
  * @checkstyle JavadocMethodCheck (500 lines)
  */
@@ -42,7 +42,7 @@ public final class TimedFuncTest {
     @Test(expected = TimeoutException.class)
     public void functionGetsInterrupted() throws Exception {
         final long period = 100L;
-        new TimedFunc<Boolean, Boolean>(
+        new Timed<Boolean, Boolean>(
             input -> {
                 return new And(
                     new Endless<>(() -> input)
@@ -65,7 +65,7 @@ public final class TimedFuncTest {
                 }
             );
         try {
-            new TimedFunc<Boolean, Boolean>(
+            new Timed<Boolean, Boolean>(
                 period,
                 input -> future
             ).apply(true);
@@ -82,7 +82,7 @@ public final class TimedFuncTest {
     public void functionIsExecuted() throws Exception {
         final long period = 3000L;
         MatcherAssert.assertThat(
-            new TimedFunc<Boolean, Boolean>(
+            new Timed<Boolean, Boolean>(
                 input -> true,
                 period
             ).apply(true),

--- a/src/test/java/org/cactoos/iterator/SyncedTest.java
+++ b/src/test/java/org/cactoos/iterator/SyncedTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.llorllale.cactoos.matchers.RunsInThreads;
 
 /**
- * Test for {@link SyncIterator}.
+ * Test for {@link Synced}.
  *
  * @since 1.0
  * @checkstyle JavadocMethodCheck (500 lines)
@@ -39,7 +39,7 @@ import org.llorllale.cactoos.matchers.RunsInThreads;
  * @checkstyle TodoCommentCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class SyncIteratorTest {
+public final class SyncedTest {
 
     @Test
     public void syncIteratorReturnsCorrectValuesWithExternalLock() {
@@ -47,7 +47,7 @@ public final class SyncIteratorTest {
         MatcherAssert.assertThat(
             "Unexpected value found.",
             new ListOf<>(
-                new SyncIterator<>(
+                new Synced<>(
                     new ListOf<>("a", "b").iterator(), lock
                 )
             ).toArray(),
@@ -60,7 +60,7 @@ public final class SyncIteratorTest {
         MatcherAssert.assertThat(
             "Unexpected value found.",
             new ListOf<>(
-                new SyncIterator<>(
+                new Synced<>(
                     new ListOf<>("a", "b").iterator()
                 )
             ).toArray(),
@@ -85,7 +85,7 @@ public final class SyncIteratorTest {
                     return true;
                 },
                 new RunsInThreads<>(
-                    new SyncIterator<>(
+                    new Synced<>(
                         new ListOf<>("a", "b").iterator()
                     ),
                     2
@@ -125,7 +125,7 @@ public final class SyncIteratorTest {
                     return true;
                 },
                 new RunsInThreads<>(
-                    new SyncIterator<>(
+                    new Synced<>(
                         new ListOf<>("a", "b").iterator()
                     ),
                     2

--- a/src/test/java/org/cactoos/scalar/IoCheckedTest.java
+++ b/src/test/java/org/cactoos/scalar/IoCheckedTest.java
@@ -23,44 +23,51 @@
  */
 package org.cactoos.scalar;
 
-import org.cactoos.Scalar;
+import java.io.IOException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
 
 /**
- * Long Scalar which sums up the values of other Scalars of the same type
+ * Test case for {@link IoChecked}.
  *
- * <p>Here is how you can use it to summarize numbers:</p>
- *
- * <pre>{@code
- * long sum = new SumOfLongScalar(() -> 1,() -> 2, () -> 3).value();
- * }</pre>
- *
- * <p>This class implements {@link Scalar}, which throws a checked
- * {@link Exception}. Despite that this class does NOT throw a checked
- * exception.</p>
- *
- * <p>There is no thread-safety guarantee.
- *
- * @since 0.30
+ * @since 0.4
+ * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class SumOfLongScalar implements Scalar<Long> {
+public final class IoCheckedTest {
 
-    /**
-     * Varargs of Scalar to sum up values from.
-     */
-    private final Scalar<Long>[] scalars;
-
-    /**
-     * Ctor.
-     * @param src Varargs of Scalar to sum up values from
-     * @since 0.30
-     */
-    @SafeVarargs
-    public SumOfLongScalar(final Scalar<Long>... src) {
-        this.scalars = src;
+    @Test
+    public void rethrowsIoException() {
+        final IOException exception = new IOException("intended");
+        try {
+            new IoChecked<>(
+                () -> {
+                    throw exception;
+                }
+            ).value();
+        } catch (final IOException ex) {
+            MatcherAssert.assertThat(
+                ex, Matchers.is(exception)
+            );
+        }
     }
 
-    @Override
-    public Long value() {
-        return new SumOfScalar(this.scalars).value().longValue();
+    @Test(expected = IOException.class)
+    public void throwsException() throws Exception {
+        new IoChecked<>(
+            () -> {
+                throw new Exception("intended to fail");
+            }
+        ).value();
     }
+
+    @Test(expected = IllegalStateException.class)
+    public void runtimeExceptionGoesOut() throws IOException {
+        new IoChecked<>(
+            () -> {
+                throw new IllegalStateException("intended to fail here");
+            }
+        ).value();
+    }
+
 }

--- a/src/test/java/org/cactoos/scalar/RetryTest.java
+++ b/src/test/java/org/cactoos/scalar/RetryTest.java
@@ -23,45 +23,35 @@
  */
 package org.cactoos.scalar;
 
-import org.cactoos.Scalar;
+import java.security.SecureRandom;
+import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.ScalarHasValue;
 
 /**
- * Integer Scalar which sums up the values of other Scalars of the same type
+ * Test case for {@link Retry}.
  *
- * <p>Here is how you can use it to summarize numbers:</p>
- *
- * <pre>{@code
- * int sum = new SumOfIntScalar(() -> 1,() -> 2, () -> 3).value();
- * // sum equal to 6
- * }</pre>
- *
- * <p>This class implements {@link Scalar}, which throws a checked
- * {@link Exception}. Despite that this class does NOT throw a checked
- * exception.</p>
- *
- * <p>There is no thread-safety guarantee.
- *
- * @since 0.30
+ * @since 0.9
+ * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class SumOfIntScalar implements Scalar<Integer> {
+public final class RetryTest {
 
-    /**
-     * Varargs of Scalar to sum up values from.
-     */
-    private final Scalar<Integer>[] scalars;
-
-    /**
-     * Ctor.
-     * @param src Varargs of Scalar to sum up values from
-     * @since 0.30
-     */
-    @SafeVarargs
-    public SumOfIntScalar(final Scalar<Integer>... src) {
-        this.scalars = src;
+    @Test
+    public void runsScalarMultipleTimes() throws Exception {
+        new Assertion<>(
+            "must retry in case of failure",
+            () -> new Retry<>(
+                () -> {
+                    // @checkstyle MagicNumberCheck (1 line)
+                    if (new SecureRandom().nextDouble() > 0.3d) {
+                        throw new IllegalArgumentException("May happen");
+                    }
+                    return 0;
+                },
+                Integer.MAX_VALUE
+            ),
+            new ScalarHasValue<>(0)
+        ).affirm();
     }
 
-    @Override
-    public Integer value() {
-        return new SumOfScalar(this.scalars).value().intValue();
-    }
 }

--- a/src/test/java/org/cactoos/scalar/StickyTest.java
+++ b/src/test/java/org/cactoos/scalar/StickyTest.java
@@ -25,27 +25,28 @@ package org.cactoos.scalar;
 
 import java.security.SecureRandom;
 import org.cactoos.Scalar;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 
 /**
- * Test case for {@link StickyScalar}.
+ * Test case for {@link Sticky}.
  *
  * @since 0.4
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class StickyScalarTest {
+public final class StickyTest {
 
     @Test
     public void cachesScalarResults() throws Exception {
-        final Scalar<Integer> scalar = new StickyScalar<>(
+        final Scalar<Integer> scalar = new Sticky<>(
             () -> new SecureRandom().nextInt()
         );
-        MatcherAssert.assertThat(
-            scalar.value() + scalar.value(),
-            Matchers.equalTo(scalar.value() + scalar.value())
-        );
+        new Assertion<>(
+            "must compute value only once",
+            () -> scalar.value() + scalar.value(),
+            new IsEqual<>(scalar.value() + scalar.value())
+        ).affirm();
     }
 
 }

--- a/src/test/java/org/cactoos/scalar/SumOfDoubleTest.java
+++ b/src/test/java/org/cactoos/scalar/SumOfDoubleTest.java
@@ -23,34 +23,43 @@
  */
 package org.cactoos.scalar;
 
-import java.security.SecureRandom;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.ScalarHasValue;
 
 /**
- * Test case for {@link RetryScalar}.
+ * Test case for {@link SumOfDouble}.
  *
- * @since 0.9
+ * @since 0.30
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle MagicNumberCheck (500 lines)
  */
-public final class RetryScalarTest {
+public final class SumOfDoubleTest {
 
     @Test
-    public void runsScalarMultipleTimes() throws Exception {
-        MatcherAssert.assertThat(
-            new RetryScalar<>(
-                () -> {
-                    // @checkstyle MagicNumberCheck (1 line)
-                    if (new SecureRandom().nextDouble() > 0.3d) {
-                        throw new IllegalArgumentException("May happen");
-                    }
-                    return 0;
-                },
-                Integer.MAX_VALUE
-            ).value(),
-            Matchers.equalTo(0)
-        );
+    public void withListOfScalarsInt() {
+        new Assertion<>(
+            "must sum scalars",
+            () -> new SumOfDouble(() -> 1.1, () -> 2.1, () -> 3.1),
+            new ScalarHasValue<>(6.3)
+        ).affirm();
     }
 
+    @Test
+    public void withEmptyList() {
+        new Assertion<>(
+            "must sum empty list to 0",
+            () -> new SumOfDouble(),
+            new ScalarHasValue<>(0.0)
+        ).affirm();
+    }
+
+    @Test
+    public void withListOfOneElement() {
+        new Assertion<>(
+            "must sum singleton list",
+            () ->  new SumOfDouble(() -> 5.1),
+            new ScalarHasValue<>(5.1)
+        ).affirm();
+    }
 }

--- a/src/test/java/org/cactoos/scalar/SumOfFloatTest.java
+++ b/src/test/java/org/cactoos/scalar/SumOfFloatTest.java
@@ -23,50 +23,43 @@
  */
 package org.cactoos.scalar;
 
-import java.security.SecureRandom;
-import org.cactoos.Scalar;
-import org.cactoos.list.ListOf;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.Test;
-import org.llorllale.cactoos.matchers.RunsInThreads;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.ScalarHasValue;
 
 /**
- * Test case for {@link SolidScalar}.
+ * Test case for {@link SumOfFloat}.
  *
- * @since 0.24
+ * @since 0.30
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle MagicNumberCheck (500 lines)
  */
-public final class SolidScalarTest {
+public final class SumOfFloatTest {
 
     @Test
-    public void cachesScalarResults() throws Exception {
-        final Scalar<Integer> scalar = new SolidScalar<>(
-            () -> new SecureRandom().nextInt()
-        );
-        MatcherAssert.assertThat(
-            scalar.value() + scalar.value(),
-            Matchers.equalTo(scalar.value() + scalar.value())
-        );
+    public void withListOfScalarsInt() {
+        new Assertion<>(
+            "must sum scalars",
+            () -> new SumOfFloat(() -> 1f, () -> 2f, () -> 3f),
+            new ScalarHasValue<>(6f)
+        ).affirm();
     }
 
     @Test
-    public void worksInThreads() {
-        MatcherAssert.assertThat(
-            "Can't work well in multiple threads",
-            scalar -> {
-                MatcherAssert.assertThat(
-                    scalar.value(),
-                    Matchers.equalTo(scalar.value())
-                );
-                return true;
-            },
-            new RunsInThreads<>(
-                new UncheckedScalar<>(
-                    new SolidScalar<>(() -> new ListOf<>(1, 2))
-                )
-            )
-        );
+    public void withEmptyList() {
+        new Assertion<>(
+            "must sum empty list to 0",
+            () -> new SumOfFloat(),
+            new ScalarHasValue<>(0f)
+        ).affirm();
     }
 
+    @Test
+    public void withListOfOneElement() {
+        new Assertion<>(
+            "must sum singleton list",
+            () -> new SumOfFloat(() -> 5f),
+            new ScalarHasValue<>(5f)
+        ).affirm();
+    }
 }

--- a/src/test/java/org/cactoos/scalar/SumOfIntTest.java
+++ b/src/test/java/org/cactoos/scalar/SumOfIntTest.java
@@ -23,34 +23,43 @@
  */
 package org.cactoos.scalar;
 
-import java.util.LinkedList;
-import java.util.List;
-import org.cactoos.Scalar;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.Test;
-import org.llorllale.cactoos.matchers.RunsInThreads;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.ScalarHasValue;
 
 /**
- * Test case for {@link SyncScalar}.
+ * Test case for {@link SumOfInt}.
  *
- * @since 0.24
+ * @since 0.30
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle MagicNumberCheck (500 lines)
  */
-public final class SyncScalarTest {
+public final class SumOfIntTest {
 
     @Test
-    public void worksInThreads() {
-        final List<Integer> list = new LinkedList<>();
-        final int threads = 100;
-        MatcherAssert.assertThat(
-            "Can't work well in multiple threads",
-            Scalar::value,
-            new RunsInThreads<>(
-                new SyncScalar<>(() -> list.add(1)), threads
-            )
-        );
-        MatcherAssert.assertThat(list.size(), Matchers.equalTo(threads));
+    public void withListOfScalarsInt() {
+        new Assertion<>(
+            "must sum scalars",
+            () -> new SumOfInt(() -> 1, () -> 2, () -> 3),
+            new ScalarHasValue<>(6)
+        ).affirm();
     }
 
+    @Test
+    public void withEmptyList() {
+        new Assertion<>(
+            "must sum empty list to 0",
+            () -> new SumOfInt(),
+            new ScalarHasValue<>(0)
+        ).affirm();
+    }
+
+    @Test
+    public void withListOfOneElement() {
+        new Assertion<>(
+            "must sum singleton list",
+            () -> new SumOfInt(() -> 5),
+            new ScalarHasValue<>(5)
+        ).affirm();
+    }
 }

--- a/src/test/java/org/cactoos/scalar/SumOfLongTest.java
+++ b/src/test/java/org/cactoos/scalar/SumOfLongTest.java
@@ -23,53 +23,43 @@
  */
 package org.cactoos.scalar;
 
-import org.cactoos.Scalar;
+import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.ScalarHasValue;
 
 /**
- * Cached and synchronized version of a Scalar.
+ * Test case for {@link SumOfLong}.
  *
- * <p>Objects of this class are thread safe.
- *
- * @param <T> Type of result
- * @see StickyScalar
- * @see SyncScalar
- * @since 0.24
+ * @since 0.30
+ * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle MagicNumberCheck (500 lines)
  */
-public final class SolidScalar<T> implements Scalar<T> {
+public final class SumOfLongTest {
 
-    /**
-     * Origin.
-     */
-    private final Scalar<T> origin;
-
-    /**
-     * Cache.
-     */
-    private volatile T cache;
-
-    /**
-     * Sync lock.
-     */
-    private final Object lock;
-
-    /**
-     * Ctor.
-     * @param origin The Scalar to cache and sync
-     */
-    public SolidScalar(final Scalar<T> origin) {
-        this.origin = origin;
-        this.lock = new Object();
+    @Test
+    public void withListOfScalarsInt() {
+        new Assertion<>(
+            "must sum scalars",
+            () -> new SumOfLong(() -> 1L, () -> 2L, () -> 3L),
+            new ScalarHasValue<>(6L)
+        ).affirm();
     }
 
-    @Override
-    public T value() throws Exception {
-        if (this.cache == null) {
-            synchronized (this.lock) {
-                if (this.cache == null) {
-                    this.cache = this.origin.value();
-                }
-            }
-        }
-        return this.cache;
+    @Test
+    public void withEmptyList() {
+        new Assertion<>(
+            "must sum empty list to 0",
+            () -> new SumOfLong(),
+            new ScalarHasValue<>(0L)
+        ).affirm();
+    }
+
+    @Test
+    public void withListOfOneElement() {
+        new Assertion<>(
+            "must sum singleton list",
+            () -> new SumOfLong(() -> 5L),
+            new ScalarHasValue<>(5L)
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/scalar/SyncedTest.java
+++ b/src/test/java/org/cactoos/scalar/SyncedTest.java
@@ -23,51 +23,38 @@
  */
 package org.cactoos.scalar;
 
-import java.io.IOException;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import java.util.LinkedList;
+import java.util.List;
+import org.cactoos.Scalar;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.RunsInThreads;
 
 /**
- * Test case for {@link IoCheckedScalar}.
+ * Test case for {@link Synced}.
  *
- * @since 0.4
+ * @since 0.24
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class IoCheckedScalarTest {
+public final class SyncedTest {
 
     @Test
-    public void rethrowsIoException() {
-        final IOException exception = new IOException("intended");
-        try {
-            new IoCheckedScalar<>(
-                () -> {
-                    throw exception;
-                }
-            ).value();
-        } catch (final IOException ex) {
-            MatcherAssert.assertThat(
-                ex, Matchers.is(exception)
-            );
-        }
-    }
-
-    @Test(expected = IOException.class)
-    public void throwsException() throws Exception {
-        new IoCheckedScalar<>(
-            () -> {
-                throw new Exception("intended to fail");
-            }
-        ).value();
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void runtimeExceptionGoesOut() throws IOException {
-        new IoCheckedScalar<>(
-            () -> {
-                throw new IllegalStateException("intended to fail here");
-            }
-        ).value();
+    public void worksInThreads() {
+        final List<Integer> list = new LinkedList<>();
+        final int threads = 100;
+        new Assertion<>(
+            "must work well in multiple threads",
+            () -> Scalar::value,
+            new RunsInThreads<>(
+                new Synced<>(() -> list.add(1)), threads
+            )
+        ).affirm();
+        new Assertion<>(
+            "must have correct size",
+            list::size,
+            new IsEqual<>(threads)
+        ).affirm();
     }
 
 }

--- a/src/test/java/org/cactoos/scalar/UncheckedScalarTest.java
+++ b/src/test/java/org/cactoos/scalar/UncheckedScalarTest.java
@@ -28,13 +28,14 @@ import java.io.UncheckedIOException;
 import org.junit.Test;
 
 /**
- * Test case for {@link UncheckedScalar}.
+ * Test case for {@link Unchecked}.
  *
  * @since 0.3
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 public final class UncheckedScalarTest {
 
+    @SuppressWarnings("deprecation")
     @Test(expected = UncheckedIOException.class)
     public void rethrowsCheckedToUncheckedException() {
         new UncheckedScalar<>(

--- a/src/test/java/org/cactoos/scalar/UncheckedTest.java
+++ b/src/test/java/org/cactoos/scalar/UncheckedTest.java
@@ -23,41 +23,25 @@
  */
 package org.cactoos.scalar;
 
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsEqual;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import org.junit.Test;
 
 /**
- * Test case for {@link SumOfFloatScalar}.
+ * Test case for {@link Unchecked}.
  *
- * @since 0.30
+ * @since 0.3
  * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle MagicNumberCheck (500 lines)
  */
-public final class SumOfFloatScalarTest {
+public final class UncheckedTest {
 
-    @Test
-    public void withListOfScalarsInt() {
-        MatcherAssert.assertThat(
-            new SumOfFloatScalar(() -> 1f, () -> 2f, () -> 3f)
-                .value(),
-            new IsEqual<>(6f)
-        );
+    @Test(expected = UncheckedIOException.class)
+    public void rethrowsCheckedToUncheckedException() {
+        new Unchecked<>(
+            () -> {
+                throw new IOException("intended");
+            }
+        ).value();
     }
 
-    @Test
-    public void withEmptyList() {
-        MatcherAssert.assertThat(
-            new SumOfFloatScalar().value(),
-            new IsEqual<>(0f)
-        );
-    }
-
-    @Test
-    public void withListOfOneElement() {
-        MatcherAssert.assertThat(
-            new SumOfFloatScalar(() -> 5f).value(),
-            new IsEqual<>(5f)
-        );
-    }
 }


### PR DESCRIPTION
For #1003.

Since there was nothing to be renamed in set, I did the scalar package as well as some other that were lying around. So removed their `@todo` when relevant ;)

Also I left `UncheckedScalar` as a deprecated implementation based on `Unchecked` because cactoos-matchers relies on it. I added a `@todo` to resolve this situation later.

@llorllale I wonder if the list in https://github.com/yegor256/cactoos/issues/913#issuecomment-402332247 shouldn't be updated because it looks like new classes were introduced that could benefit from this new naming.