### PR TITLE
(#1137) Simplified responsibility and implementation of FirstOf

### DIFF
--- a/src/main/java/org/cactoos/scalar/FirstOf.java
+++ b/src/main/java/org/cactoos/scalar/FirstOf.java
@@ -23,12 +23,9 @@
  */
 package org.cactoos.scalar;
 
-import java.util.NoSuchElementException;
 import org.cactoos.Func;
 import org.cactoos.Scalar;
 import org.cactoos.iterable.Filtered;
-import org.cactoos.iterable.HeadOf;
-import org.cactoos.iterable.IterableOf;
 
 /**
  * Find first element in a list that satisfies specified condition.
@@ -71,9 +68,9 @@ public final class FirstOf<T> implements Scalar<T> {
     @Override
     public T value() throws Exception {
         return new ItemAt<>(
-                0,
-                this.fallback.value(),
-                new Filtered<>(this.condition, this.source)
+            0,
+            this.fallback.value(),
+            new Filtered<>(this.condition, this.source)
         ).value();
     }
 }

--- a/src/main/java/org/cactoos/scalar/FirstOf.java
+++ b/src/main/java/org/cactoos/scalar/FirstOf.java
@@ -70,19 +70,10 @@ public final class FirstOf<T> implements Scalar<T> {
 
     @Override
     public T value() throws Exception {
-        return new ScalarWithFallback<>(
-            () -> new HeadOf<>(
-                1,
+        return new ItemAt<>(
+                0,
+                this.fallback.value(),
                 new Filtered<>(this.condition, this.source)
-            ).iterator().next(),
-            new IterableOf<FallbackFrom<T>>(
-                new FallbackFrom<>(
-                    new IterableOf<Class<? extends Throwable>>(
-                        NoSuchElementException.class
-                    ),
-                    t1 -> this.fallback.value()
-                )
-            )
         ).value();
     }
 }


### PR DESCRIPTION
This is for #1137. I replaced params `Func<T, Boolean> cond` and `Iterable<T> src` to `Filtered<T>` in `FirstOf<>()` constructor, and ofcourse fixed tests.