### PR TITLE
(#1141): Continued speeding up the `mvn test` in SyncedTest.java

### DIFF
--- a/src/test/java/org/cactoos/iterator/SyncedTest.java
+++ b/src/test/java/org/cactoos/iterator/SyncedTest.java
@@ -38,14 +38,6 @@ import org.llorllale.cactoos.matchers.RunsInThreads;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle MagicNumberCheck (500 lines)
  * @checkstyle TodoCommentCheck (500 lines)
- * @todo #1115:30min Continue speeding up the `mvn test` goal until it
- *  executes in less than 10 seconds, or as fast as reasonably possible.
- *  A good solution would be reducing the number of tries to at most 10
- *  in the two tests below with the for loop. After some manual testing
- *  to evaluate actual overlaps of threads (see code details in
- *  https://www.yegor256.com/2018/03/27/how-to-test-thread-safety.html),
- *  it seems most of the tries results in 0 overlapping thread. This is
- *  why so much tries are needed in the for loop for the tests to be sound.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class SyncedTest {


### PR DESCRIPTION
This is for #1141.  I made 10 attempts to check the problem with SyncedTest.java and always I had average time less than 10 seconds.

```
Tests run: 1193, Failures: 0, Errors: 0, Skipped: 2

Running org.cactoos.iterator.SyncedTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.59 sec - in org.cactoos.iterator.SyncedTest

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.797 s
[INFO] Finished at: 2019-07-13T11:21:54+07:00
[INFO] ------------------------------------------------------------------------
```

You can check the time in Travis pipeline build. The task was not relevant. I removed todo from class description.