### PR TITLE
(#1102) toString() implementation for Immutable iterator

### DIFF
--- a/src/main/java/org/cactoos/iterator/Immutable.java
+++ b/src/main/java/org/cactoos/iterator/Immutable.java
@@ -58,4 +58,8 @@ public final class Immutable<T> implements Iterator<T> {
         return this.iterator.next();
     }
 
+    @Override
+    public String toString() {
+        return this.iterator.toString();
+    }
 }

--- a/src/test/java/org/cactoos/iterator/ImmutableTest.java
+++ b/src/test/java/org/cactoos/iterator/ImmutableTest.java
@@ -91,7 +91,7 @@ public final class ImmutableTest {
         final Iterator<Object> immutable = new Immutable<>(iterator);
         new Assertion<>(
             "must delegate toString to decorated iterator",
-            () -> new TextOf(immutable.toString()),
+            new TextOf(immutable.toString()),
             new TextIs(iterator.toString())
         ).affirm();
     }

--- a/src/test/java/org/cactoos/iterator/ImmutableTest.java
+++ b/src/test/java/org/cactoos/iterator/ImmutableTest.java
@@ -28,15 +28,19 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
 import org.cactoos.text.Randomized;
+import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.TextIs;
 
 /**
  * Test Case for {@link Immutable}.
  *
  * @since 0.32
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class ImmutableTest {
     @Test(expected = UnsupportedOperationException.class)
@@ -69,7 +73,7 @@ public final class ImmutableTest {
     }
 
     @Test
-    public void delegatesToString() {
+    public void decoratesToString() {
         final String string = new Randomized().asString();
         final Iterator<Object> iterator = new Iterator<Object>() {
             public Object next() {
@@ -85,8 +89,10 @@ public final class ImmutableTest {
             }
         };
         final Iterator<Object> immutable = new Immutable<>(iterator);
-        MatcherAssert.assertThat(
-            immutable.toString(), new IsEqual<>(iterator.toString())
-        );
+        new Assertion<>(
+            "must delegate toString to decorated iterator",
+            () -> new TextOf(immutable.toString()),
+            new TextIs(iterator.toString())
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/iterator/ImmutableTest.java
+++ b/src/test/java/org/cactoos/iterator/ImmutableTest.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
+import org.cactoos.text.Randomized;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
@@ -65,5 +66,27 @@ public final class ImmutableTest {
         MatcherAssert.assertThat(immutable.hasNext(), new IsEqual<>(true));
         immutable.next();
         MatcherAssert.assertThat(immutable.hasNext(), new IsEqual<>(false));
+    }
+
+    @Test
+    public void delegatesToString() {
+        final String string = new Randomized().asString();
+        final Iterator<Object> iterator = new Iterator<Object>() {
+            public Object next() {
+                return new Object();
+            }
+
+            public boolean hasNext() {
+                return false;
+            }
+
+            public String toString() {
+                return string;
+            }
+        };
+        final Iterator<Object> immutable = new Immutable<>(iterator);
+        MatcherAssert.assertThat(
+            immutable.toString(), new IsEqual<>(iterator.toString())
+        );
     }
 }


### PR DESCRIPTION
This is for #1102 

As discussed in the issue, `toString()` implementation for `Immutable` should be delegated to its inner iterator. 
