### PR TITLE
(#1048) Refactor GzipInput and GzipOutput tests to be more readable

### DIFF
--- a/src/test/java/org/cactoos/io/GzipInputTest.java
+++ b/src/test/java/org/cactoos/io/GzipInputTest.java
@@ -24,38 +24,47 @@
 
 package org.cactoos.io;
 
+import java.io.BufferedWriter;
+import java.io.ByteArrayOutputStream;
 import java.io.EOFException;
-import java.util.zip.GZIPInputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.util.zip.GZIPOutputStream;
 import org.cactoos.scalar.LengthOf;
 import org.cactoos.text.TextOf;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 
 /**
  * Test case for {@link org.cactoos.io.GzipInput}.
  * @since 0.29
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class GzipInputTest {
 
     @Test
     public void readFromGzipInput() throws Exception {
-        final byte[] bytes = {
-            (byte) GZIPInputStream.GZIP_MAGIC,
-            -117, 8, 0, 0, 0,
-            0, 0, 0, 0, -13,
-            72, -51, -55, -55, 87,
-            4, 0, 86, -52, 42,
-            -99, 6, 0, 0, 0,
-        };
-        MatcherAssert.assertThat(
+        final String content = "Hello!";
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (
+            Writer writer = new BufferedWriter(
+                new OutputStreamWriter(
+                    new GZIPOutputStream(out)
+                )
+            )
+        ) {
+            writer.write(content);
+        }
+        final byte[] bytes = out.toByteArray();
+        new Assertion<>(
             "Can't read from a gzip input",
-            new TextOf(
+            () -> new TextOf(
                 new GzipInput(new InputOf(bytes))
             ).asString(),
-            Matchers.equalTo("Hello!")
-        );
+            new IsEqual<>(content)
+        ).affirm();
     }
 
     @Test(expected = EOFException.class)

--- a/src/test/java/org/cactoos/io/GzipInputTest.java
+++ b/src/test/java/org/cactoos/io/GzipInputTest.java
@@ -43,13 +43,11 @@ public final class GzipInputTest {
     public void readFromGzipInput() throws Exception {
         final byte[] bytes = {
             (byte) GZIPInputStream.GZIP_MAGIC,
-            // @checkstyle MagicNumberCheck (1 line)
-            (byte) (GZIPInputStream.GZIP_MAGIC >> 8), (byte) 0x08,
-            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
-            (byte) 0x00, (byte) 0x00, (byte) 0xF3, (byte) 0x48, (byte) 0xCD,
-            (byte) 0xC9, (byte) 0xC9, (byte) 0x57, (byte) 0x04, (byte) 0x00,
-            (byte) 0x56, (byte) 0xCC, (byte) 0x2A, (byte) 0x9D, (byte) 0x06,
-            (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            -117, 8, 0, 0, 0,
+            0, 0, 0, 0, -13,
+            72, -51, -55, -55, 87,
+            4, 0, 86, -52, 42,
+            -99, 6, 0, 0, 0,
         };
         MatcherAssert.assertThat(
             "Can't read from a gzip input",

--- a/src/test/java/org/cactoos/io/GzipOutputTest.java
+++ b/src/test/java/org/cactoos/io/GzipOutputTest.java
@@ -53,13 +53,11 @@ public final class GzipOutputTest {
     public void writeToGzipOutput() throws Exception {
         final byte[] bytes = {
             (byte) GZIPInputStream.GZIP_MAGIC,
-            // @checkstyle MagicNumberCheck (1 line)
-            (byte) (GZIPInputStream.GZIP_MAGIC >> 8), (byte) 0x08,
-            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
-            (byte) 0x00, (byte) 0x00, (byte) 0xF3, (byte) 0x48, (byte) 0xCD,
-            (byte) 0xC9, (byte) 0xC9, (byte) 0x57, (byte) 0x04, (byte) 0x00,
-            (byte) 0x56, (byte) 0xCC, (byte) 0x2A, (byte) 0x9D, (byte) 0x06,
-            (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            -117, 8, 0, 0, 0,
+            0, 0, 0, 0, -13,
+            72, -51, -55, -55, 87,
+            4, 0, 86, -52, 42,
+            -99, 6, 0, 0, 0,
         };
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (final OutputStream output = new GzipOutput(


### PR DESCRIPTION
This if for #1048 
I replaced data bytes with simple numbers