### PR TITLE
(#996) Make ListEnvelope public and consolidate API

### DIFF
--- a/src/main/java/org/cactoos/collection/CollectionEnvelope.java
+++ b/src/main/java/org/cactoos/collection/CollectionEnvelope.java
@@ -39,6 +39,9 @@ import org.cactoos.scalar.Unchecked;
  * <p>There is no thread-safety guarantee.</p>
  * @param <X> Element type
  * @since 0.23
+ * @todo #996:30min Make the toString() method final and simplify the
+ *  implementation of Mapped that redefine sit so that it can rely on
+ *  the implementation of toString already present here.
  * @checkstyle AbstractClassNameCheck (500 lines)
  */
 @SuppressWarnings(

--- a/src/main/java/org/cactoos/list/ListEnvelope.java
+++ b/src/main/java/org/cactoos/list/ListEnvelope.java
@@ -31,7 +31,7 @@ import org.cactoos.collection.CollectionEnvelope;
 import org.cactoos.scalar.Unchecked;
 
 /**
- * List envelope.
+ * {@link List} envelope that doesn't allow mutations.
  *
  * <p>There is no thread-safety guarantee.</p>
  *
@@ -45,7 +45,7 @@ import org.cactoos.scalar.Unchecked;
         "PMD.AbstractNaming"
     }
 )
-abstract class ListEnvelope<T> extends CollectionEnvelope<T> implements
+public abstract class ListEnvelope<T> extends CollectionEnvelope<T> implements
     List<T> {
 
     /**
@@ -57,7 +57,7 @@ abstract class ListEnvelope<T> extends CollectionEnvelope<T> implements
      * Ctor.
      * @param src Source
      */
-    ListEnvelope(final Scalar<List<T>> src) {
+    public ListEnvelope(final Scalar<List<T>> src) {
         super(src::value);
         this.list = new Unchecked<>(src);
     }
@@ -114,11 +114,8 @@ abstract class ListEnvelope<T> extends CollectionEnvelope<T> implements
 
     @Override
     public final List<T> subList(final int start, final int end) {
-        return this.list.value().subList(start, end);
-    }
-
-    @Override
-    public String toString() {
-        return this.list.value().toString();
+        return new ListEnvelope<T>(
+            () -> this.list.value().subList(start, end)
+        ) { };
     }
 }

--- a/src/main/java/org/cactoos/list/ListIteratorOf.java
+++ b/src/main/java/org/cactoos/list/ListIteratorOf.java
@@ -30,7 +30,7 @@ import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.Unchecked;
 
 /**
- * Iterator of the list.
+ * Iterator of the list that doesn't allow mutations.
  *
  * <p>There is no thread-safety guarantee.
  *

--- a/src/main/java/org/cactoos/list/Mapped.java
+++ b/src/main/java/org/cactoos/list/Mapped.java
@@ -24,7 +24,6 @@
 package org.cactoos.list;
 
 import org.cactoos.Func;
-import org.cactoos.text.TextOf;
 
 /**
  * Mapped list.
@@ -46,10 +45,5 @@ public final class Mapped<X, Y> extends ListEnvelope<Y> {
         super(() -> new ListOf<Y>(
             new org.cactoos.iterable.Mapped<>(fnc, src)
         ));
-    }
-
-    @Override
-    public String toString() {
-        return new TextOf(this).toString();
     }
 }

--- a/src/test/java/org/cactoos/list/ListEnvelopeTest.java
+++ b/src/test/java/org/cactoos/list/ListEnvelopeTest.java
@@ -23,33 +23,27 @@
  */
 package org.cactoos.list;
 
+import java.util.Arrays;
 import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.ListIterator;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 
 /**
  * Test case for {@link ListEnvelope}.
  *
  * @since 0.32
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle JavadocTypeCheck (500 lines)
  * @checkstyle MagicNumberCheck (500 lines)
  */
+@SuppressWarnings({ "PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals" })
 public final class ListEnvelopeTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void returnsListIteratorWithUnsupportedRemove() {
-        final ListEnvelope<String> list = new ListEnvelope<String>(
-            () -> {
-                final List<String> inner = new LinkedList<>();
-                inner.add("one");
-                return inner;
-            }
-        ) {
-        };
+        final ListEnvelope<String> list = new StringList("one");
         final Iterator<String> iterator = list.listIterator();
         iterator.next();
         iterator.remove();
@@ -57,76 +51,130 @@ public final class ListEnvelopeTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void returnsListIteratorWithUnsupportedSet() {
-        final ListEnvelope<String> list = new ListEnvelope<String>(
-            () -> {
-                final List<String> inner = new LinkedList<>();
-                inner.add("three");
-                return inner;
-            }
-        ) {
-        };
+        final ListEnvelope<String> list = new StringList("one");
         final ListIterator<String> iterator = list.listIterator(1);
         iterator.set("zero");
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void returnsListIteratorWithUnsupportedAdd() {
-        final ListEnvelope<String> list = new ListEnvelope<String>(
-            () -> {
-                final List<String> inner = new LinkedList<>();
-                inner.add("ten");
-                return inner;
-            }
-        ) {
-        };
+        final ListEnvelope<String> list = new StringList("one");
         final ListIterator<String> iterator = list.listIterator();
         iterator.next();
-        iterator.add("twenty");
+        iterator.add("two");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void subListReturnsListIteratorWithUnsupportedRemove() {
+        final ListEnvelope<String> list = new StringList("one");
+        final Iterator<String> iterator = list.subList(0, 1)
+            .listIterator();
+        iterator.next();
+        iterator.remove();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void subListReturnsListIteratorWithUnsupportedSet() {
+        final ListEnvelope<String> list = new StringList("one");
+        final ListIterator<String> iterator = list.subList(0, 1)
+            .listIterator(1);
+        iterator.set("zero");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void subListReturnsListIteratorWithUnsupportedAdd() {
+        final ListEnvelope<String> list = new StringList("one");
+        final ListIterator<String> iterator = list.subList(0, 1)
+            .listIterator();
+        iterator.next();
+        iterator.add("two");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void removeIsNotSupported() {
+        final ListEnvelope<String> list = new StringList("one");
+        list.remove(0);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void setIsNotSupported() {
+        final ListEnvelope<String> list = new StringList("one");
+        list.set(0, "zero");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void addIsNotSupported() {
+        final ListEnvelope<String> list = new StringList("one");
+        list.add("two");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void returnsSubListWithUnsupportedRemove() {
+        final ListEnvelope<String> list = new StringList("one");
+        list.subList(0, 1).remove(0);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void returnsSubListWithUnsupportedSet() {
+        final ListEnvelope<String> list = new StringList("one");
+        list.subList(0, 1).set(0, "zero");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void returnsSubListWithUnsupportedAdd() {
+        final ListEnvelope<String> list = new StringList("one");
+        list.subList(0, 1).add("two");
     }
 
     @Test
     public void getsPreviousIndex() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "List iterator returns incorrect previous index",
             new ListIteratorOf<>(
                 new ListOf<>(1)
-            ).previousIndex(),
+            )::previousIndex,
             new IsEqual<>(-1)
-        );
+        ).affirm();
     }
 
     @Test
     public void getsPrevious() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "List iterator returns incorrect previous item",
             new ListIteratorOf<>(
                 new ListOf<>(3, 7),
                 1
-            ).previous(),
+            )::previous,
             new IsEqual<>(3)
-        );
+        ).affirm();
     }
 
     @Test
     public void getsNextIndex() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "List iterator returns incorrect next index",
             new ListIteratorOf<>(
                 new ListOf<>(1)
-            ).nextIndex(),
+            )::nextIndex,
             new IsEqual<>(0)
-        );
+        ).affirm();
     }
 
     @Test
     public void getsNext() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "List iterator returns incorrect next item",
             new ListIteratorOf<>(
                 new ListOf<>(5, 11, 13),
                 1
-            ).next(),
+            )::next,
             new IsEqual<>(11)
-        );
+        ).affirm();
+    }
+
+    private static final class StringList extends ListEnvelope<String> {
+        StringList(final String... elements) {
+            super(() -> Arrays.asList(elements));
+        }
     }
 }

--- a/src/test/java/org/cactoos/list/MappedTest.java
+++ b/src/test/java/org/cactoos/list/MappedTest.java
@@ -84,7 +84,7 @@ public final class MappedTest {
                 x -> x * 2,
                 new ListOf<>(1, 2, 3)
             ).toString(),
-            Matchers.equalTo("2, 4, 6")
+            Matchers.equalTo("[2, 4, 6]")
         );
     }
 }


### PR DESCRIPTION
This is for #996:
- made `ListEnvelope` public and clarified doc on its behaviour
- Ensured `subList` was returning a `List` with the same behaviour (note that it means sublist is now called lazily)
- Added some tests for this
- Prevented overriding of `toString` and simplified `Mapped` as a result