### PR TITLE
(#930) Homogeneous constructor parameters for iter

### DIFF
--- a/src/main/java/org/cactoos/iterable/Skipped.java
+++ b/src/main/java/org/cactoos/iterable/Skipped.java
@@ -50,8 +50,8 @@ public final class Skipped<T> extends IterableEnvelope<T> {
      */
     public Skipped(final int skip, final Iterable<T> iterable) {
         super(() -> () -> new org.cactoos.iterator.Skipped<>(
-            iterable.iterator(),
-            skip
+            skip,
+            iterable.iterator()
         ));
     }
 }

--- a/src/main/java/org/cactoos/iterable/Synced.java
+++ b/src/main/java/org/cactoos/iterable/Synced.java
@@ -65,7 +65,7 @@ public final class Synced<X> implements Iterable<X> {
      * @param iterable The iterable synchronize access to.
      */
     public Synced(final Iterable<X> iterable) {
-        this(iterable, new Object());
+        this(new Object(), iterable);
     }
 
     /**
@@ -73,7 +73,7 @@ public final class Synced<X> implements Iterable<X> {
      * @param iterable The iterable synchronize access to.
      * @param lck The lock to synchronize with.
      */
-    public Synced(final Iterable<X> iterable, final Object lck) {
+    public Synced(final Object lck, final Iterable<X> iterable) {
         this.origin = iterable;
         this.lock = lck;
     }

--- a/src/main/java/org/cactoos/iterator/Skipped.java
+++ b/src/main/java/org/cactoos/iterator/Skipped.java
@@ -51,7 +51,7 @@ public final class Skipped<T> implements Iterator<T> {
      * @param iterator Decorated iterator
      * @param skp Count skip elements
      */
-    public Skipped(final Iterator<T> iterator, final int skp) {
+    public Skipped(final int skp, final Iterator<T> iterator) {
         this.origin = iterator;
         this.skip = skp;
     }

--- a/src/main/java/org/cactoos/iterator/Synced.java
+++ b/src/main/java/org/cactoos/iterator/Synced.java
@@ -57,7 +57,7 @@ public final class Synced<T> implements Iterator<T> {
      * @param iterator The iterator to synchronize access to.
      */
     public Synced(final Iterator<T> iterator) {
-        this(iterator, new ReentrantReadWriteLock());
+        this(new ReentrantReadWriteLock(), iterator);
     }
 
     /**
@@ -65,7 +65,7 @@ public final class Synced<T> implements Iterator<T> {
      * @param iterator The iterator to synchronize access to.
      * @param lock The lock to use for synchronization.
      */
-    public Synced(final Iterator<T> iterator, final ReadWriteLock lock) {
+    public Synced(final ReadWriteLock lock, final Iterator<T> iterator) {
         this.iterator = iterator;
         this.lock = lock;
     }

--- a/src/main/java/org/cactoos/scalar/ItemAt.java
+++ b/src/main/java/org/cactoos/scalar/ItemAt.java
@@ -37,6 +37,9 @@ import org.cactoos.text.FormattedText;
  *
  * @param <T> Scalar type
  * @since 0.7
+ * @todo #930:30min To be consistent with other objects working on iterables
+ *  such as HeadOf, TailOf, etc, the constructor of ItemAt should always take
+ *  the iterable/iterator as a last parameter.
  */
 public final class ItemAt<T> implements Scalar<T> {
 

--- a/src/test/java/org/cactoos/iterator/SkippedTest.java
+++ b/src/test/java/org/cactoos/iterator/SkippedTest.java
@@ -25,9 +25,9 @@ package org.cactoos.iterator;
 
 import java.util.NoSuchElementException;
 import org.cactoos.iterable.IterableOf;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 
 /**
  * Test Case for {@link Skipped}.
@@ -40,28 +40,30 @@ public final class SkippedTest {
     @Test
     @SuppressWarnings("PMD.AvoidDuplicateLiterals")
     public void skipIterator() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't skip elements in iterator",
-            () -> new Skipped<>(
-                new IterableOf<>(
-                    "one", "two", "three", "four"
-                ).iterator(),
-                2
+            () -> new IterableOf<>(
+                new Skipped<>(
+                    2,
+                    new IteratorOf<>(
+                        "one", "two", "three", "four"
+                    )
+                )
             ),
             Matchers.contains(
                 "three",
                 "four"
             )
-        );
+        ).affirm();
     }
 
     @Test(expected = NoSuchElementException.class)
     public void errorSkippedMoreThanExists() {
         new Skipped<>(
-            new IterableOf<>(
+            2,
+            new IteratorOf<>(
                 "one", "two"
-            ).iterator(),
-            2
+            )
         ).next();
     }
 }

--- a/src/test/java/org/cactoos/iterator/SyncedTest.java
+++ b/src/test/java/org/cactoos/iterator/SyncedTest.java
@@ -25,9 +25,10 @@ package org.cactoos.iterator;
 
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.cactoos.list.ListOf;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.RunsInThreads;
 
 /**
@@ -44,53 +45,54 @@ public final class SyncedTest {
     @Test
     public void syncIteratorReturnsCorrectValuesWithExternalLock() {
         final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Unexpected value found.",
             new ListOf<>(
                 new Synced<>(
-                    new ListOf<>("a", "b").iterator(), lock
+                    lock, new IteratorOf<>("a", "b")
                 )
-            ).toArray(),
-            Matchers.equalTo(new Object[]{"a", "b"})
-        );
+            )::toArray,
+            new IsEqual<>(new Object[]{"a", "b"})
+        ).affirm();
     }
 
     @Test
     public void syncIteratorReturnsCorrectValuesWithInternalLock() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Unexpected value found.",
             new ListOf<>(
                 new Synced<>(
-                    new ListOf<>("a", "b").iterator()
+                    new IteratorOf<>("a", "b")
                 )
-            ).toArray(),
-            Matchers.equalTo(new Object[]{"a", "b"})
-        );
+            )::toArray,
+            new IsEqual<>(new Object[]{"a", "b"})
+        ).affirm();
     }
 
     @Test
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     public void correctValuesForConcurrentNextNext() {
         for (int iter = 0; iter < 5000; iter += 1) {
-            MatcherAssert.assertThat(
+            new Assertion<>(
                 "",
-                map -> {
-                    MatcherAssert.assertThat(
-                        map.next(),
+                () -> map -> {
+                    new Assertion<>(
+                        "",
+                        map::next,
                         Matchers.anyOf(
-                            Matchers.equalTo("a"),
-                            Matchers.equalTo("b")
+                            new IsEqual<>("a"),
+                            new IsEqual<>("b")
                         )
-                    );
+                    ).affirm();
                     return true;
                 },
                 new RunsInThreads<>(
                     new Synced<>(
-                        new ListOf<>("a", "b").iterator()
+                        new IteratorOf<>("a", "b")
                     ),
                     2
                 )
-            );
+            ).affirm();
         }
     }
 
@@ -98,40 +100,42 @@ public final class SyncedTest {
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     public void correctValuesForConcurrentNextHasNext() {
         for (int iter = 0; iter < 5000; iter += 1) {
-            MatcherAssert.assertThat(
+            new Assertion<>(
                 "",
-                map -> {
-                    MatcherAssert.assertThat(
-                        map.hasNext(),
+                () -> map -> {
+                    new Assertion<>(
+                        "",
+                        map::hasNext,
                         Matchers.anyOf(
-                            Matchers.equalTo(true),
-                            Matchers.equalTo(true)
+                            new IsEqual<>(true),
+                            new IsEqual<>(true)
                         )
-                    );
-                    MatcherAssert.assertThat(
-                        map.next(),
+                    ).affirm();
+                    new Assertion<>(
+                        "",
+                        map::next,
                         Matchers.anyOf(
-                            Matchers.equalTo("a"),
-                            Matchers.equalTo("b")
+                            new IsEqual<>("a"),
+                            new IsEqual<>("b")
                         )
-                    );
-                    MatcherAssert.assertThat(
-                        map.hasNext(),
+                    ).affirm();
+                    new Assertion<>(
+                        "",
+                        map::hasNext,
                         Matchers.anyOf(
-                            Matchers.equalTo(true),
-                            Matchers.equalTo(false)
+                            new IsEqual<>(true),
+                            new IsEqual<>(false)
                         )
-                    );
+                    ).affirm();
                     return true;
                 },
                 new RunsInThreads<>(
                     new Synced<>(
-                        new ListOf<>("a", "b").iterator()
+                        new IteratorOf<>("a", "b")
                     ),
                     2
                 )
-            );
+            ).affirm();
         }
     }
-
 }


### PR DESCRIPTION
This is for #930.

While I was at it, I took care of the parameter order of Synced too and I updated the tests modified to use `Assertion`.