### PR TITLE
(#927) What is the expected behaviour of BehavesAsMap?

### DIFF
--- a/src/test/java/org/cactoos/map/BehavesAsMap.java
+++ b/src/test/java/org/cactoos/map/BehavesAsMap.java
@@ -28,6 +28,7 @@ import org.hamcrest.Description;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.collection.IsMapContaining;
+import org.hamcrest.core.IsCollectionContaining;
 import org.hamcrest.core.IsEqual;
 
 /**
@@ -69,6 +70,16 @@ public final class BehavesAsMap<K, V> extends TypeSafeMatcher<Map<K, V>>  {
                 new IsEqual<>(this.key),
                 new IsEqual<>(this.value)
             )
+        );
+        MatcherAssert.assertThat(
+            "Doesn't contain the key in #keySet()",
+            map.keySet(),
+            new IsCollectionContaining<>(new IsEqual<>(this.key))
+        );
+        MatcherAssert.assertThat(
+            "Doesn't contain the value in #values()",
+            map.values(),
+            new IsCollectionContaining<>(new IsEqual<>(this.value))
         );
         return true;
     }

--- a/src/test/java/org/cactoos/map/BehavesAsMap.java
+++ b/src/test/java/org/cactoos/map/BehavesAsMap.java
@@ -28,8 +28,6 @@ import org.hamcrest.Description;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.collection.IsMapContaining;
-import org.hamcrest.core.IsAnything;
-import org.hamcrest.core.IsCollectionContaining;
 import org.hamcrest.core.IsEqual;
 
 /**
@@ -69,26 +67,8 @@ public final class BehavesAsMap<K, V> extends TypeSafeMatcher<Map<K, V>>  {
             map,
             new IsMapContaining<>(
                 new IsEqual<>(this.key),
-                new IsAnything<>()
-            )
-        );
-        MatcherAssert.assertThat(
-            "Doesn't contain the value",
-            map,
-            new IsMapContaining<>(
-                new IsAnything<>(),
                 new IsEqual<>(this.value)
             )
-        );
-        MatcherAssert.assertThat(
-            "Doesn't contain the key in #keySet()",
-            map.keySet(),
-            new IsCollectionContaining<>(new IsEqual<>(this.key))
-        );
-        MatcherAssert.assertThat(
-            "Doesn't contain the value in #values()",
-            map.values(),
-            new IsCollectionContaining<>(new IsEqual<>(this.value))
         );
         return true;
     }

--- a/src/test/java/org/cactoos/map/MapOfTest.java
+++ b/src/test/java/org/cactoos/map/MapOfTest.java
@@ -55,10 +55,11 @@ public final class MapOfTest {
             "Can't behave as a map",
             new NoNulls<>(
                 new MapOf<Integer, Integer>(
-                    new MapEntry<>(0, 1)
+                    new MapEntry<>(0, -1),
+                    new MapEntry<>(1, 1)
                 )
             ),
-            new BehavesAsMap<>(0, 1)
+            new BehavesAsMap<>(1, 1)
         );
     }
 

--- a/src/test/java/org/cactoos/map/MapOfTest.java
+++ b/src/test/java/org/cactoos/map/MapOfTest.java
@@ -55,8 +55,7 @@ public final class MapOfTest {
             "Can't behave as a map",
             new NoNulls<>(
                 new MapOf<Integer, Integer>(
-                    new MapEntry<>(0, -1),
-                    new MapEntry<>(1, 1)
+                    new MapEntry<>(0, 1)
                 )
             ),
             new BehavesAsMap<>(0, 1)

--- a/src/test/java/org/cactoos/map/SolidTest.java
+++ b/src/test/java/org/cactoos/map/SolidTest.java
@@ -52,8 +52,7 @@ public final class SolidTest {
         MatcherAssert.assertThat(
             "Can't behave as a map",
             new Solid<Integer, Integer>(
-                new MapEntry<>(0, -1),
-                new MapEntry<>(1, 1)
+                new MapEntry<>(0, 1)
             ),
             new BehavesAsMap<>(0, 1)
         );
@@ -73,8 +72,7 @@ public final class SolidTest {
             },
             new RunsInThreads<>(
                 new Solid<Integer, Integer>(
-                    new MapEntry<>(0, -1),
-                    new MapEntry<>(1, 1)
+                    new MapEntry<>(0, 1)
                 )
             )
         );

--- a/src/test/java/org/cactoos/map/SolidTest.java
+++ b/src/test/java/org/cactoos/map/SolidTest.java
@@ -52,9 +52,10 @@ public final class SolidTest {
         MatcherAssert.assertThat(
             "Can't behave as a map",
             new Solid<Integer, Integer>(
-                new MapEntry<>(0, 1)
+                new MapEntry<>(0, -1),
+                new MapEntry<>(1, 1)
             ),
-            new BehavesAsMap<>(0, 1)
+            new BehavesAsMap<>(1, 1)
         );
     }
 
@@ -66,13 +67,14 @@ public final class SolidTest {
                 MatcherAssert.assertThat(
                     "Can't behave as a map in thread",
                     map,
-                    new BehavesAsMap<>(0, 1)
+                    new BehavesAsMap<>(1, 1)
                 );
                 return true;
             },
             new RunsInThreads<>(
                 new Solid<Integer, Integer>(
-                    new MapEntry<>(0, 1)
+                    new MapEntry<>(0, -1),
+                    new MapEntry<>(1, 1)
                 )
             )
         );

--- a/src/test/java/org/cactoos/map/StickyTest.java
+++ b/src/test/java/org/cactoos/map/StickyTest.java
@@ -51,8 +51,7 @@ public final class StickyTest {
         MatcherAssert.assertThat(
             "Can't behave as a map",
             new Sticky<Integer, Integer>(
-                new MapEntry<>(0, -1),
-                new MapEntry<>(1, 1)
+                new MapEntry<>(0, 1)
             ),
             new BehavesAsMap<>(0, 1)
         );

--- a/src/test/java/org/cactoos/map/StickyTest.java
+++ b/src/test/java/org/cactoos/map/StickyTest.java
@@ -51,9 +51,10 @@ public final class StickyTest {
         MatcherAssert.assertThat(
             "Can't behave as a map",
             new Sticky<Integer, Integer>(
-                new MapEntry<>(0, 1)
+                new MapEntry<>(0, -1),
+                new MapEntry<>(1, 1)
             ),
-            new BehavesAsMap<>(0, 1)
+            new BehavesAsMap<>(1, 1)
         );
     }
 

--- a/src/test/java/org/cactoos/map/SyncedTest.java
+++ b/src/test/java/org/cactoos/map/SyncedTest.java
@@ -41,9 +41,10 @@ public final class SyncedTest {
         MatcherAssert.assertThat(
             "Can't behave as a map",
             new Synced<Integer, Integer>(
-                new MapEntry<>(0, 1)
+                new MapEntry<>(0, -1),
+                new MapEntry<>(1, 1)
             ),
-            new BehavesAsMap<>(0, 1)
+            new BehavesAsMap<>(1, 1)
         );
     }
 
@@ -55,13 +56,14 @@ public final class SyncedTest {
                 MatcherAssert.assertThat(
                     "Can't behave as a map in thread",
                     map,
-                    new BehavesAsMap<>(0, 1)
+                    new BehavesAsMap<>(1, 1)
                 );
                 return true;
             },
             new RunsInThreads<>(
                 new Synced<Integer, Integer>(
-                    new MapEntry<>(0, 1)
+                    new MapEntry<>(0, -1),
+                    new MapEntry<>(1, 1)
                 )
             )
         );

--- a/src/test/java/org/cactoos/map/SyncedTest.java
+++ b/src/test/java/org/cactoos/map/SyncedTest.java
@@ -41,8 +41,7 @@ public final class SyncedTest {
         MatcherAssert.assertThat(
             "Can't behave as a map",
             new Synced<Integer, Integer>(
-                new MapEntry<>(0, -1),
-                new MapEntry<>(1, 1)
+                new MapEntry<>(0, 1)
             ),
             new BehavesAsMap<>(0, 1)
         );
@@ -62,8 +61,7 @@ public final class SyncedTest {
             },
             new RunsInThreads<>(
                 new Synced<Integer, Integer>(
-                    new MapEntry<>(0, -1),
-                    new MapEntry<>(1, 1)
+                    new MapEntry<>(0, 1)
                 )
             )
         );


### PR DESCRIPTION
This is for #927 

Updated matchers inside BehavesAsMap.matchesSafely().
Updated tests which uses BehavesAsMap.