### PR TITLE
(#1112) Speed up unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,10 +100,11 @@ The MIT License (MIT)
       <plugins>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.7.0</version>
+          <version>3.8.0</version>
           <configuration>
             <source>1.8</source>
             <target>1.8</target>
+            <useIncrementalCompilation>false</useIncrementalCompilation>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
PR for #1112:

* Speed up ThreadsTest by shortening sleep durations, reducing number of threads, and deleting an unnecessary test  (this shaved off ~20s in my tests)
* Stop recompiling all source files due to [bug](https://issues.apache.org/jira/browse/MCOMPILER-209) in maven-compiler-plugin (this shaved off ~10s in my tests, now "only" recompiles 14 files for some reason)
* Left puzzle to continue speeding up `mvn test`

Duration after above changes (the timing keeps varying and is not all that reliable):
```
llorllale:~/dev/java/cactoos$ time mvn test
   ...lots of stuff...
[INFO] --- maven-compiler-plugin:3.8.0:compile (default-compile) @ cactoos ---
[INFO] Compiling 14 source files to /home/llorllale/dev/java/cactoos/target/classes
   ... lots of stuff...
Tests run: 1196, Failures: 0, Errors: 0, Skipped: 2

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 9.212 s
[INFO] Finished at: 2019-04-22T21:39:29-04:00
[INFO] Final Memory: 21M/256M
[INFO] ------------------------------------------------------------------------

real    0m10.920s
user    0m39.056s
sys     0m5.240s
```
