### PR TITLE
(#1109) Make CollectionEnvelope.toString final and fix Mapped

### DIFF
--- a/src/main/java/org/cactoos/collection/CollectionEnvelope.java
+++ b/src/main/java/org/cactoos/collection/CollectionEnvelope.java
@@ -143,9 +143,8 @@ public abstract class CollectionEnvelope<X> implements Collection<X> {
         );
     }
 
-    // @checkstyle DesignForExtensionCheck (5 lines)
     @Override
-    public String toString() {
+    public final String toString() {
         return this.col.value().toString();
     }
 

--- a/src/main/java/org/cactoos/collection/Mapped.java
+++ b/src/main/java/org/cactoos/collection/Mapped.java
@@ -24,10 +24,8 @@
 package org.cactoos.collection;
 
 import java.util.Collection;
-import java.util.Iterator;
 import org.cactoos.Func;
 import org.cactoos.iterable.IterableOf;
-import org.cactoos.text.TextOf;
 
 /**
  * Mapped collection.
@@ -38,13 +36,6 @@ import org.cactoos.text.TextOf;
  * @param <Y> Type of target item
  * @since 0.14
  */
-@SuppressWarnings
-    (
-        {
-            "PMD.TooManyMethods", "PMD.CyclomaticComplexity",
-            "PMD.StdCyclomaticComplexity", "PMD.ModifiedCyclomaticComplexity"
-        }
-    )
 public final class Mapped<X, Y> extends CollectionEnvelope<Y> {
 
     /**
@@ -71,99 +62,10 @@ public final class Mapped<X, Y> extends CollectionEnvelope<Y> {
      * Ctor.
      * @param src Source collection
      * @param fnc Func
-     * @checkstyle AnonInnerLengthCheck (140 lines)
      */
     public Mapped(final Func<X, Y> fnc, final Collection<X> src) {
-        super(() -> new Collection<Y>() {
-            @Override
-            public int size() {
-                return src.size();
-            }
-            @Override
-            public boolean isEmpty() {
-                return src.isEmpty();
-            }
-            @Override
-            public boolean contains(final Object item) {
-                return new CollectionOf<>(
-                    new org.cactoos.iterable.Mapped<>(
-                        fnc, src
-                    )
-                ).contains(item);
-            }
-            @Override
-            public Iterator<Y> iterator() {
-                return new org.cactoos.iterator.Mapped<>(
-                    fnc, src.iterator()
-                );
-            }
-            @Override
-            public Object[] toArray() {
-                return new CollectionOf<>(
-                    new org.cactoos.iterable.Mapped<>(
-                        fnc, src
-                    )
-                ).toArray();
-            }
-            @Override
-            @SuppressWarnings("PMD.UseVarargs")
-            public <T> T[] toArray(final T[] array) {
-                return new CollectionOf<>(
-                    new org.cactoos.iterable.Mapped<>(
-                        fnc, src
-                    )
-                ).toArray(array);
-            }
-
-            @Override
-            public boolean add(final Y item) {
-                throw new UnsupportedOperationException(
-                    "Collection is read-only, can't #add()"
-                );
-            }
-            @Override
-            public boolean remove(final Object item) {
-                throw new UnsupportedOperationException(
-                    "Collection is read-only, can't #remove()"
-                );
-            }
-            @Override
-            public boolean containsAll(final Collection<?> items) {
-                return new CollectionOf<>(
-                    new org.cactoos.iterable.Mapped<>(
-                        fnc, src
-                    )
-                ).containsAll(items);
-            }
-            @Override
-            public boolean addAll(final Collection<? extends Y> items) {
-                throw new UnsupportedOperationException(
-                    "Collection is read-only, can't #addAll()"
-                );
-            }
-            @Override
-            public boolean removeAll(final Collection<?> items) {
-                throw new UnsupportedOperationException(
-                    "Collection is read-only, can't #removeAll()"
-                );
-            }
-            @Override
-            public boolean retainAll(final Collection<?> items) {
-                throw new UnsupportedOperationException(
-                    "Collection is read-only, can't #retainAll()"
-                );
-            }
-            @Override
-            public void clear() {
-                throw new UnsupportedOperationException(
-                    "Collection is read-only, can't #clear()"
-                );
-            }
-        });
-    }
-
-    @Override
-    public String toString() {
-        return new TextOf(this).toString();
+        super(() -> new CollectionOf<>(
+            new org.cactoos.iterable.Mapped<>(fnc, src)
+        ));
     }
 }

--- a/src/test/java/org/cactoos/collection/MappedTest.java
+++ b/src/test/java/org/cactoos/collection/MappedTest.java
@@ -23,19 +23,15 @@
  */
 package org.cactoos.collection;
 
-import java.util.AbstractCollection;
-import java.util.Iterator;
-import org.cactoos.Text;
 import org.cactoos.iterable.IterableOf;
-import org.cactoos.iterator.Endless;
 import org.cactoos.list.ListOf;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.Upper;
-import org.hamcrest.collection.IsCollectionWithSize;
 import org.hamcrest.collection.IsEmptyCollection;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.TextIs;
 
 /**
  * Test case for {@link Mapped}.
@@ -49,8 +45,8 @@ public final class MappedTest {
     @Test
     public void behavesAsCollection() {
         new Assertion<>(
-            "Can't behave as a collection",
-            () -> new Mapped<Integer, Integer>(
+            "Behave as a collection",
+            () -> new Mapped<>(
                 i -> i + 1,
                 new IterableOf<>(-1, 1, 2)
             ),
@@ -59,23 +55,35 @@ public final class MappedTest {
     }
 
     @Test
+    public void transformsArray() {
+        new Assertion<>(
+            "Transforms an array",
+            () -> new Mapped<>(
+                input -> new Upper(new TextOf(input)),
+                "a", "b", "c"
+            ).iterator().next(),
+            new TextIs("A")
+        ).affirm();
+    }
+
+    @Test
     public void transformsList() {
         new Assertion<>(
-            "Can't transform an iterable",
-            () -> new Mapped<String, Text>(
+            "Transforms an iterable",
+            () -> new Mapped<>(
                 input -> new Upper(new TextOf(input)),
                 new IterableOf<>("hello", "world", "друг")
-            ).iterator().next().asString(),
-            new IsEqual<>("HELLO")
+            ).iterator().next(),
+            new TextIs("HELLO")
         ).affirm();
     }
 
     @Test
     public void transformsEmptyList() {
         new Assertion<>(
-            "Can't transform an empty iterable",
-            () -> new Mapped<String, Text>(
-                input -> new Upper(new TextOf(input)),
+            "Transforms an empty iterable",
+            () -> new Mapped<>(
+                (String input) -> new Upper(new TextOf(input)),
                 new ListOf<>()
             ),
             new IsEmptyCollection<>()
@@ -85,34 +93,12 @@ public final class MappedTest {
     @Test
     public void string() {
         new Assertion<>(
-            "Can't convert to string",
-            () -> new Mapped<Integer, Integer>(
+            "Converts to string",
+            () -> new Mapped<>(
                 x -> x * 2,
                 new ListOf<>(1, 2, 3)
             ).toString(),
-            new IsEqual<>("2, 4, 6")
+            new IsEqual<>("[2, 4, 6]")
         ).affirm();
     }
-
-    @Test
-    public void transformsEndlessCollection() {
-        new Assertion<>(
-            "Size must be 1",
-            () -> new Mapped<>(
-                String::trim,
-                new AbstractCollection<String>() {
-                    @Override
-                    public Iterator<String> iterator() {
-                        return new Endless<>("something");
-                    }
-                    @Override
-                    public int size() {
-                        return 1;
-                    }
-                }
-            ),
-            new IsCollectionWithSize<>(new IsEqual<>(1))
-        ).affirm();
-    }
-
 }


### PR DESCRIPTION
This is for #1109: it makes `CollectionEnvelope.toString` final and simplify `Mapped` in the process.

In order for `Mapped` to be simplified, I had to align some of its behaviour with all the other classes of cactoos in the `collection` package (which all delegate to the equivalent `Iterable` implementation of the same behaviour).
I had to remove one of the tests that was making a very strange assumption about it: I believe it was a test that made no sense since it wasn't really testing the expected behaviour of `Mapped` but something about its implementation.