### PR TITLE
(#1040) Remove null from CallableOf constructor

### DIFF
--- a/src/main/java/org/cactoos/func/CallableOf.java
+++ b/src/main/java/org/cactoos/func/CallableOf.java
@@ -43,21 +43,13 @@ import org.cactoos.Proc;
  * @param <X> Type of input
  * @param <T> Type of output
  * @since 0.12
- * @todo #888:30min Avoid usage of null value in ctor(Func) which is
- *  against our design principles.
- *  Most likely, dropping this ctor will be enough.
  */
 public final class CallableOf<X, T> implements Callable<T> {
 
     /**
-     * Original func.
+     * Original callable.
      */
-    private final Func<X, T> func;
-
-    /**
-     * The input.
-     */
-    private final X input;
+    private final Callable<T> callable;
 
     /**
      * Ctor.
@@ -66,39 +58,44 @@ public final class CallableOf<X, T> implements Callable<T> {
      * @since 0.32
      */
     public CallableOf(final Runnable runnable, final T result) {
-        this(new FuncOf<>(runnable, result));
+        this(() -> {
+            runnable.run();
+            return result;
+        });
     }
 
     /**
      * Ctor.
      * @param proc Encapsulated proc
+     * @param ipt Input
      * @param result Result to return
-     * @since 0.32
+     * @since 0.41
      */
-    public CallableOf(final Proc<X> proc, final T result) {
-        this(new FuncOf<>(proc, result));
-    }
-
-    /**
-     * Ctor.
-     * @param fnc Encapsulated func
-     */
-    public CallableOf(final Func<X, T> fnc) {
-        this(fnc, null);
+    public CallableOf(final Proc<X> proc, final X ipt, final T result) {
+        this(new FuncOf<>(proc, result), ipt);
     }
 
     /**
      * Ctor.
      * @param fnc Encapsulated func
      * @param ipt Input
+     * @since 0.41
      */
     public CallableOf(final Func<X, T> fnc, final X ipt) {
-        this.func = fnc;
-        this.input = ipt;
+        this(() -> fnc.apply(ipt));
+    }
+
+    /**
+     * Ctor.
+     * @param cal Encapsulated callable
+     * @since 0.41
+     */
+    public CallableOf(final Callable<T> cal) {
+        this.callable = cal;
     }
 
     @Override
     public T call() throws Exception {
-        return this.func.apply(this.input);
+        return this.callable.call();
     }
 }

--- a/src/test/java/org/cactoos/func/CallableOfTest.java
+++ b/src/test/java/org/cactoos/func/CallableOfTest.java
@@ -24,9 +24,9 @@
 package org.cactoos.func;
 
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 
 /**
  * Test case for {@link CallableOf}.
@@ -34,17 +34,8 @@ import org.junit.Test;
  * @since 0.2
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class CallableOfTest {
-
-    @Test
-    public void convertsFuncIntoCallable() throws Exception {
-        MatcherAssert.assertThat(
-            new CallableOf<>(
-                input -> 1
-            ).call(),
-            Matchers.equalTo(1)
-        );
-    }
 
     @Test
     public void convertsRunnableIntoCallable() throws Exception {
@@ -53,49 +44,44 @@ public final class CallableOfTest {
             () -> flag.set(true),
             true
         ).call();
-        MatcherAssert.assertThat(
-            flag.get(),
-            Matchers.is(true)
-        );
-    }
-
-    @Test(expected = Exception.class)
-    public void wrapsRuntimeErrorFromRunnable() throws Exception {
-        new CallableOf<>(
-            () -> {
-                throw new IllegalStateException();
-            },
-        true
-        ).call();
+        new Assertion<>(
+            "must have been set by callable",
+            flag::get,
+            new IsEqual<>(true)
+        ).affirm();
     }
 
     @Test
     public void convertsProcIntoCallable() throws Exception {
         final AtomicBoolean flag = new AtomicBoolean(false);
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "must return predefined result",
             new CallableOf<>(
-                unused -> {
-                    flag.set(true);
+                bool -> {
+                    flag.set(bool);
                 },
-                true
-            ).call(),
-            Matchers.equalTo(true)
-        );
-        MatcherAssert.assertThat(
-            flag.get(),
-            Matchers.is(true)
-        );
+                true,
+                false
+            )::call,
+            new IsEqual<>(false)
+        ).affirm();
+        new Assertion<>(
+            "must have been set by callable",
+            flag::get,
+            new IsEqual<>(true)
+        ).affirm();
     }
 
     @Test
-    public void convertsFuncWithInputIntoCallable() throws Exception {
-        MatcherAssert.assertThat(
+    public void convertsFuncIntoCallable() throws Exception {
+        new Assertion<>(
+            "must return the application of func",
             new CallableOf<>(
                 num -> num + 1,
                 1
-            ).call(),
-            Matchers.equalTo(2)
-        );
+            )::call,
+            new IsEqual<>(2)
+        ).affirm();
     }
 
 }


### PR DESCRIPTION
This is for #1040.

I had to rework `CallableOf` implementation to avoid the need for `null` and remove the constructor that was using it. Now a `Proc` or a `Func` must always be accompanied by an input to be transformed into a `Callable`.