### PR TITLE
(#1037) Add equals and hashCode to IterableEnvelope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,7 @@ The MIT License (MIT)
                 <exclude>findbugs:org.cactoos.map.MapEntry</exclude>
                 <exclude>findbugs:org.cactoos.scalar.NumberOf</exclude>
                 <exclude>findbugs:org.cactoos.text.TextEnvelopeTest</exclude>
+                <exclude>findbugs:org.cactoos.iterable.IterableEnvelope</exclude>
                 <exclude>findbugs:org.cactoos.iterator.Cycled</exclude>
                 <exclude>findbugs:org.cactoos.iterator.Endless</exclude>
               </excludes>

--- a/src/main/java/org/cactoos/iterable/IterableEnvelope.java
+++ b/src/main/java/org/cactoos/iterable/IterableEnvelope.java
@@ -26,6 +26,10 @@ package org.cactoos.iterable;
 import java.util.Iterator;
 import org.cactoos.Scalar;
 import org.cactoos.iterator.Immutable;
+import org.cactoos.scalar.And;
+import org.cactoos.scalar.Folded;
+import org.cactoos.scalar.Or;
+import org.cactoos.scalar.SumOfInt;
 import org.cactoos.scalar.Unchecked;
 
 /**
@@ -60,4 +64,41 @@ public abstract class IterableEnvelope<X> implements Iterable<X> {
         );
     }
 
+    @Override
+    public final boolean equals(final Object other) {
+        return new Unchecked<>(
+            new Or(
+                () -> other == this,
+                new And(
+                    () -> other != null,
+                    () -> Iterable.class.isAssignableFrom(other.getClass()),
+                    () -> {
+                        final Iterable<?> compared = (Iterable<?>) other;
+                        final Iterator<?> iterator = compared.iterator();
+                        return new Unchecked<>(
+                            new And(
+                                (X input) -> input.equals(iterator.next()),
+                                this
+                            )
+                        ).value();
+                    }
+                )
+            )
+        ).value();
+    }
+
+    // @checkstyle MagicNumberCheck (30 lines)
+    @Override
+    public final int hashCode() {
+        return new Unchecked<>(
+            new Folded<>(
+                42,
+                (hash, entry) -> new SumOfInt(
+                    () -> 37 * hash,
+                    entry::hashCode
+                ).value(),
+                this
+            )
+        ).value();
+    }
 }

--- a/src/test/java/org/cactoos/iterable/IterableEnvelopeTest.java
+++ b/src/test/java/org/cactoos/iterable/IterableEnvelopeTest.java
@@ -26,7 +26,10 @@ package org.cactoos.iterable;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 
 /**
  * Test case for {@link IterableEnvelope}.
@@ -48,5 +51,76 @@ public final class IterableEnvelopeTest {
         final Iterator<String> iterator = list.iterator();
         iterator.next();
         iterator.remove();
+    }
+
+    @Test
+    public void notEqualsToObjectOfAnotherType() {
+        new Assertion<>(
+            "Must not equal to object of another type",
+            IterableOf::new,
+            new IsNot<>(new IsEqual<>(new Object()))
+        ).affirm();
+    }
+
+    @Test
+    public void notEqualsToIterableWithDifferentElements() {
+        final IterableOf<Integer> first = new IterableOf<>(1, 2);
+        final IterableOf<Integer> second = new IterableOf<>(1, 3);
+        new Assertion<>(
+            "Must not equal to Iterable with different elements",
+            () -> first,
+            new IsNot<>(new IsEqual<>(second))
+        ).affirm();
+    }
+
+    @Test
+    public void isEqualToItself() {
+        final IterableOf<Integer> iterable = new IterableOf<>(1, 2);
+        new Assertion<>(
+            "Must be equal to itself",
+            () -> iterable,
+           new IsEqual<>(iterable)
+        ).affirm();
+    }
+
+    @Test
+    public void isEqualToIterableWithTheSameElements() {
+        final IterableOf<Integer> iterable = new IterableOf<>(1, 2);
+        new Assertion<>(
+            "Must be equal to Iterable with the same elements",
+            () -> iterable,
+            new IsEqual<>(new IterableOf<>(1, 2))
+        ).affirm();
+    }
+
+    @Test
+    public void equalToEmptyIterable() {
+        final IterableOf<Integer> iterable = new IterableOf<>();
+        new Assertion<>(
+            "Empty Iterable must be equal to empty Iterable",
+            () -> iterable,
+            new IsEqual<>(new IterableOf<>())
+        ).affirm();
+    }
+
+    @Test
+    public void differentHashCode() {
+        final IterableOf<Integer> first = new IterableOf<>(1, 2);
+        final IterableOf<Integer> second = new IterableOf<>(2, 1);
+        new Assertion<>(
+            "hashCode is equal for Iterables with different content",
+            first::hashCode,
+            new IsNot<>(new IsEqual<>(second.hashCode()))
+        ).affirm();
+    }
+
+    @Test
+    public void equalHashCode() {
+        final IterableOf<Integer> iterable = new IterableOf<>(1, 2);
+        new Assertion<>(
+            "hashCode is different for Iterables with equal content",
+            iterable::hashCode,
+            new IsEqual<>(new IterableOf<>(1, 2).hashCode())
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/iterable/IterableEnvelopeTest.java
+++ b/src/test/java/org/cactoos/iterable/IterableEnvelopeTest.java
@@ -108,7 +108,7 @@ public final class IterableEnvelopeTest {
         final IterableOf<Integer> first = new IterableOf<>(1, 2);
         final IterableOf<Integer> second = new IterableOf<>(2, 1);
         new Assertion<>(
-            "hashCode is equal for Iterables with different content",
+            "Must have different hashCode for Iterables with different content",
             first::hashCode,
             new IsNot<>(new IsEqual<>(second.hashCode()))
         ).affirm();
@@ -118,7 +118,7 @@ public final class IterableEnvelopeTest {
     public void equalHashCode() {
         final IterableOf<Integer> iterable = new IterableOf<>(1, 2);
         new Assertion<>(
-            "hashCode is different for Iterables with equal content",
+            "Must have equal hashCode for Iterables with equal content",
             iterable::hashCode,
             new IsEqual<>(new IterableOf<>(1, 2).hashCode())
         ).affirm();

--- a/src/test/java/org/cactoos/iterable/IterableOfTest.java
+++ b/src/test/java/org/cactoos/iterable/IterableOfTest.java
@@ -25,13 +25,11 @@ package org.cactoos.iterable;
 
 import java.util.Iterator;
 import org.cactoos.iterator.IteratorOf;
-import org.cactoos.list.ListOf;
 import org.cactoos.scalar.LengthOf;
 import org.cactoos.scalar.Ternary;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.hamcrest.collection.IsIterableContainingInOrder;
 import org.hamcrest.collection.IsIterableWithSize;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
@@ -81,10 +79,6 @@ public final class IterableOfTest {
         );
     }
 
-    // @todo #971:30min Implement equals() and hashCode() on IterableEnvelope.
-    //  Then, refactor this test so that only
-    //  `new IsEqual<>(new Joined<>(first, second, third))` is required as a
-    //  matcher.
     @Test
     @SuppressWarnings({"unchecked", "PMD.AvoidDuplicateLiterals"})
     public void containAllPagedContentInOrder() throws Exception {
@@ -105,15 +99,7 @@ public final class IterableOfTest {
                     () -> new IteratorOf<String>()
                 ).value()
             ),
-            new IsIterableContainingInOrder<>(
-                new ListOf<>(
-                    new IsEqual<>("one"),
-                    new IsEqual<>("two"),
-                    new IsEqual<>("three"),
-                    new IsEqual<>("four"),
-                    new IsEqual<>("five")
-                )
-            )
+            new IsEqual<>(new Joined<>(first, second, third))
         );
     }
 


### PR DESCRIPTION
PR for #1037 
I added equals() and hashCode() to IterableEnvelope.