### PR TITLE
(#949) DateOf now parses also date without time

### DIFF
--- a/src/main/java/org/cactoos/time/DateOf.java
+++ b/src/main/java/org/cactoos/time/DateOf.java
@@ -26,6 +26,8 @@ package org.cactoos.time;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
 import java.util.Date;
 import org.cactoos.Scalar;
 import org.cactoos.scalar.Unchecked;
@@ -66,8 +68,12 @@ public final class DateOf implements Scalar<Date> {
     public DateOf(final CharSequence date, final DateTimeFormatter formatter) {
         this.parsed = new Unchecked<>(
             () -> Date.from(
-                LocalDateTime.from(
-                    formatter.parse(date)
+                LocalDateTime.parse(
+                    date,
+                    new DateTimeFormatterBuilder()
+                        .append(formatter)
+                        .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+                        .toFormatter()
                 ).toInstant(ZoneOffset.UTC)
             )
         );

--- a/src/test/java/org/cactoos/time/DateOfTest.java
+++ b/src/test/java/org/cactoos/time/DateOfTest.java
@@ -43,7 +43,7 @@ public class DateOfTest {
     @Test
     public final void testParsingIsoFormattedStringToDate() {
         new Assertion<>(
-            "Can't parse a Date with default/ISO format.",
+            "must parse a Date with default/ISO format.",
             () -> new DateOf("2017-12-13T14:15:16.000000017Z"),
             new ScalarHasValue<>(
                 Date.from(
@@ -58,7 +58,7 @@ public class DateOfTest {
     @Test
     public final void testParsingCustomFormattedStringToDate() {
         new Assertion<>(
-            "Can't parse a Date with custom format.",
+            "must parse a Date with custom format.",
             () -> new DateOf(
                 "2017-12-13 14:15:16.000000017",
                 "yyyy-MM-dd HH:mm:ss.n"
@@ -74,9 +74,27 @@ public class DateOfTest {
     }
 
     @Test
+    public final void testParsingCustomFormattedStringWithoutTimeToDate() {
+        new Assertion<>(
+            "must parse a Date with custom format.",
+            () -> new DateOf(
+                "2018-01-01",
+                "yyyy-MM-dd"
+            ),
+            new ScalarHasValue<>(
+                Date.from(
+                    LocalDateTime.of(
+                        2018, 01, 01, 0, 0, 0, 0
+                    ).toInstant(ZoneOffset.UTC)
+                )
+            )
+        ).affirm();
+    }
+
+    @Test
     public final void testParsingCustomFormatterStringToDate() {
         new Assertion<>(
-            "Can't parse a Date with custom format.",
+            "must parse a Date with custom format.",
             () -> new DateOf(
                 "2017-12-13 14:15:16.000000017",
                 DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.n")


### PR DESCRIPTION
This is for #949.

Added a test for the issue and implemented a solution based on https://stackoverflow.com/a/39685202/9046139