### PR TITLE
(#1095) ItemAt always takes the iterable/iterator last

### DIFF
--- a/src/main/java/org/cactoos/scalar/ItemAt.java
+++ b/src/main/java/org/cactoos/scalar/ItemAt.java
@@ -50,43 +50,6 @@ public final class ItemAt<T> implements Scalar<T> {
     /**
      * Ctor.
      *
-     * @param iterable Iterable
-     */
-    public ItemAt(final Iterable<T> iterable) {
-        this(
-            itr -> {
-                throw new IOException("The iterable is empty");
-            },
-            iterable
-        );
-    }
-
-    /**
-     * Ctor.
-     *
-     * @param fallback Fallback value
-     * @param iterable Iterable
-     */
-    public ItemAt(final Scalar<T> fallback, final Iterable<T> iterable) {
-        this(new FuncOf<>(fallback), iterable);
-    }
-
-    /**
-     * Ctor.
-     *
-     * @param fallback Fallback value
-     * @param iterable Iterable
-     */
-    public ItemAt(
-        final Func<Iterable<T>, T> fallback,
-        final Iterable<T> iterable
-    ) {
-        this(0, fallback, iterable);
-    }
-
-    /**
-     * Ctor.
-     *
      * @param position Position
      * @param iterable Iterable
      */

--- a/src/test/java/org/cactoos/iterable/CycledTest.java
+++ b/src/test/java/org/cactoos/iterable/CycledTest.java
@@ -29,6 +29,7 @@ import org.cactoos.scalar.LengthOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.ScalarHasValue;
 
 /**
@@ -39,11 +40,11 @@ import org.llorllale.cactoos.matchers.ScalarHasValue;
 public final class CycledTest {
 
     @Test
-    public void repeatIterableTest() throws Exception {
+    public void repeatIterableTest() {
         final String expected = "two";
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't repeat iterable",
-            new ItemAt<>(
+            () -> new ItemAt<>(
                 // @checkstyle MagicNumberCheck (1 line)<
                 7, new Cycled<>(
                     new IterableOf<>(
@@ -54,7 +55,7 @@ public final class CycledTest {
             new ScalarHasValue<>(
                 expected
             )
-        );
+        ).affirm();
     }
 
     @Test

--- a/src/test/java/org/cactoos/iterator/CycledTest.java
+++ b/src/test/java/org/cactoos/iterator/CycledTest.java
@@ -28,8 +28,8 @@ import java.util.NoSuchElementException;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.NoNulls;
 import org.cactoos.scalar.ItemAt;
-import org.hamcrest.MatcherAssert;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.ScalarHasValue;
 
 /**
@@ -42,9 +42,11 @@ public final class CycledTest {
     @Test
     public void repeatIteratorTest() throws Exception {
         final String expected = "two";
-        MatcherAssert.assertThat(
-            "Can't repeat iterator",
-            new ItemAt<>(
+        new Assertion<>(
+            "must repeat iterator",
+            () -> new ItemAt<>(
+                // @checkstyle MagicNumberCheck (1 line)
+                7,
                 new IterableOf<>(
                     new Cycled<>(
                         new NoNulls<>(
@@ -53,14 +55,12 @@ public final class CycledTest {
                             )
                         )
                     )
-                ),
-                // @checkstyle MagicNumberCheck (1 line)
-                7
+                )
             ),
             new ScalarHasValue<>(
                 expected
             )
-        );
+        ).affirm();
     }
 
     @Test(expected = NoSuchElementException.class)

--- a/src/test/java/org/cactoos/scalar/ItemAtTest.java
+++ b/src/test/java/org/cactoos/scalar/ItemAtTest.java
@@ -24,137 +24,172 @@
 package org.cactoos.scalar;
 
 import java.io.IOException;
-import java.util.Collections;
 import org.cactoos.iterable.IterableOf;
-import org.cactoos.list.ListOf;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.ScalarHasValue;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test Case for {@link ItemAt}.
+ *
  * @since 0.7
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-@SuppressWarnings("PMD.TooManyMethods")
+@SuppressWarnings({ "PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals" })
 public final class ItemAtTest {
 
     @Test
-    public void firstElementIterableTest() throws Exception {
-        MatcherAssert.assertThat(
-            "Can't take the first item from the iterable",
-            new ItemAt<>(
+    public void firstElementIterableTest() {
+        new Assertion<>(
+            "must take the first item from the iterable",
+            () -> new ItemAt<>(
                 // @checkstyle MagicNumber (1 line)
                 new IterableOf<>(1, 2, 3)
             ),
             new ScalarHasValue<>(1)
-        );
+        ).affirm();
     }
 
     @Test
-    public void elementByPosIterableTest() throws Exception {
-        MatcherAssert.assertThat(
-            "Can't take the item by position from the iterable",
-            new ItemAt<>(
+    public void elementByPosIterableTest() {
+        new Assertion<>(
+            "must take the item by position from the iterable",
+            () -> new ItemAt<>(
                 // @checkstyle MagicNumber (1 line)
                 1, new IterableOf<>(1, 2, 3)
             ),
             new ScalarHasValue<>(2)
-        );
-    }
-
-    @Test(expected = IOException.class)
-    public void failForEmptyIterableTest() throws Exception {
-        new ItemAt<>(Collections.emptyList()).value();
+        ).affirm();
     }
 
     @Test
-    public void fallbackIterableTest() throws Exception {
+    public void failForEmptyIterableTest() {
+        new Assertion<>(
+            "Must fail for empty iterable",
+            () -> new ItemAt<>(new IterableOf<>()).value(),
+            new Throws<>("The iterable is empty", IOException.class)
+        ).affirm();
+    }
+
+    @Test
+    public void fallbackIterableTest() {
         final String fallback = "default";
-        MatcherAssert.assertThat(
-            "Can't fallback to default one",
-            new ItemAt<>(
-                fallback, Collections.emptyList()
+        new Assertion<>(
+            "must fallback to default one",
+            () -> new ItemAt<>(
+                () -> fallback,
+                new IterableOf<>()
             ),
             new ScalarHasValue<>(fallback)
-        );
+        ).affirm();
     }
 
     @Test
-    public void firstElementTest() throws Exception {
-        MatcherAssert.assertThat(
-            "Can't take the first item from the iterator",
-            new ItemAt<>(
+    public void elementByPosFallbackIterableTest() {
+        final int fallback = 5;
+        new Assertion<>(
+            "must fallback to default one",
+            () -> new ItemAt<>(
+                1, fallback, new IterableOf<>()
+            ),
+            new ScalarHasValue<>(fallback)
+        ).affirm();
+    }
+
+    @Test
+    public void elementByPosNoFallbackIterableTest() {
+        new Assertion<>(
+            "must take the item by position from the iterable",
+            () -> new ItemAt<>(
+                // @checkstyle MagicNumber (1 line)
+                1, 5, new IterableOf<>(0, 1)
+            ),
+            new ScalarHasValue<>(1)
+        ).affirm();
+    }
+
+    @Test
+    public void firstElementTest() {
+        new Assertion<>(
+            "must take the first item from the iterator",
+            () -> new ItemAt<>(
                 // @checkstyle MagicNumber (1 line)
                 new IterableOf<>(1, 2, 3)
             ),
             new ScalarHasValue<>(1)
-        );
+        ).affirm();
     }
 
     @Test
-    public void elementByPosTest() throws Exception {
-        MatcherAssert.assertThat(
-            "Can't take the item by position from the iterator",
-            new ItemAt<>(
+    public void elementByPosTest() {
+        new Assertion<>(
+            "must take the item by position from the iterator",
+            () -> new ItemAt<>(
+                1,
                 // @checkstyle MagicNumber (1 line)
-                new IterableOf<>(1, 2, 3),
-                1
+                new IterableOf<>(1, 2, 3)
             ),
             new ScalarHasValue<>(2)
-        );
-    }
-
-    @Test(expected = IOException.class)
-    public void failForEmptyCollectionTest() throws Exception {
-        new ItemAt<>(new ListOf<>()).value();
-    }
-
-    @Test(expected = IOException.class)
-    public void failForNegativePositionTest() throws Exception {
-        new ItemAt<>(
-            // @checkstyle MagicNumber (1 line)
-            new IterableOf<>(1, 2, 3),
-            -1
-        ).value();
+        ).affirm();
     }
 
     @Test
-    public void fallbackTest() throws Exception {
-        final String fallback = "fallback";
-        MatcherAssert.assertThat(
-            "Can't fallback to default value",
-            new ItemAt<>(
-                new ListOf<>(),
-                fallback
-            ),
-            new ScalarHasValue<>(fallback)
-        );
+    public void failForNegativePositionTest() {
+        new Assertion<>(
+            "Must fail for negative position",
+            () -> new ItemAt<>(
+                -1,
+                // @checkstyle MagicNumber (1 line)
+                new IterableOf<>(1, 2, 3)
+            ).value(),
+            new Throws<>(
+                "The position must be non-negative: -1",
+                IOException.class
+            )
+        ).affirm();
     }
 
-    @Test(expected = IOException.class)
-    public void failForPosMoreLengthTest() throws Exception {
-        new ItemAt<>(
-            // @checkstyle MagicNumberCheck (2 lines)
-            new IterableOf<>(1, 2, 3),
-            3
-        ).value();
+    @Test
+    public void fallbackTest() {
+        final int fallback = 5;
+        new Assertion<>(
+            "Can't fallback to default value",
+            () -> new ItemAt<>(
+                () -> fallback,
+                new IterableOf<>()
+            ),
+            new ScalarHasValue<>(fallback)
+        ).affirm();
+    }
+
+    @Test
+    public void failForPosMoreLengthTest() {
+        new Assertion<>(
+            "Must fail for greater than length position",
+            () -> new ItemAt<>(
+                // @checkstyle MagicNumberCheck (2 lines)
+                3,
+                new IterableOf<>(1, 2, 3)
+            ).value(),
+            new Throws<>(
+                "The iterable doesn't have the position #3",
+                IOException.class
+            )
+        ).affirm();
     }
 
     @Test
     public void sameValueTest() throws Exception {
         final ItemAt<Integer> item = new ItemAt<>(
-            // @checkstyle MagicNumberCheck (2 lines)
-            new IterableOf<>(1, 2, 3),
-            1
+            1,
+            // @checkstyle MagicNumberCheck (1 lines)
+            new IterableOf<>(1, 2, 3)
         );
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Not the same value",
-            item.value(),
-            Matchers.equalTo(
-                item.value()
-            )
-        );
+            () -> item,
+            new ScalarHasValue<>(item.value())
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/scalar/ItemAtTest.java
+++ b/src/test/java/org/cactoos/scalar/ItemAtTest.java
@@ -40,18 +40,6 @@ import org.llorllale.cactoos.matchers.Throws;
 public final class ItemAtTest {
 
     @Test
-    public void firstElementIterableTest() {
-        new Assertion<>(
-            "must take the first item from the iterable",
-            () -> new ItemAt<>(
-                // @checkstyle MagicNumber (1 line)
-                new IterableOf<>(1, 2, 3)
-            ),
-            new ScalarHasValue<>(1)
-        ).affirm();
-    }
-
-    @Test
     public void elementByPosIterableTest() {
         new Assertion<>(
             "must take the item by position from the iterable",
@@ -60,28 +48,6 @@ public final class ItemAtTest {
                 1, new IterableOf<>(1, 2, 3)
             ),
             new ScalarHasValue<>(2)
-        ).affirm();
-    }
-
-    @Test
-    public void failForEmptyIterableTest() {
-        new Assertion<>(
-            "Must fail for empty iterable",
-            () -> new ItemAt<>(new IterableOf<>()).value(),
-            new Throws<>("The iterable is empty", IOException.class)
-        ).affirm();
-    }
-
-    @Test
-    public void fallbackIterableTest() {
-        final String fallback = "default";
-        new Assertion<>(
-            "must fallback to default one",
-            () -> new ItemAt<>(
-                () -> fallback,
-                new IterableOf<>()
-            ),
-            new ScalarHasValue<>(fallback)
         ).affirm();
     }
 
@@ -104,18 +70,6 @@ public final class ItemAtTest {
             () -> new ItemAt<>(
                 // @checkstyle MagicNumber (1 line)
                 1, 5, new IterableOf<>(0, 1)
-            ),
-            new ScalarHasValue<>(1)
-        ).affirm();
-    }
-
-    @Test
-    public void firstElementTest() {
-        new Assertion<>(
-            "must take the first item from the iterator",
-            () -> new ItemAt<>(
-                // @checkstyle MagicNumber (1 line)
-                new IterableOf<>(1, 2, 3)
             ),
             new ScalarHasValue<>(1)
         ).affirm();
@@ -147,19 +101,6 @@ public final class ItemAtTest {
                 "The position must be non-negative: -1",
                 IOException.class
             )
-        ).affirm();
-    }
-
-    @Test
-    public void fallbackTest() {
-        final int fallback = 5;
-        new Assertion<>(
-            "Can't fallback to default value",
-            () -> new ItemAt<>(
-                () -> fallback,
-                new IterableOf<>()
-            ),
-            new ScalarHasValue<>(fallback)
         ).affirm();
     }
 


### PR DESCRIPTION
This is for #1095, it always put the iterable/iterator last in the constructor

While doing so I:
- removed duplicate constructors
- added extra constructors for simpler fallback and position
- removed constructors taking `Iterator` since I am also assigned #1104 (it's less work to do so than doing both separated, and it's easier to review too).
 
Note that I had to replace the `T` type with a `Scalar<T>` for `fallback` in one constructor to avoid confusion between position and fallback in the two-parameters constructors (in particular when applying to an `Iterable<Integer>`)
An alternative would be to remove all constructor not taking a position (which would make complete sense IMHO).