### PR TITLE
(#1039) Replaced @Rule with Throws matcher

### DIFF
--- a/src/test/java/org/cactoos/ScalarTest.java
+++ b/src/test/java/org/cactoos/ScalarTest.java
@@ -24,9 +24,9 @@
 package org.cactoos;
 
 import org.cactoos.scalar.NoNulls;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link NoNulls}.
@@ -35,24 +35,28 @@ import org.junit.rules.ExpectedException;
  */
 public final class ScalarTest {
 
-    /**
-     * A rule for handling an exception.
-     */
-    @Rule
-    public final ExpectedException cause = ExpectedException.none();
-
     @Test
-    public void failForNullArgument() throws Exception {
-        this.cause.expect(IllegalArgumentException.class);
-        this.cause.expectMessage("NULL instead of a valid scalar");
-        new NoNulls<>(null).value();
+    public void failForNullArgument() {
+        new Assertion<>(
+            "Must fail for null argument",
+            () -> new NoNulls<>(null).value(),
+            new Throws<>(
+                "NULL instead of a valid scalar",
+                IllegalArgumentException.class
+            )
+        ).affirm();
     }
 
     @Test
-    public void failForNullResult() throws Exception {
-        this.cause.expect(IllegalStateException.class);
-        this.cause.expectMessage("NULL instead of a valid value");
-        new NoNulls<>(() -> null).value();
+    public void failForNullResult() {
+        new Assertion<>(
+            "Must fail for null result",
+            () -> new NoNulls<>(() -> null).value(),
+            new Throws<>(
+                "NULL instead of a valid value",
+                IllegalStateException.class
+            )
+        ).affirm();
     }
 
     @Test

--- a/src/test/java/org/cactoos/TextTest.java
+++ b/src/test/java/org/cactoos/TextTest.java
@@ -26,41 +26,40 @@ package org.cactoos;
 import org.cactoos.text.NoNulls;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.TextHasString;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link Text}.
  * @since 0.11
- * @todo #1023:30min Replace all occurrences of @Rule ExpectedException
- *  tests that use it should be refactored to use Throws class
- *  introduced in cactoos-matchers 0.13.
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 public final class TextTest {
 
-    /**
-     * A rule for handling an exception.
-     */
-    @Rule
-    public final ExpectedException cause = ExpectedException.none();
-
     @Test
-    public void failForNullArgument() throws Exception {
-        this.cause.expect(IllegalArgumentException.class);
-        this.cause.expectMessage("NULL instead of a valid text");
-        new NoNulls(null).asString();
+    public void failForNullArgument() {
+        new Assertion<>(
+            "Must fail for null argument",
+            () -> new NoNulls(null).asString(),
+            new Throws<>(
+                "NULL instead of a valid text",
+                IllegalArgumentException.class
+            )
+        ).affirm();
     }
 
     @Test
-    public void failForNullResult() throws Exception {
-        this.cause.expect(IllegalStateException.class);
-        this.cause.expectMessage("NULL instead of a valid result string");
-        new NoNulls(
-            () -> null
-        ).asString();
+    public void failForNullResult() {
+        new Assertion<>(
+            "Must fail for null result",
+            () -> new NoNulls(() -> null).asString(),
+            new Throws<>(
+                "NULL instead of a valid result string",
+                IllegalStateException.class
+            )
+        ).affirm();
     }
 
     @Test

--- a/src/test/java/org/cactoos/collection/NoNullsTest.java
+++ b/src/test/java/org/cactoos/collection/NoNullsTest.java
@@ -23,9 +23,9 @@
  */
 package org.cactoos.collection;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test cases for {@link NoNulls}.
@@ -38,42 +38,45 @@ import org.junit.rules.ExpectedException;
  */
 public final class NoNullsTest {
 
-    /**
-     * A rule for handling an exception.
-     */
-    @Rule
-    public final ExpectedException exception = ExpectedException.none();
-
     @Test
     public void throwsErrorIfNullInToArray() {
-        this.exception.expect(IllegalStateException.class);
-        this.exception.expectMessage(
-            "Item #1 of #toArray() is NULL"
-        );
-        new NoNulls<>(
-            new CollectionOf<>(1, null, 3)
-        ).toArray();
+        new Assertion<>(
+            "Must throw exception",
+            () -> new NoNulls<>(
+                new CollectionOf<>(1, null, 3)
+            ).toArray(),
+            new Throws<>(
+                "Item #1 of #toArray() is NULL",
+                IllegalStateException.class
+            )
+        ).affirm();
     }
 
     @Test
     public void throwsErrorIfNullInToArrayWithArg() {
-        this.exception.expect(IllegalStateException.class);
-        this.exception.expectMessage(
-            "Item #1 of #toArray(array) is NULL"
-        );
-        new NoNulls<>(
-            new CollectionOf<>(1, null, 3)
-        ).toArray(new Object[3]);
+        new Assertion<>(
+            "Must throw exception for the item#1",
+            () -> new NoNulls<>(
+                new CollectionOf<>(1, null, 3)
+            ).toArray(new Object[3]),
+            new Throws<>(
+                "Item #1 of #toArray(array) is NULL",
+                IllegalStateException.class
+            )
+        ).affirm();
     }
 
     @Test
     public void throwsErrorIfNullInContainsArg() {
-        this.exception.expect(IllegalArgumentException.class);
-        this.exception.expectMessage(
-            "Argument of #contains(T) is NULL"
-        );
-        new NoNulls<>(
-            new CollectionOf<>(1, 2, 3)
-        ).contains(null);
+        new Assertion<>(
+            "Must throw exception for #contains(null)",
+            () -> new NoNulls<>(
+                new CollectionOf<>(1, 2, 3)
+            ).contains(null),
+            new Throws<>(
+                "Argument of #contains(T) is NULL",
+                IllegalArgumentException.class
+            )
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/iterator/NoNullsTest.java
+++ b/src/test/java/org/cactoos/iterator/NoNullsTest.java
@@ -24,14 +24,11 @@
 package org.cactoos.iterator;
 
 import java.util.Iterator;
-import org.cactoos.iterable.IterableOf;
-import org.hamcrest.Matcher;
-import org.hamcrest.core.AllOf;
-import org.hamcrest.core.StringEndsWith;
-import org.hamcrest.core.StringStartsWith;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test cases for {@link NoNulls}.
@@ -51,34 +48,39 @@ public final class NoNullsTest {
 
     @Test
     public void nextThrowsErrorIfNull() {
-        this.exception.expect(IllegalStateException.class);
-        this.exception.expectMessage(
-            new AllOf<>(
-                new IterableOf<Matcher<? super String>>(
-                    new StringStartsWith(
-                        "Item #0 of org.cactoos.iterator"
-                    ),
-                    new StringEndsWith(
-                        "is NULL"
-                    )
-                )
-            )
-        );
-        new NoNulls<>(
-            new Iterator<Integer>() {
-                @Override
-                public boolean hasNext() {
-                    return true;
-                }
+        new Assertion<>(
+            "Must throw exception",
+            () -> new NoNulls<>(
+                new Iterator<Integer>() {
+                    @Override
+                    public boolean hasNext() {
+                        return true;
+                    }
 
-                @Override
-                public Integer next() {
-                    return null;
+                    @Override
+                    public Integer next() {
+                        return null;
+                    }
+
+                    @Override
+                    public String toString() {
+                        return "Iterator@NoNullsTest";
+                    }
                 }
-            }
-        ).next();
+            ).next(),
+            new Throws<>(
+                "Item #0 of Iterator@NoNullsTest is NULL",
+                IllegalStateException.class
+            )
+        ).affirm();
     }
 
+    /*
+    * @todo #1039:15min Currently it's impossible to match error messages
+    *  by a pattern or partially. Replace {@link Rule} with {@link Throws} after
+    *  <a href="https://github.com/llorllale/cactoos-matchers/issues/108">llorllale/cactoos-matchers#108</a>
+    *  is fixed
+    */
     @Test
     public void nthThrowsErrorIfNull() {
         this.exception.expect(IllegalStateException.class);

--- a/src/test/java/org/cactoos/map/MapEnvelopeTest.java
+++ b/src/test/java/org/cactoos/map/MapEnvelopeTest.java
@@ -25,15 +25,12 @@ package org.cactoos.map;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.cactoos.func.FuncOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNot;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.llorllale.cactoos.matchers.Assertion;
-import org.llorllale.cactoos.matchers.MatcherOf;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link MapEnvelope}.
@@ -46,94 +43,74 @@ import org.llorllale.cactoos.matchers.MatcherOf;
 @SuppressWarnings("PMD.TooManyMethods")
 public final class MapEnvelopeTest {
 
-    /**
-     * A rule for handling an exception.
-     */
-    @Rule
-    public final ExpectedException exception = ExpectedException.none();
-
     @Test
     public void putThrowsException() {
-        this.exception.expect(UnsupportedOperationException.class);
-        this.exception.expectMessage(
-            "#put() is not supported, it's a read-only map"
-        );
-        MatcherAssert.assertThat(
-            "put method did not throw exception",
-            new NoNulls<>(
+        new Assertion<>(
+            "put method must throw exception",
+            () -> new NoNulls<>(
                 new MapOf<Integer, Integer>(
-                    new MapEntry<Integer, Integer>(0, -1)
+                    new MapEntry<>(0, -1)
                 )
-            ),
-            new MatcherOf<>(
-                new FuncOf<>(
-                    (map) -> map.put(2, 2),
-                    true
-                ))
-        );
+            ).put(2, 2),
+            new Throws<>(
+                "#put() is not supported, it's a read-only map",
+                UnsupportedOperationException.class
+            )
+        ).affirm();
     }
 
     @Test
     public void removeThrowsException() {
-        this.exception.expect(UnsupportedOperationException.class);
-        this.exception.expectMessage(
-            "#remove() is not supported, it's a read-only map"
-        );
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "remove method did not throw exception",
-            new NoNulls<>(
+            () -> new NoNulls<>(
                 new MapOf<Integer, Integer>(
                     new MapEntry<>(0, -1)
                 )
-            ),
-            new MatcherOf<>(
-                new FuncOf<>(
-                    (map) -> map.remove(0),
-                    true
-                ))
-        );
+            ).remove(0),
+            new Throws<>(
+                "#remove() is not supported, it's a read-only map",
+                UnsupportedOperationException.class
+            )
+        ).affirm();
     }
 
     @Test
     public void putAllThrowsException() {
-        this.exception.expect(UnsupportedOperationException.class);
-        this.exception.expectMessage(
-            "#putAll() is not supported, it's a read-only map"
-        );
-        MatcherAssert.assertThat(
-            "putAll method did not throw exception",
-            new NoNulls<>(
-                new MapOf<Integer, Integer>(
-                    new MapEntry<>(0, -1)
-                )
-            ),
-            new MatcherOf<>(
-                new FuncOf<>(
-                    (map) -> map.putAll(new MapOf<Integer, Integer>()),
-                    true
-                ))
-        );
+        new Assertion<>(
+            "putAll method must throw exception",
+            () -> {
+                new NoNulls<>(
+                    new MapOf<Integer, Integer>(
+                        new MapEntry<>(0, -1)
+                    )
+                ).putAll(new MapOf<Integer, Integer>());
+                return 0;
+            },
+            new Throws<>(
+                "#putAll() is not supported, it's a read-only map",
+                UnsupportedOperationException.class
+            )
+        ).affirm();
     }
 
     @Test
     public void clearThrowsException() {
-        this.exception.expect(UnsupportedOperationException.class);
-        this.exception.expectMessage(
-            "#clear() is not supported, it's a read-only map"
-        );
-        MatcherAssert.assertThat(
-            "clear method did not throw exception",
-            new NoNulls<>(
-                new MapOf<Integer, Integer>(
-                    new MapEntry<>(0, -1)
-                )
-            ),
-            new MatcherOf<>(
-                new FuncOf<>(
-                    Map::clear,
-                    true
-                ))
-        );
+        new Assertion<>(
+            "clear method must throw exception",
+            () -> {
+                new NoNulls<>(
+                    new MapOf<Integer, Integer>(
+                        new MapEntry<>(0, -1)
+                    )
+                ).clear();
+                return 0;
+            },
+            new Throws<>(
+                "#clear() is not supported, it's a read-only map",
+                UnsupportedOperationException.class
+            )
+        ).affirm();
     }
 
     @Test

--- a/src/test/java/org/cactoos/text/StrictTest.java
+++ b/src/test/java/org/cactoos/text/StrictTest.java
@@ -25,11 +25,10 @@ package org.cactoos.text;
 
 import java.util.regex.Pattern;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.StringContains;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.TextIs;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link Strict}.
@@ -41,20 +40,19 @@ import org.llorllale.cactoos.matchers.TextIs;
 public final class StrictTest {
 
     /**
-     * A rule for handling an exception.
-     */
-    @Rule
-    public final ExpectedException exception = ExpectedException.none();
-
-    /**
      * Ensures that Strict is failing on a negative predicate result.
      * @throws Exception If fails
      */
     @Test
-    public void failsIfPredicateIsNegative() throws Exception {
-        this.exception.expect(IllegalArgumentException.class);
-        this.exception.expectMessage(new StringContains("text"));
-        new Strict(s -> false, new TextOf("text")).asString();
+    public void failsIfPredicateIsNegative() {
+        new Assertion<>(
+            "Must throw IllegalArgumentException",
+            () -> new Strict(s -> false, new TextOf("text")).asString(),
+            new Throws<>(
+                "String 'text' does not match a given predicate",
+                IllegalArgumentException.class
+            )
+        ).affirm();
     }
 
     /**
@@ -75,13 +73,18 @@ public final class StrictTest {
      * @throws Exception If fails
      */
     @Test
-    public void failsIfNotMatchedWithPattern() throws Exception {
-        this.exception.expect(IllegalArgumentException.class);
-        this.exception.expectMessage("text");
-        new Strict(
-            Pattern.compile("^[a-zA-Z]+$"),
-            new TextOf("text12")
-        ).asString();
+    public void failsIfNotMatchedWithPattern() {
+        new Assertion<>(
+            "Must throw IllegalArgumentException",
+            () -> new Strict(
+                Pattern.compile("^[a-zA-Z]+$"),
+                new TextOf("text12")
+            ).asString(),
+            new Throws<>(
+                "String 'text12' does not match a given predicate",
+                IllegalArgumentException.class
+            )
+        ).affirm();
     }
 
     /**


### PR DESCRIPTION
It updates the `TextTest` by using `Throws` matcher instead of `@Rule`-marked exception check.