### PR TITLE
(#1115) Speed up more tests

### DIFF
--- a/src/test/java/org/cactoos/experimental/ThreadsTest.java
+++ b/src/test/java/org/cactoos/experimental/ThreadsTest.java
@@ -42,8 +42,6 @@ import org.llorllale.cactoos.matchers.Throws;
  * @since 1.0.0
  * @checkstyle MagicNumberCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @todo #1112:30min Continue speeding up the `mvn test` goal until it
- *  executes in less than 10 seconds, or as fast as reasonably possible.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class ThreadsTest {

--- a/src/test/java/org/cactoos/iterable/SolidTest.java
+++ b/src/test/java/org/cactoos/iterable/SolidTest.java
@@ -71,7 +71,7 @@ public final class SolidTest {
 
     @Test
     public void worksInThreadsMultipleTimes() {
-        for (int count = 0; count < 100; ++count) {
+        for (int count = 0; count < 10; ++count) {
             this.worksInThreads();
         }
     }

--- a/src/test/java/org/cactoos/iterator/SyncedTest.java
+++ b/src/test/java/org/cactoos/iterator/SyncedTest.java
@@ -38,6 +38,14 @@ import org.llorllale.cactoos.matchers.RunsInThreads;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle MagicNumberCheck (500 lines)
  * @checkstyle TodoCommentCheck (500 lines)
+ * @todo #1115:30min Continue speeding up the `mvn test` goal until it
+ *  executes in less than 10 seconds, or as fast as reasonably possible.
+ *  A good solution would be reducing the number of tries to at most 10
+ *  in the two tests below with the for loop. After some manual testing
+ *  to evaluate actual overlaps of threads (see code details in
+ *  https://www.yegor256.com/2018/03/27/how-to-test-thread-safety.html),
+ *  it seems most of the tries results in 0 overlapping thread. This is
+ *  why so much tries are needed in the for loop for the tests to be sound.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class SyncedTest {


### PR DESCRIPTION
This is for #1115.

One more step toward faster tests.
After manually testing the robustness of `RunsInThreads` (using the same method as https://www.yegor256.com/2018/03/27/how-to-test-thread-safety.html), I established that in `org.cactoos.iterable.SolidTest` there was a lot of overlapping threads and thus the number of loops could be reduced.
The results are not so good in `org.cactoos.iterator.SyncedTest` so I added a todo with instruction on how to improve things.

On my machine (2 cpus), before:
```
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 12.567 sec - in org.cactoos.iterable.SolidTest
```

After:
```
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.721 sec - in org.cactoos.iterable.SolidTest
```