### PR TITLE
(#922) equals() and hashCode() of MapEnvelope should be tolerant to nulls

### DIFF
--- a/src/main/java/org/cactoos/map/MapEnvelope.java
+++ b/src/main/java/org/cactoos/map/MapEnvelope.java
@@ -23,15 +23,10 @@
  */
 package org.cactoos.map;
 
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+
 import org.cactoos.Scalar;
-import org.cactoos.scalar.And;
-import org.cactoos.scalar.Folded;
-import org.cactoos.scalar.Or;
-import org.cactoos.scalar.SumOfInt;
-import org.cactoos.scalar.Unchecked;
+import org.cactoos.scalar.*;
 import org.cactoos.text.TextOf;
 
 /**
@@ -170,7 +165,12 @@ public abstract class MapEnvelope<X, Y> implements Map<X, Y> {
                     ).value();
                     return new SumOfInt(
                         () -> 37 * keys,
-                        () -> entry.getValue().hashCode()
+                        () -> new Ternary<>(
+                                entry.getValue(),
+                                o -> o != null,
+                                o -> o.hashCode(),
+                                o -> 0)
+                                .value()
                     ).value();
                 },
                 this.map.value().entrySet()
@@ -192,7 +192,7 @@ public abstract class MapEnvelope<X, Y> implements Map<X, Y> {
                     final Y value = entry.getValue();
                     return new And(
                         () -> other.containsKey(key),
-                        () -> other.get(key).equals(value)
+                        () -> new EqualsNullable(other.get(key), (value)).value()
                     ).value();
                 }, this.entrySet()
             )

--- a/src/main/java/org/cactoos/map/MapEnvelope.java
+++ b/src/main/java/org/cactoos/map/MapEnvelope.java
@@ -51,8 +51,7 @@ import org.cactoos.text.TextOf;
 @SuppressWarnings(
     {
         "PMD.TooManyMethods",
-        "PMD.AbstractNaming",
-        "unchecked"
+        "PMD.AbstractNaming"
     }
 )
 public abstract class MapEnvelope<X, Y> implements Map<X, Y> {
@@ -167,16 +166,11 @@ public abstract class MapEnvelope<X, Y> implements Map<X, Y> {
         return new Unchecked<>(
             new Folded<>(
                 42,
-                (hash, entry) -> {
-                    final int keys = new SumOfInt(
-                        () -> 37 * hash,
-                        () -> entry.getKey().hashCode()
-                    ).value();
-                    return new SumOfInt(
-                        () -> 37 * keys,
-                        () -> Objects.hashCode(entry.getValue())
-                    ).value();
-                },
+                (hash, entry) -> new SumOfInt(
+                    () -> 37 * hash,
+                    () -> entry.getKey().hashCode(),
+                    () -> Objects.hashCode(entry.getValue())
+                ).value(),
                 this.map.value().entrySet()
             )
         ).value();
@@ -192,13 +186,11 @@ public abstract class MapEnvelope<X, Y> implements Map<X, Y> {
         return new Unchecked<>(
             new And(
                 (entry) -> {
-                    final X key = entry.getKey();
-                    final Y value = entry.getValue();
                     return new And(
-                        () -> other.containsKey(key),
+                        () -> other.containsKey(entry.getKey()),
                         () -> new EqualsNullable(
-                            () -> other.get(key),
-                            value
+                            () -> other.get(entry.getKey()),
+                            entry.getValue()
                         ).value()
                     ).value();
                 }, this.entrySet()

--- a/src/main/java/org/cactoos/map/MapEnvelope.java
+++ b/src/main/java/org/cactoos/map/MapEnvelope.java
@@ -23,10 +23,18 @@
  */
 package org.cactoos.map;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
 
 import org.cactoos.Scalar;
-import org.cactoos.scalar.*;
+import org.cactoos.scalar.And;
+import org.cactoos.scalar.EqualsNullable;
+import org.cactoos.scalar.Folded;
+import org.cactoos.scalar.Or;
+import org.cactoos.scalar.SumOfInt;
+import org.cactoos.scalar.Ternary;
+import org.cactoos.scalar.Unchecked;
 import org.cactoos.text.TextOf;
 
 /**

--- a/src/main/java/org/cactoos/map/MapEnvelope.java
+++ b/src/main/java/org/cactoos/map/MapEnvelope.java
@@ -33,7 +33,6 @@ import org.cactoos.scalar.EqualsNullable;
 import org.cactoos.scalar.Folded;
 import org.cactoos.scalar.Or;
 import org.cactoos.scalar.SumOfInt;
-import org.cactoos.scalar.Ternary;
 import org.cactoos.scalar.Unchecked;
 import org.cactoos.text.TextOf;
 

--- a/src/main/java/org/cactoos/map/MapEnvelope.java
+++ b/src/main/java/org/cactoos/map/MapEnvelope.java
@@ -26,7 +26,6 @@ package org.cactoos.map;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
-
 import org.cactoos.Scalar;
 import org.cactoos.scalar.And;
 import org.cactoos.scalar.EqualsNullable;
@@ -174,11 +173,11 @@ public abstract class MapEnvelope<X, Y> implements Map<X, Y> {
                     return new SumOfInt(
                         () -> 37 * keys,
                         () -> new Ternary<>(
-                                entry.getValue(),
-                                o -> o != null,
-                                o -> o.hashCode(),
-                                o -> 0)
-                                .value()
+                            entry.getValue(),
+                            o -> o != null,
+                            o -> o.hashCode(),
+                            o -> 0)
+                        .value()
                     ).value();
                 },
                 this.map.value().entrySet()

--- a/src/main/java/org/cactoos/map/MapEnvelope.java
+++ b/src/main/java/org/cactoos/map/MapEnvelope.java
@@ -176,8 +176,8 @@ public abstract class MapEnvelope<X, Y> implements Map<X, Y> {
                             entry.getValue(),
                             o -> o != null,
                             o -> o.hashCode(),
-                            o -> 0)
-                        .value()
+                            o -> 0
+                        ).value()
                     ).value();
                 },
                 this.map.value().entrySet()
@@ -199,7 +199,10 @@ public abstract class MapEnvelope<X, Y> implements Map<X, Y> {
                     final Y value = entry.getValue();
                     return new And(
                         () -> other.containsKey(key),
-                        () -> new EqualsNullable(other.get(key), (value)).value()
+                        () -> new EqualsNullable(
+                            other.get(key),
+                            value
+                        ).value()
                     ).value();
                 }, this.entrySet()
             )

--- a/src/main/java/org/cactoos/map/MapEnvelope.java
+++ b/src/main/java/org/cactoos/map/MapEnvelope.java
@@ -25,6 +25,7 @@ package org.cactoos.map;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.cactoos.Scalar;
 import org.cactoos.scalar.And;
@@ -46,11 +47,13 @@ import org.cactoos.text.TextOf;
  * @see Sticky
  * @since 0.24
  * @checkstyle AbstractClassNameCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings(
     {
         "PMD.TooManyMethods",
-        "PMD.AbstractNaming"
+        "PMD.AbstractNaming",
+        "unchecked"
     }
 )
 public abstract class MapEnvelope<X, Y> implements Map<X, Y> {
@@ -172,12 +175,7 @@ public abstract class MapEnvelope<X, Y> implements Map<X, Y> {
                     ).value();
                     return new SumOfInt(
                         () -> 37 * keys,
-                        () -> new Ternary<>(
-                            entry.getValue(),
-                            o -> o != null,
-                            o -> o.hashCode(),
-                            o -> 0
-                        ).value()
+                        () -> Objects.hashCode(entry.getValue())
                     ).value();
                 },
                 this.map.value().entrySet()
@@ -200,7 +198,7 @@ public abstract class MapEnvelope<X, Y> implements Map<X, Y> {
                     return new And(
                         () -> other.containsKey(key),
                         () -> new EqualsNullable(
-                            other.get(key),
+                            () -> other.get(key),
                             value
                         ).value()
                     ).value();

--- a/src/main/java/org/cactoos/scalar/EqualsNullable.java
+++ b/src/main/java/org/cactoos/scalar/EqualsNullable.java
@@ -1,0 +1,16 @@
+package org.cactoos.scalar;
+
+import org.cactoos.Scalar;
+
+public class EqualsNullable implements Scalar<Boolean> {
+    private final Object a, b;
+
+    public EqualsNullable (Object a, Object b) {
+        this.a = a;
+        this.b = b;
+    }
+    @Override
+    public Boolean value() throws Exception {
+        return (a == b) || (a != null && a.equals(b));
+    }
+}

--- a/src/main/java/org/cactoos/scalar/EqualsNullable.java
+++ b/src/main/java/org/cactoos/scalar/EqualsNullable.java
@@ -31,7 +31,7 @@ import org.cactoos.Scalar;
  * <p>There is no thread-safety guarantee.
  * @since 1.0
  */
-@SuppressWarnings("PMD.SuspiciousEqualsMethodName")
+@SuppressWarnings({"PMD.SuspiciousEqualsMethodName", "PMD.CompareObjectsWithEquals"})
 public final class EqualsNullable implements Scalar<Boolean> {
     /**
      * The first object for comparison.
@@ -70,20 +70,21 @@ public final class EqualsNullable implements Scalar<Boolean> {
     }
 
     /**
-     * Accepts 2 scalars to get get values from
+     * Accepts 2 scalars to get get values from.
      * @param first Scalar to get value to compare
      * @param second Scalar to get value to compare with
      */
-    public EqualsNullable(final Scalar<Object> first, final Scalar<Object> second) {
+    public EqualsNullable(final Scalar<Object> first,
+        final Scalar<Object> second) {
         this.first = first;
         this.second = second;
     }
 
     @Override
     public Boolean value() throws Exception {
-        final Object firstValue = first.value();
-        final Object secondValue = second.value();
-        return firstValue == secondValue
-            || firstValue != null && firstValue.equals(secondValue);
+        final Object source = this.first.value();
+        final Object compared = this.second.value();
+        return source == compared
+            || source != null && source.equals(compared);
     }
 }

--- a/src/main/java/org/cactoos/scalar/EqualsNullable.java
+++ b/src/main/java/org/cactoos/scalar/EqualsNullable.java
@@ -31,12 +31,6 @@ import org.cactoos.Scalar;
  * <p>There is no thread-safety guarantee.
  * @since 1.0
  */
-@SuppressWarnings(
-    {
-        "PMD.SuspiciousEqualsMethodName",
-        "PMD.CompareObjectsWithEquals"
-    }
-)
 public final class EqualsNullable implements Scalar<Boolean> {
     /**
      * The first object for comparison.
@@ -86,6 +80,7 @@ public final class EqualsNullable implements Scalar<Boolean> {
     }
 
     @Override
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     public Boolean value() throws Exception {
         final Object source = this.first.value();
         final Object compared = this.second.value();

--- a/src/main/java/org/cactoos/scalar/EqualsNullable.java
+++ b/src/main/java/org/cactoos/scalar/EqualsNullable.java
@@ -27,34 +27,66 @@ import org.cactoos.Scalar;
 
 /**
  * Checks 2 objects for equality.
- * Nullable values are enabled.
- *
- * <p>This class implements {@link Scalar}, which throws first checked
- * {@link Exception}. This may not be convenient in many cases. To make
- * it more convenient and get rid of the checked exception you can
- * use the {@link Unchecked} decorator. Or you may use
- * {@link IoChecked} to wrap it in an IOException.</p>
- *
+ * Null values are accepted.
  * <p>There is no thread-safety guarantee.
  * @since 1.0
  */
+@SuppressWarnings("PMD.SuspiciousEqualsMethodName")
 public final class EqualsNullable implements Scalar<Boolean> {
-    private final Object first;
-    private final Object second;
+    /**
+     * The first object for comparison.
+     */
+    private final Scalar<Object> first;
+    /**
+     * The second object for comparison.
+     */
+    private final Scalar<Object> second;
 
     /**
-     * Default constructor
-     * @param first object to compare
-     * @param second object to compare with
+     * Accepts 2 objects to compare.
+     * @param first Object to compare
+     * @param second Object to compare with
      */
     public EqualsNullable(final Object first, final Object second) {
+        this.first = () -> first;
+        this.second = () -> second;
+    }
+
+    /**
+     * Accepts scalar to get value from and object to compare with.
+     * @param first Scalar to get value to compare
+     * @param second Object to compare with
+     */
+    public EqualsNullable(final Scalar<Object> first, final Object second) {
+        this.first = first;
+        this.second = () -> second;
+    }
+
+    /**
+     * Accepts object to compare with and scalar to get value from.
+     * @param first Object to compare
+     * @param second Scalar to get value to compare
+     */
+    public EqualsNullable(final Object first, final Scalar<Object> second) {
+        this.first = () -> first;
+        this.second = second;
+    }
+
+    /**
+     * Accepts 2 scalars to get get values from
+     * @param first Scalar to get value to compare
+     * @param second Scalar to get value to compare with
+     */
+    public EqualsNullable(final Scalar<Object> first, final Scalar<Object> second) {
         this.first = first;
         this.second = second;
     }
 
     @Override
-    public Boolean value() {
-        return (this.first == this.second) ||
-            (this.first != null && this.first.equals(this.second));
+    public Boolean value() throws Exception {
+        final Object firstValue = first.value();
+        final Object secondValue = second.value();
+        return firstValue == secondValue
+            || firstValue != null && firstValue.equals(secondValue);
     }
 }

--- a/src/main/java/org/cactoos/scalar/EqualsNullable.java
+++ b/src/main/java/org/cactoos/scalar/EqualsNullable.java
@@ -2,15 +2,29 @@ package org.cactoos.scalar;
 
 import org.cactoos.Scalar;
 
+/**
+ * Checks 2 objects for equality.
+ * Nullable values are enabled.
+ *
+ * <p>This class implements {@link Scalar}, which throws first checked
+ * {@link Exception}. This may not be convenient in many cases. To make
+ * it more convenient and get rid of the checked exception you can
+ * use the {@link Unchecked} decorator. Or you may use
+ * {@link IoChecked} to wrap it in an IOException.</p>
+ *
+ * <p>There is no thread-safety guarantee.
+ */
 public class EqualsNullable implements Scalar<Boolean> {
-    private final Object a, b;
+    private final Object first;
+    private final Object second;
 
-    public EqualsNullable (Object a, Object b) {
-        this.a = a;
-        this.b = b;
+    public EqualsNullable(final Object first, final Object second) {
+        this.first = first;
+        this.second = second;
     }
+
     @Override
     public Boolean value() throws Exception {
-        return (a == b) || (a != null && a.equals(b));
+        return (this.first == this.second) || (this.first != null && this.first.equals(this.second));
     }
 }

--- a/src/main/java/org/cactoos/scalar/EqualsNullable.java
+++ b/src/main/java/org/cactoos/scalar/EqualsNullable.java
@@ -31,7 +31,12 @@ import org.cactoos.Scalar;
  * <p>There is no thread-safety guarantee.
  * @since 1.0
  */
-@SuppressWarnings({"PMD.SuspiciousEqualsMethodName", "PMD.CompareObjectsWithEquals"})
+@SuppressWarnings(
+    {
+        "PMD.SuspiciousEqualsMethodName",
+        "PMD.CompareObjectsWithEquals"
+    }
+)
 public final class EqualsNullable implements Scalar<Boolean> {
     /**
      * The first object for comparison.

--- a/src/main/java/org/cactoos/scalar/EqualsNullable.java
+++ b/src/main/java/org/cactoos/scalar/EqualsNullable.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.cactoos.scalar;
 
 import org.cactoos.Scalar;
@@ -13,18 +36,25 @@ import org.cactoos.Scalar;
  * {@link IoChecked} to wrap it in an IOException.</p>
  *
  * <p>There is no thread-safety guarantee.
+ * @since 1.0
  */
-public class EqualsNullable implements Scalar<Boolean> {
+public final class EqualsNullable implements Scalar<Boolean> {
     private final Object first;
     private final Object second;
 
+    /**
+     * Default constructor
+     * @param first object to compare
+     * @param second object to compare with
+     */
     public EqualsNullable(final Object first, final Object second) {
         this.first = first;
         this.second = second;
     }
 
     @Override
-    public Boolean value() throws Exception {
-        return (this.first == this.second) || (this.first != null && this.first.equals(this.second));
+    public Boolean value() {
+        return (this.first == this.second) ||
+            (this.first != null && this.first.equals(this.second));
     }
 }

--- a/src/main/java/org/cactoos/scalar/EqualsNullable.java
+++ b/src/main/java/org/cactoos/scalar/EqualsNullable.java
@@ -48,8 +48,7 @@ public final class EqualsNullable implements Scalar<Boolean> {
      * @param second Object to compare with
      */
     public EqualsNullable(final Object first, final Object second) {
-        this.first = () -> first;
-        this.second = () -> second;
+        this(() -> first, () -> second);
     }
 
     /**
@@ -58,8 +57,7 @@ public final class EqualsNullable implements Scalar<Boolean> {
      * @param second Object to compare with
      */
     public EqualsNullable(final Scalar<Object> first, final Object second) {
-        this.first = first;
-        this.second = () -> second;
+        this(first, () -> second);
     }
 
     /**
@@ -68,8 +66,7 @@ public final class EqualsNullable implements Scalar<Boolean> {
      * @param second Scalar to get value to compare
      */
     public EqualsNullable(final Object first, final Scalar<Object> second) {
-        this.first = () -> first;
-        this.second = second;
+        this(() -> first, second);
     }
 
     /**

--- a/src/test/java/org/cactoos/map/MapEnvelopeTest.java
+++ b/src/test/java/org/cactoos/map/MapEnvelopeTest.java
@@ -250,7 +250,7 @@ public final class MapEnvelopeTest {
     }
 
     @Test
-    public void equalNotFailsOnNull() {
+    public void equalsDoesNotFailOnNulls() {
         final MapEntry<String, String> first =
             new MapEntry<>("key3", "value3");
         final MapEntry<String, String> second =
@@ -308,7 +308,7 @@ public final class MapEnvelopeTest {
     }
 
     @Test
-    public void hashCodeNotFailsOnNull() {
+    public void hashCodeDoesNotFailOnNulls() {
         final MapEntry<String, String> first =
             new MapEntry<>("key10", "value10");
         final MapEntry<String, String> second =

--- a/src/test/java/org/cactoos/map/MapEnvelopeTest.java
+++ b/src/test/java/org/cactoos/map/MapEnvelopeTest.java
@@ -249,14 +249,14 @@ public final class MapEnvelopeTest {
         );
     }
 
-    @Test(expected = NullPointerException.class)
-    public void equalFailsOnNull() {
+    @Test
+    public void equalNotFailsOnNull() {
         final MapEntry<String, String> first =
             new MapEntry<>("key3", "value3");
         final MapEntry<String, String> second =
             new MapEntry<>("key4", null);
         MatcherAssert.assertThat(
-            "Map allows null values, but shouldn't",
+            "Map must allow null values",
             new MapOf<String, String>(first, second),
             new IsEqual<>(new MapOf<String, String>(first, second))
         );
@@ -307,8 +307,8 @@ public final class MapEnvelopeTest {
         );
     }
 
-    @Test(expected = NullPointerException.class)
-    public void hashCodeFailsOnNull() {
+    @Test
+    public void hashCodeNotFailsOnNull() {
         final MapEntry<String, String> first =
             new MapEntry<>("key10", "value10");
         final MapEntry<String, String> second =

--- a/src/test/java/org/cactoos/scalar/EqualsNullableTest.java
+++ b/src/test/java/org/cactoos/scalar/EqualsNullableTest.java
@@ -1,0 +1,26 @@
+package org.cactoos.scalar;
+
+import org.junit.Test;
+
+/**
+ * Test case for {@link EqualsNullable}.
+ *
+ */
+public class EqualsNullableTest {
+
+    @Test
+    public void nullEqualsNull() throws Exception {
+        assert new EqualsNullable(null, null).value();
+    }
+
+    @Test
+    public void equals() throws Exception {
+        assert new EqualsNullable(1, 1).value();
+    }
+
+    @Test
+    public void notEquals() throws Exception {
+        Boolean value = new EqualsNullable(1, 2).value();
+        assert !value;
+    }
+}

--- a/src/test/java/org/cactoos/scalar/EqualsNullableTest.java
+++ b/src/test/java/org/cactoos/scalar/EqualsNullableTest.java
@@ -54,7 +54,7 @@ public class EqualsNullableTest {
     public void notEquals() throws Exception {
         MatcherAssert.assertThat(
             "Must return false for non equal objects",
-            new EqualsNullable(1, 2).value()
+            !new EqualsNullable(1, 2).value()
         );
     }
 }

--- a/src/test/java/org/cactoos/scalar/EqualsNullableTest.java
+++ b/src/test/java/org/cactoos/scalar/EqualsNullableTest.java
@@ -33,32 +33,33 @@ import org.llorllale.cactoos.matchers.IsTrue;
  * @since 1.0
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.SuspiciousEqualsMethodName")
 public final class EqualsNullableTest {
 
     @Test
     public void nullEqualsNull() throws Exception {
         new Assertion<>(
-                "Must return true for both null objects",
-                new EqualsNullable(() -> null, () -> null),
-                new IsTrue()
+            "Must return true for both null objects",
+            new EqualsNullable(() -> null, () -> null),
+            new IsTrue()
         ).affirm();
     }
 
     @Test
     public void equals() throws Exception {
         new Assertion<>(
-                "Must return true for equal objects",
-                new EqualsNullable(1, 1),
-                new IsTrue()
+            "Must return true for equal objects",
+            new EqualsNullable(1, 1),
+            new IsTrue()
         ).affirm();
     }
 
     @Test
     public void notEquals() throws Exception {
         new Assertion<>(
-                "Must return false for non equal objects",
-                () -> !new EqualsNullable(1, 2).value(),
-                new IsTrue()
+            "Must return false for non equal objects",
+            () -> !new EqualsNullable(1, 2).value(),
+            new IsTrue()
         ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/scalar/EqualsNullableTest.java
+++ b/src/test/java/org/cactoos/scalar/EqualsNullableTest.java
@@ -62,4 +62,22 @@ public final class EqualsNullableTest {
             new IsTrue()
         ).affirm();
     }
+
+    @Test
+    public void equalsObjectAndScalar() throws Exception {
+        new Assertion<>(
+            "Must return true for object and scalar with the same value",
+            new EqualsNullable(1, () -> 1),
+            new IsTrue()
+        ).affirm();
+    }
+
+    @Test
+    public void equalsScalarAndObject() throws Exception {
+        new Assertion<>(
+            "Must return true for scalar and object with the same value",
+            new EqualsNullable(() -> 1, 1),
+            new IsTrue()
+        ).affirm();
+    }
 }

--- a/src/test/java/org/cactoos/scalar/EqualsNullableTest.java
+++ b/src/test/java/org/cactoos/scalar/EqualsNullableTest.java
@@ -24,37 +24,44 @@
 package org.cactoos.scalar;
 
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsNot;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.IsTrue;
+import org.llorllale.cactoos.matchers.ScalarHasValue;
 
 /**
  * Test case for {@link EqualsNullable}.
  *
- * @checkstyle JavadocMethodCheck (500 lines)
  * @since 1.0
+ * @checkstyle JavadocMethodCheck (500 lines)
  */
-public class EqualsNullableTest {
+public final class EqualsNullableTest {
 
     @Test
     public void nullEqualsNull() throws Exception {
-        MatcherAssert.assertThat(
+        new Assertion<>(
                 "Must return true for both null objects",
-                new EqualsNullable(null, null).value()
-        );
+                new EqualsNullable(null, null),
+                new IsTrue()
+        ).affirm();
     }
 
     @Test
     public void equals() throws Exception {
-        MatcherAssert.assertThat(
+        new Assertion<>(
                 "Must return true for equal objects",
-                new EqualsNullable(1, 1).value()
-        );
+                new EqualsNullable(1, 1),
+                new IsTrue()
+        ).affirm();
     }
 
     @Test
     public void notEquals() throws Exception {
-        MatcherAssert.assertThat(
-            "Must return false for non equal objects",
-            !new EqualsNullable(1, 2).value()
-        );
+        new Assertion<>(
+                "Must return false for non equal objects",
+                () -> !new EqualsNullable(1, 2).value(),
+                new IsTrue()
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/scalar/EqualsNullableTest.java
+++ b/src/test/java/org/cactoos/scalar/EqualsNullableTest.java
@@ -1,26 +1,60 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.cactoos.scalar;
 
+import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 
 /**
  * Test case for {@link EqualsNullable}.
  *
+ * @checkstyle JavadocMethodCheck (500 lines)
+ * @since 1.0
  */
 public class EqualsNullableTest {
 
     @Test
     public void nullEqualsNull() throws Exception {
-        assert new EqualsNullable(null, null).value();
+        MatcherAssert.assertThat(
+                "Must return true for both null objects",
+                new EqualsNullable(null, null).value()
+        );
     }
 
     @Test
     public void equals() throws Exception {
-        assert new EqualsNullable(1, 1).value();
+        MatcherAssert.assertThat(
+                "Must return true for equal objects",
+                new EqualsNullable(1, 1).value()
+        );
     }
 
     @Test
     public void notEquals() throws Exception {
-        Boolean value = new EqualsNullable(1, 2).value();
-        assert !value;
+        MatcherAssert.assertThat(
+            "Must return false for non equal objects",
+            new EqualsNullable(1, 2).value()
+        );
     }
 }

--- a/src/test/java/org/cactoos/scalar/EqualsNullableTest.java
+++ b/src/test/java/org/cactoos/scalar/EqualsNullableTest.java
@@ -23,12 +23,9 @@
  */
 package org.cactoos.scalar;
 
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsNot;
 import org.junit.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.IsTrue;
-import org.llorllale.cactoos.matchers.ScalarHasValue;
 
 /**
  * Test case for {@link EqualsNullable}.
@@ -42,7 +39,7 @@ public final class EqualsNullableTest {
     public void nullEqualsNull() throws Exception {
         new Assertion<>(
                 "Must return true for both null objects",
-                new EqualsNullable(null, null),
+                new EqualsNullable(() -> null, () -> null),
                 new IsTrue()
         ).affirm();
     }


### PR DESCRIPTION
This is for (#922).

I update equals() and hashCode() to not fail with null values.
Also I updated tests which covered this fuctionality.