### PR TITLE
(#1033) Replace use of MatcherAssert.assertThat with Assertion from cactoos-matchers

### DIFF
--- a/src/main/java/org/cactoos/io/package-info.java
+++ b/src/main/java/org/cactoos/io/package-info.java
@@ -26,5 +26,9 @@
  * Input/Output.
  *
  * @since 0.1
+ * @todo #1033:30min Continue replacing usage of MatcherAssert.assertThat with
+ *  Assertion from cactoos-matchers. Once there is no more usage of
+ *  MatcherAssert.assertThat, add the signature of MatcherAssert.assertThat to
+ *  forbidden-apis.txt
  */
 package org.cactoos.io;

--- a/src/test/java/org/cactoos/TextTest.java
+++ b/src/test/java/org/cactoos/TextTest.java
@@ -25,7 +25,6 @@ package org.cactoos;
 
 import org.cactoos.text.NoNulls;
 import org.cactoos.text.TextOf;
-import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.TextHasString;
@@ -65,13 +64,13 @@ public final class TextTest {
     @Test
     public void okForNoNulls() {
         final String message = "Hello";
-        MatcherAssert.assertThat(
-            "Can't work with null text",
-            new NoNulls(
+        new Assertion<>(
+            "Must work with NoNulls",
+            () -> new NoNulls(
                 new TextOf(message)
             ),
             new TextHasString(message)
-        );
+        ).affirm();
     }
 
 }

--- a/src/test/java/org/cactoos/io/LSInputOfTest.java
+++ b/src/test/java/org/cactoos/io/LSInputOfTest.java
@@ -23,9 +23,9 @@
  */
 package org.cactoos.io;
 
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 
 /**
  * Test case for {@link LSInputOf}.
@@ -38,41 +38,41 @@ public final class LSInputOfTest {
 
     @Test
     public void readsSimpleInput() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't read simple input",
-            new LSInputOf(
+            () -> new LSInputOf(
                 new InputOf("hello, world!")
             ).getStringData(),
             Matchers.endsWith("world!")
-        );
+        ).affirm();
     }
 
     @Test
     public void readsBiggerInput() {
         final int size = 400_000;
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't read bigger input",
-            new LSInputOf(
+            () -> new LSInputOf(
                 new InputOf(
                     new SlowInputStream(size)
                 )
             ).getStringData().length(),
             Matchers.equalTo(size)
-        );
+        ).affirm();
     }
 
     @Test
     public void countsBytesInBiggerInput() {
         final int size = 300_000;
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't count bytes in a bigger input",
-            new LSInputOf(
+            () -> new LSInputOf(
                 new InputOf(
                     new SlowInputStream(size)
                 )
             ).getStringData().length(),
             Matchers.equalTo(size)
-        );
+        ).affirm();
     }
 
 }

--- a/src/test/java/org/cactoos/io/TeeInputFromReaderTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputFromReaderTest.java
@@ -27,10 +27,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.cactoos.text.TextOf;
-import org.hamcrest.MatcherAssert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.TeeInputHasResult;
 
 /**
@@ -54,8 +54,9 @@ public final class TeeInputFromReaderTest {
         final String input =
             "Hello, товарищ file #1 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
-            new TeeInput(
+        new Assertion<>(
+            "Must copy from reader to file.",
+            () -> new TeeInput(
                 new ReaderOf(input),
                 output
             ),
@@ -63,7 +64,7 @@ public final class TeeInputFromReaderTest {
                 input,
                 new TextOf(output)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -71,8 +72,9 @@ public final class TeeInputFromReaderTest {
         final String input =
             "Hello, товарищ file #2 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
-            new TeeInput(
+        new Assertion<>(
+            "Must copy from reader with size to file.",
+            () -> new TeeInput(
                 new ReaderOf(input),
                 output,
                 input.length()
@@ -81,7 +83,7 @@ public final class TeeInputFromReaderTest {
                 input,
                 new TextOf(output)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -89,8 +91,9 @@ public final class TeeInputFromReaderTest {
         final String input =
             "Hello, товарищ file #3 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
-            new TeeInput(
+        new Assertion<>(
+            "Must copy from reader with charset to file.",
+            () -> new TeeInput(
                 new ReaderOf(input),
                 output,
                 StandardCharsets.UTF_8
@@ -99,7 +102,7 @@ public final class TeeInputFromReaderTest {
                 input,
                 new TextOf(output)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -107,8 +110,9 @@ public final class TeeInputFromReaderTest {
         final String input =
             "Hello, товарищ file #4 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
-            new TeeInput(
+        new Assertion<>(
+            "Must copy from reader with charset and size to file.",
+            () -> new TeeInput(
                 new ReaderOf(input),
                 output,
                 StandardCharsets.UTF_8,
@@ -118,7 +122,7 @@ public final class TeeInputFromReaderTest {
                 input,
                 new TextOf(output)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -126,8 +130,9 @@ public final class TeeInputFromReaderTest {
         final String input =
             "Hello, товарищ file #5 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
-            new TeeInput(
+        new Assertion<>(
+            "Must copy from reader with charset by name to file.",
+            () -> new TeeInput(
                 new ReaderOf(input),
                 output,
                 StandardCharsets.UTF_8.name()
@@ -136,7 +141,7 @@ public final class TeeInputFromReaderTest {
                 input,
                 new TextOf(output)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -145,8 +150,9 @@ public final class TeeInputFromReaderTest {
         final String input =
             "Hello, товарищ file #6 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
-            new TeeInput(
+        new Assertion<>(
+            "Must copy from reader with charset by name and size to file.",
+            () -> new TeeInput(
                 new ReaderOf(input),
                 output,
                 StandardCharsets.UTF_8.name(),
@@ -156,7 +162,7 @@ public final class TeeInputFromReaderTest {
                 input,
                 new TextOf(output)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -164,8 +170,9 @@ public final class TeeInputFromReaderTest {
         final String input =
             "Hello, товарищ path #1 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
-            new TeeInput(
+        new Assertion<>(
+            "Must copy from reader to path.",
+            () -> new TeeInput(
                 new ReaderOf(input),
                 output.toPath()
             ),
@@ -173,7 +180,7 @@ public final class TeeInputFromReaderTest {
                 input,
                 new TextOf(output)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -181,8 +188,9 @@ public final class TeeInputFromReaderTest {
         final String input =
             "Hello, товарищ path #2 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
-            new TeeInput(
+        new Assertion<>(
+            "Must copy from reader with size to path",
+            () -> new TeeInput(
                 new ReaderOf(input),
                 output.toPath(),
                 input.length()
@@ -191,7 +199,7 @@ public final class TeeInputFromReaderTest {
                 input,
                 new TextOf(output)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -199,8 +207,9 @@ public final class TeeInputFromReaderTest {
         final String input =
             "Hello, товарищ path #3 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
-            new TeeInput(
+        new Assertion<>(
+            "Must copy from reader with charset to path.",
+            () -> new TeeInput(
                 new ReaderOf(input),
                 output.toPath(),
                 StandardCharsets.UTF_8
@@ -209,7 +218,7 @@ public final class TeeInputFromReaderTest {
                 input,
                 new TextOf(output)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -217,8 +226,9 @@ public final class TeeInputFromReaderTest {
         final String input =
             "Hello, товарищ path #4 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
-            new TeeInput(
+        new Assertion<>(
+            "Must copy from reader with charset and size to path.",
+            () -> new TeeInput(
                 new ReaderOf(input),
                 output.toPath(),
                 StandardCharsets.UTF_8,
@@ -228,7 +238,7 @@ public final class TeeInputFromReaderTest {
                 input,
                 new TextOf(output)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -236,8 +246,9 @@ public final class TeeInputFromReaderTest {
         final String input =
             "Hello, товарищ path #5 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
-            new TeeInput(
+        new Assertion<>(
+            "Must copy from reader with charset by name to path.",
+            () -> new TeeInput(
                 new ReaderOf(input),
                 output.toPath(),
                 StandardCharsets.UTF_8.name()
@@ -246,7 +257,7 @@ public final class TeeInputFromReaderTest {
                 input,
                 new TextOf(output)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -255,8 +266,9 @@ public final class TeeInputFromReaderTest {
         final String input =
             "Hello, товарищ path #6 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
-            new TeeInput(
+        new Assertion<>(
+            "Must copy from reader with charset by name and size to path.",
+            () -> new TeeInput(
                 new ReaderOf(input),
                 output.toPath(),
                 StandardCharsets.UTF_8.name(),
@@ -266,7 +278,7 @@ public final class TeeInputFromReaderTest {
                 input,
                 new TextOf(output)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -274,8 +286,9 @@ public final class TeeInputFromReaderTest {
         final String input =
             "Hello, товарищ output #1 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
-            new TeeInput(
+        new Assertion<>(
+            "Must copy from reader to output.",
+            () -> new TeeInput(
                 new ReaderOf(input),
                 new OutputTo(output)
             ),
@@ -283,7 +296,7 @@ public final class TeeInputFromReaderTest {
                 input,
                 new TextOf(output)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -291,8 +304,9 @@ public final class TeeInputFromReaderTest {
         final String input =
             "Hello, товарищ output #2 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
-            new TeeInput(
+        new Assertion<>(
+            "Must copy from reader with size to output.",
+            () -> new TeeInput(
                 new ReaderOf(input),
                 new OutputTo(output),
                 input.length()
@@ -301,7 +315,7 @@ public final class TeeInputFromReaderTest {
                 input,
                 new TextOf(output)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -309,8 +323,9 @@ public final class TeeInputFromReaderTest {
         final String input =
             "Hello, товарищ output #3 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
-            new TeeInput(
+        new Assertion<>(
+            "Must copy from reader with charset to output.",
+            () -> new TeeInput(
                 new ReaderOf(input),
                 new OutputTo(output),
                 StandardCharsets.UTF_8
@@ -319,7 +334,7 @@ public final class TeeInputFromReaderTest {
                 input,
                 new TextOf(output)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -328,8 +343,9 @@ public final class TeeInputFromReaderTest {
         final String input =
             "Hello, товарищ output #4 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
-            new TeeInput(
+        new Assertion<>(
+            "Must copy from reader with charset and size to output.",
+            () -> new TeeInput(
                 new ReaderOf(input),
                 new OutputTo(output),
                 StandardCharsets.UTF_8,
@@ -339,7 +355,7 @@ public final class TeeInputFromReaderTest {
                 input,
                 new TextOf(output)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -347,8 +363,9 @@ public final class TeeInputFromReaderTest {
         final String input =
             "Hello, товарищ output #5 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
-            new TeeInput(
+        new Assertion<>(
+            "Must copy from reader with charset by name to output.",
+            () -> new TeeInput(
                 new ReaderOf(input),
                 new OutputTo(output),
                 StandardCharsets.UTF_8.name()
@@ -357,7 +374,7 @@ public final class TeeInputFromReaderTest {
                 input,
                 new TextOf(output)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -366,8 +383,9 @@ public final class TeeInputFromReaderTest {
         final String input =
             "Hello, товарищ output #6 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
-            new TeeInput(
+        new Assertion<>(
+            "Must copy from reader with charset by name and size to output.",
+            () -> new TeeInput(
                 new ReaderOf(input),
                 new OutputTo(output),
                 StandardCharsets.UTF_8.name(),
@@ -377,6 +395,6 @@ public final class TeeInputFromReaderTest {
                 input,
                 new TextOf(output)
             )
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/io/TeeInputFromUriTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputFromUriTest.java
@@ -28,10 +28,10 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import org.cactoos.text.TextOf;
-import org.hamcrest.MatcherAssert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.TeeInputHasResult;
 
 /**
@@ -59,8 +59,9 @@ public final class TeeInputFromUriTest {
             message.getBytes(StandardCharsets.UTF_8)
         );
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
-            new TeeInput(
+        new Assertion<>(
+            "Must copy from URI to path.",
+            () -> new TeeInput(
                 input.toURI(),
                 output
             ),
@@ -68,7 +69,7 @@ public final class TeeInputFromUriTest {
                 message,
                 new TextOf(output)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -81,8 +82,9 @@ public final class TeeInputFromUriTest {
             message.getBytes(StandardCharsets.UTF_8)
         );
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
-            new TeeInput(
+        new Assertion<>(
+            "Must copy from URI to file.",
+            () -> new TeeInput(
                 input.toURI(),
                 output
             ),
@@ -90,7 +92,7 @@ public final class TeeInputFromUriTest {
                 message,
                 new TextOf(output)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -103,8 +105,9 @@ public final class TeeInputFromUriTest {
             message.getBytes(StandardCharsets.UTF_8)
         );
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
-            new TeeInput(
+        new Assertion<>(
+            "Must copy from URI to output.",
+            () -> new TeeInput(
                 input.toURI(),
                 new OutputTo(output)
             ),
@@ -112,6 +115,6 @@ public final class TeeInputFromUriTest {
                 message,
                 new TextOf(output)
             )
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/io/TeeInputFromUrlTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputFromUrlTest.java
@@ -28,10 +28,10 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import org.cactoos.text.TextOf;
-import org.hamcrest.MatcherAssert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.TeeInputHasResult;
 
 /**
@@ -59,8 +59,9 @@ public final class TeeInputFromUrlTest {
             message.getBytes(StandardCharsets.UTF_8)
         );
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
-            new TeeInput(
+        new Assertion<>(
+            "Must copy from URL to path.",
+            () -> new TeeInput(
                 input
                     .toURI()
                     .toURL(),
@@ -70,7 +71,7 @@ public final class TeeInputFromUrlTest {
                 message,
                 new TextOf(output)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -83,8 +84,9 @@ public final class TeeInputFromUrlTest {
             message.getBytes(StandardCharsets.UTF_8)
         );
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
-            new TeeInput(
+        new Assertion<>(
+            "Must copy from URL to file.",
+            () -> new TeeInput(
                 input
                     .toURI()
                     .toURL(),
@@ -94,7 +96,7 @@ public final class TeeInputFromUrlTest {
                 message,
                 new TextOf(output)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -107,8 +109,9 @@ public final class TeeInputFromUrlTest {
             message.getBytes(StandardCharsets.UTF_8)
         );
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
-            new TeeInput(
+        new Assertion<>(
+            "Must copy from URL to output.",
+            () -> new TeeInput(
                 input
                     .toURI()
                     .toURL(),
@@ -118,6 +121,6 @@ public final class TeeInputFromUrlTest {
                 message,
                 new TextOf(output)
             )
-        );
+        ).affirm();
     }
 }


### PR DESCRIPTION
This is for #1033.

I replaced some of the `MatcherAssert#assertThat` usages with `Assertion` from cactoos-matchers. There is still a lot code to replace - I added a `@todo` for that.