### PR TITLE
(#1119) Remove static matchers from list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@ The MIT License (MIT)
                 <signaturesFile>./src/test/resources/forbidden-apis.txt</signaturesFile>
               </signaturesFiles>
               <!--
-               @todo #1082:30min In the continuation of #588, all the calls
+               @todo #1119:30min In the continuation of #588, all the calls
                 to Matchers should be replaced with their OO counterparts.
                 This todo should be updated with a new one until everything is
                 done. The newly covered classes should be added to the include
@@ -198,6 +198,7 @@ The MIT License (MIT)
                 <include>org/cactoos/map/*.class</include>
                 <include>org/cactoos/time/*.class</include>
                 <include>org/cactoos/collection/*.class</include>
+                <include>org/cactoos/experimental/*.class</include>
               </includes>
             </configuration>
             <executions>

--- a/src/test/java/org/cactoos/list/BehavesAsList.java
+++ b/src/test/java/org/cactoos/list/BehavesAsList.java
@@ -26,9 +26,12 @@ package org.cactoos.list;
 import java.util.List;
 import org.cactoos.collection.BehavesAsCollection;
 import org.hamcrest.Description;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.core.IsNot;
+import org.hamcrest.core.IsNull;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.IsTrue;
+import org.llorllale.cactoos.matchers.MatcherOf;
 
 /**
  * Matcher for collection.
@@ -54,23 +57,31 @@ public final class BehavesAsList<E> extends TypeSafeMatcher<List<E>>  {
 
     @Override
     public boolean matchesSafely(final List<E> list) {
-        MatcherAssert.assertThat(list.get(0), Matchers.notNullValue());
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "must contain at least one non-null element",
+            list.get(0),
+            new IsNot<>(new IsNull<>())
+        ).affirm();
+        new Assertion<>(
+            "must have an index for the sample item",
             list.indexOf(this.sample),
-            Matchers.greaterThanOrEqualTo(0)
-        );
-        MatcherAssert.assertThat(
+            new MatcherOf<>(i -> i >= 0)
+        ).affirm();
+        new Assertion<>(
+            "must have a last index for the sample item",
             list.lastIndexOf(this.sample),
-            Matchers.greaterThanOrEqualTo(0)
-        );
-        MatcherAssert.assertThat(
+            new MatcherOf<>(i -> i >= 0)
+        ).affirm();
+        new Assertion<>(
+            "must have at least one element in list iterator",
             list.listIterator().hasNext(),
-            Matchers.is(true)
-        );
-        MatcherAssert.assertThat(
+            new IsTrue()
+        ).affirm();
+        new Assertion<>(
+            "must have at least one element in sublist iterator",
             list.subList(0, 1).iterator().hasNext(),
-            Matchers.is(true)
-        );
+            new IsTrue()
+        ).affirm();
         return new BehavesAsCollection<E>(this.sample).matchesSafely(list);
     }
 

--- a/src/test/java/org/cactoos/list/JoinedTest.java
+++ b/src/test/java/org/cactoos/list/JoinedTest.java
@@ -24,8 +24,9 @@
 package org.cactoos.list;
 
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.IsTrue;
 
 /**
  * Test case for {@link org.cactoos.collection.Joined}.
@@ -56,7 +57,7 @@ public final class JoinedTest {
                 new ListOf<>(1, 2),
                 new ListOf<>(3, 4)
             ).size(),
-            Matchers.equalTo(4)
+            new IsEqual<>(4)
         );
     }
 
@@ -66,7 +67,7 @@ public final class JoinedTest {
             new Joined<Integer>(
                 new ListOf<Integer>(5, 6)
             ).isEmpty(),
-            Matchers.equalTo(false)
+            new IsEqual<>(false)
         );
     }
 
@@ -78,7 +79,7 @@ public final class JoinedTest {
                 new ListOf<>(7, 8),
                 new ListOf<>(9, element)
             ).contains(element),
-            Matchers.equalTo(true)
+            new IsTrue()
         );
     }
 
@@ -90,7 +91,7 @@ public final class JoinedTest {
                 new ListOf<>(element, "first"),
                 new ListOf<>("second", "third")
             ).iterator().next(),
-            Matchers.equalTo(element)
+            new IsEqual<>(element)
         );
     }
 
@@ -101,7 +102,7 @@ public final class JoinedTest {
                 new ListOf<>(11, 12),
                 new ListOf<>(13, 14)
             ).toArray(),
-            Matchers.equalTo(new ListOf<>(11, 12, 13, 14).toArray())
+            new IsEqual<>(new ListOf<>(11, 12, 13, 14).toArray())
         );
     }
 
@@ -124,7 +125,7 @@ public final class JoinedTest {
                 new ListOf<>(first, "item3"),
                 new ListOf<>(second, "item4")
             ).containsAll(new ListOf<>(first, second)),
-            Matchers.equalTo(true)
+            new IsEqual<>(true)
         );
     }
 
@@ -167,7 +168,7 @@ public final class JoinedTest {
                 new ListOf<>("element1"),
                 new ListOf<>(element, "element3")
             ).get(1),
-            Matchers.equalTo(element)
+            new IsEqual<>(element)
         );
     }
 
@@ -199,7 +200,7 @@ public final class JoinedTest {
                 new ListOf<>("elem1", element),
                 new ListOf<>("elem3", "elem4")
             ).subList(1, 3).iterator().next(),
-            Matchers.equalTo(element)
+            new IsEqual<>(element)
         );
     }
 
@@ -210,7 +211,7 @@ public final class JoinedTest {
                 0,
                 new ListOf<>(1, 2, 3)
             ),
-            Matchers.contains(0, 1, 2, 3)
+            new IsEqual<>(new ListOf<>(0, 1, 2, 3))
         );
     }
 }

--- a/src/test/java/org/cactoos/list/ListOfTest.java
+++ b/src/test/java/org/cactoos/list/ListOfTest.java
@@ -28,14 +28,16 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.cactoos.iterable.IterableOf;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.HasSize;
 
 /**
  * Test case for {@link ListOf}.
  *
  * @since 0.1
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle MagicNumberCheck (500 lines)
  */
@@ -61,7 +63,7 @@ public final class ListOfTest {
         MatcherAssert.assertThat(
             "Can't convert an iterable to a list",
             new ListOf<>(-1, num, 0, 1).get(1),
-            Matchers.equalTo(num)
+            new IsEqual<>(num)
         );
     }
 
@@ -73,7 +75,7 @@ public final class ListOfTest {
             new ListOf<>(
                 Collections.nCopies(size, 0)
             ),
-            Matchers.hasSize(size)
+            new HasSize(size)
         );
     }
 
@@ -82,9 +84,9 @@ public final class ListOfTest {
         MatcherAssert.assertThat(
             "Can't convert an empty iterable to an empty list",
             new ListOf<>(
-                Collections.emptyList()
-            ).size(),
-            Matchers.equalTo(0)
+                new IterableOf<>()
+            ),
+            new HasSize(0)
         );
     }
 
@@ -109,7 +111,7 @@ public final class ListOfTest {
         MatcherAssert.assertThat(
             "Can't sense the changes in the underlying iterable",
             list.size(),
-            Matchers.not(Matchers.equalTo(list.size()))
+            new IsNot<>(new IsEqual<>(list.size()))
         );
     }
 
@@ -123,11 +125,13 @@ public final class ListOfTest {
         );
         MatcherAssert.assertThat(
             "Can't turn a mapped iterable into a list",
-            list, Matchers.iterableWithSize(4)
+            list,
+            new HasSize(4)
         );
         MatcherAssert.assertThat(
             "Can't turn a mapped iterable into a list, again",
-            list, Matchers.iterableWithSize(4)
+            list,
+            new HasSize(4)
         );
     }
 

--- a/src/test/java/org/cactoos/list/MappedTest.java
+++ b/src/test/java/org/cactoos/list/MappedTest.java
@@ -23,18 +23,19 @@
  */
 package org.cactoos.list;
 
-import java.util.Collections;
 import org.cactoos.Text;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.Upper;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.HasSize;
 
 /**
  * Test case for {@link Mapped}.
  * @since 0.14
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle MagicNumberCheck (500 lines)
  */
@@ -60,7 +61,7 @@ public final class MappedTest {
                 input -> new Upper(new TextOf(input)),
                 new IterableOf<>("hello", "world", "друг")
             ).iterator().next().asString(),
-            Matchers.equalTo("HELLO")
+            new IsEqual<>("HELLO")
         );
     }
 
@@ -70,9 +71,9 @@ public final class MappedTest {
             "Can't transform an empty iterable",
             new Mapped<String, Text>(
                 input -> new Upper(new TextOf(input)),
-                Collections.emptyList()
+                new IterableOf<>()
             ),
-            Matchers.emptyIterable()
+            new HasSize(0)
         );
     }
 
@@ -84,7 +85,7 @@ public final class MappedTest {
                 x -> x * 2,
                 new ListOf<>(1, 2, 3)
             ).toString(),
-            Matchers.equalTo("[2, 4, 6]")
+            new IsEqual<>("[2, 4, 6]")
         );
     }
 }

--- a/src/test/java/org/cactoos/list/ShuffledTest.java
+++ b/src/test/java/org/cactoos/list/ShuffledTest.java
@@ -24,8 +24,8 @@
 package org.cactoos.list;
 
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.HasValues;
 
 /**
  * Test Case for {@link Shuffled}.
@@ -55,7 +55,7 @@ public final class ShuffledTest {
             new Shuffled<>(
                 new ListOf<>(1, 0, -1, -1, 2)
             ),
-            Matchers.hasItem(-1)
+            new HasValues<>(-1)
         );
     }
 }

--- a/src/test/java/org/cactoos/list/SolidTest.java
+++ b/src/test/java/org/cactoos/list/SolidTest.java
@@ -28,8 +28,9 @@ import java.util.List;
 import org.cactoos.Scalar;
 import org.cactoos.iterable.IterableOf;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.HasSize;
 import org.llorllale.cactoos.matchers.RunsInThreads;
 
 /**
@@ -74,11 +75,13 @@ public final class SolidTest {
         );
         MatcherAssert.assertThat(
             "Can't turn a mapped iterable into a list",
-            list, Matchers.iterableWithSize(4)
+            list,
+            new HasSize(4)
         );
         MatcherAssert.assertThat(
             "Can't turn a mapped iterable into a list, again",
-            list, Matchers.iterableWithSize(4)
+            list,
+            new HasSize(4)
         );
     }
 
@@ -92,7 +95,8 @@ public final class SolidTest {
         );
         MatcherAssert.assertThat(
             "Can't map only once",
-            list.get(0), Matchers.equalTo(list.get(0))
+            list.get(0),
+            new IsEqual<>(list.get(0))
         );
     }
 

--- a/src/test/java/org/cactoos/list/SortedTest.java
+++ b/src/test/java/org/cactoos/list/SortedTest.java
@@ -25,7 +25,7 @@ package org.cactoos.list;
 
 import java.util.Comparator;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 
 /**
@@ -56,8 +56,8 @@ public final class SortedTest {
                     "one", "two", "three", "four"
                 )
             ),
-            Matchers.contains(
-                "four", "one", "three", "two"
+            new IsEqual<>(
+                new ListOf<>("four", "one", "three", "two")
             )
         );
     }
@@ -70,7 +70,7 @@ public final class SortedTest {
                 Comparator.reverseOrder(),
                 "alpha", "beta", "gamma", "delta"
             ).get(1),
-            Matchers.equalTo("delta")
+            new IsEqual<>("delta")
         );
     }
 

--- a/src/test/java/org/cactoos/list/StickyTest.java
+++ b/src/test/java/org/cactoos/list/StickyTest.java
@@ -30,12 +30,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.cactoos.Scalar;
 import org.cactoos.iterable.IterableOf;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.HasSize;
+import org.llorllale.cactoos.matchers.IsTrue;
 
 /**
  * Test case for {@link Sticky}.
  * @since 0.8
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle MagicNumberCheck (500 lines)
  */
@@ -62,7 +65,7 @@ public final class StickyTest {
         MatcherAssert.assertThat(
             "Can't ignore the changes in the underlying iterable",
             list.size(),
-            Matchers.equalTo(list.size())
+            new IsEqual<>(list.size())
         );
     }
 
@@ -71,7 +74,7 @@ public final class StickyTest {
         MatcherAssert.assertThat(
             "Can't decorate an array of numbers",
             new Sticky<>(-1, 0).size(),
-            Matchers.equalTo(2)
+            new IsEqual<>(2)
         );
     }
 
@@ -79,7 +82,7 @@ public final class StickyTest {
     public void testEmpty() {
         MatcherAssert.assertThat(
             new Sticky<>().isEmpty(),
-            Matchers.equalTo(true)
+            new IsTrue()
         );
     }
 
@@ -87,7 +90,7 @@ public final class StickyTest {
     public void testContains() {
         MatcherAssert.assertThat(
             new Sticky<>(1, 2).contains(1),
-            Matchers.equalTo(true)
+            new IsTrue()
         );
     }
 
@@ -95,7 +98,7 @@ public final class StickyTest {
     public void testToArray() {
         MatcherAssert.assertThat(
             new Sticky<>(1, 2).toArray(),
-            Matchers.arrayContaining(1, 2)
+            new IsEqual<>(new int[] {1, 2 })
         );
     }
 
@@ -104,7 +107,7 @@ public final class StickyTest {
         final Integer[] arr = new Integer[2];
         MatcherAssert.assertThat(
             new Sticky<>(1, 2).toArray(arr),
-            Matchers.arrayContaining(1, 2)
+            new IsEqual<>(new int[] {1, 2 })
         );
     }
 
@@ -112,7 +115,7 @@ public final class StickyTest {
     public void testContainsAll() {
         MatcherAssert.assertThat(
             new Sticky<>(1, 2).containsAll(new ListOf<>(1, 2)),
-            Matchers.equalTo(true)
+            new IsTrue()
         );
     }
 
@@ -120,7 +123,7 @@ public final class StickyTest {
     public void testIndexOf() {
         MatcherAssert.assertThat(
             new Sticky<>(1, 2).indexOf(1),
-            Matchers.equalTo(0)
+            new IsEqual<>(0)
         );
     }
 
@@ -128,7 +131,7 @@ public final class StickyTest {
     public void testLastIndexOf() {
         MatcherAssert.assertThat(
             new Sticky<>(1, 2, 2).lastIndexOf(2),
-            Matchers.equalTo(2)
+            new IsEqual<>(2)
         );
     }
 
@@ -136,7 +139,7 @@ public final class StickyTest {
     public void testGet() {
         MatcherAssert.assertThat(
             new Sticky<>(1, 2).get(1),
-            Matchers.equalTo(2)
+            new IsEqual<>(2)
         );
     }
 
@@ -147,7 +150,7 @@ public final class StickyTest {
         ).subList(0, 2);
         MatcherAssert.assertThat(
             list.size(),
-            Matchers.equalTo(2)
+            new IsEqual<>(2)
         );
     }
 
@@ -206,11 +209,13 @@ public final class StickyTest {
         );
         MatcherAssert.assertThat(
             "Can't turn a mapped iterable into a list",
-            list, Matchers.iterableWithSize(4)
+            list,
+            new HasSize(4)
         );
         MatcherAssert.assertThat(
             "Can't turn a mapped iterable into a list, again",
-            list, Matchers.iterableWithSize(4)
+            list,
+            new HasSize(4)
         );
     }
 
@@ -224,7 +229,8 @@ public final class StickyTest {
         );
         MatcherAssert.assertThat(
             "Can't map only once",
-            list.get(0), Matchers.equalTo(list.get(0))
+            list.get(0),
+            new IsEqual<>(list.get(0))
         );
     }
 


### PR DESCRIPTION
This is for #1119. I haven't add the list package to the includes of the plugin because there is is still the `MatcherAssert` static to be migrated to `Assertion`.