### PR TITLE
(#1143) Using getAbsoluteFile() to fix error for single filename files

### DIFF
--- a/src/main/java/org/cactoos/io/OutputTo.java
+++ b/src/main/java/org/cactoos/io/OutputTo.java
@@ -64,7 +64,7 @@ public final class OutputTo implements Output {
         this(
             () -> {
                 if (mkdirs) {
-                    file.getParentFile().mkdirs();
+                    file.getAbsoluteFile().getParentFile().mkdirs();
                 }
                 return new FileOutputStream(file);
             }


### PR DESCRIPTION
This is for #1143.

There isn't much to say, the issue description already analyzes the problem in detail and suggests a solution. I agree, and applied the simple fix.
I see no way to correctly unit test this, since it would require the creation of a file from a relative path consisting only of the filename, and of course we would want to put such file in a temporary directory, like we do for other tests. However, it seems that [there is no reliable way to accomplish this](https://stackoverflow.com/questions/840190/changing-the-current-working-directory-in-java).