### PR TITLE
(#1063) All classes implementing Text need to be refactored to extend TextEnvelope

### DIFF
--- a/src/main/java/org/cactoos/text/Abbreviated.java
+++ b/src/main/java/org/cactoos/text/Abbreviated.java
@@ -23,6 +23,7 @@
  */
 package org.cactoos.text;
 
+import org.cactoos.Scalar;
 import org.cactoos.Text;
 
 /**
@@ -31,11 +32,8 @@ import org.cactoos.Text;
  * <p>There is no thread-safety guarantee.
  *
  * @since 0.29
- * @todo #897:30min All classes implementing Text need to be refactored
- *  to extend TextEnvelope - asString() should be removed and implementation
- *  from TextEnvelope should be used.
  */
-public final class Abbreviated implements Text {
+public final class Abbreviated extends TextEnvelope {
 
     /**
      * The default max line width.
@@ -46,16 +44,6 @@ public final class Abbreviated implements Text {
      * The ellipses width.
      */
     private static final int ELLIPSES_WIDTH = 3;
-
-    /**
-     * The origin Text.
-     */
-    private final Text origin;
-
-    /**
-     * The max width of the resulting string.
-     */
-    private final int width;
 
     /**
      * Ctor.
@@ -94,26 +82,26 @@ public final class Abbreviated implements Text {
      * @param text The Text
      * @param max Max width of the result string
      */
+    @SuppressWarnings({
+        "PMD.CallSuperInConstructor",
+        "PMD.ConstructorOnlyInitializesOrCallOtherConstructors"
+        })
     public Abbreviated(final Text text, final int max) {
-        this.origin = text;
-        this.width = max;
-    }
-
-    @Override
-    public String asString() throws Exception {
-        final Text abbreviated;
-        if (this.origin.asString().length() <= this.width) {
-            abbreviated = this.origin;
-        } else {
-            abbreviated = new FormattedText(
-                "%s...",
-                new Sub(
-                    this.origin,
-                    0,
-                    this.width - Abbreviated.ELLIPSES_WIDTH
-                ).asString()
-            );
-        }
-        return abbreviated.asString();
+        super((Scalar<String>) () -> {
+            final Text abbreviated;
+            if (text.asString().length() <= max) {
+                abbreviated = text;
+            } else {
+                abbreviated = new FormattedText(
+                    "%s...",
+                    new Sub(
+                        text,
+                        0,
+                        max - Abbreviated.ELLIPSES_WIDTH
+                    ).asString()
+                );
+            }
+            return abbreviated.asString();
+        });
     }
 }

--- a/src/main/java/org/cactoos/text/FormattedText.java
+++ b/src/main/java/org/cactoos/text/FormattedText.java
@@ -36,6 +36,10 @@ import org.cactoos.list.ListOf;
  * <p>There is no thread-safety guarantee.
  *
  * @since 0.1
+ * @todo #1063:30min All classes implementing Text need to be refactored
+ *  to extend TextEnvelope - asString() should be removed and implementation
+ *  from TextEnvelope should be used. This to-do should be moved to another
+ *  class which need to be refactored.
  */
 public final class FormattedText implements Text {
 


### PR DESCRIPTION
This is for #1063 

I replaced implementing Text with extending TextEnvelope and moved logic from asString to constructor.
