### PR TITLE
(#1152) Remove some more static Matcher asserts

### DIFF
--- a/src/main/java/org/cactoos/io/package-info.java
+++ b/src/main/java/org/cactoos/io/package-info.java
@@ -26,9 +26,5 @@
  * Input/Output.
  *
  * @since 0.1
- * @todo #1117:30min Continue replacing usage of MatcherAssert.assertThat with
- *  Assertion from cactoos-matchers. Once there is no more usage of
- *  MatcherAssert.assertThat, add the signature of MatcherAssert.assertThat to
- *  forbidden-apis.txt
  */
 package org.cactoos.io;

--- a/src/test/java/org/cactoos/io/DirectoryTest.java
+++ b/src/test/java/org/cactoos/io/DirectoryTest.java
@@ -27,11 +27,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.HasSize;
 
 /**
  * Test case for {@link Directory}.
@@ -52,12 +52,12 @@ public final class DirectoryTest {
         final Path dir = this.folder.newFolder().toPath();
         dir.resolve("x/y").toFile().mkdirs();
         Files.write(dir.resolve("x/y/test"), "".getBytes());
-        MatcherAssert.assertThat(
-            "Can't list files in a directory represented by a path",
+        new Assertion<>(
+            "must list files in a directory represented by a path",
             new Directory(dir),
             // @checkstyle MagicNumber (1 line)
-            Matchers.iterableWithSize(4)
-        );
+            new HasSize(4)
+        ).affirm();
     }
 
     @Test
@@ -66,11 +66,11 @@ public final class DirectoryTest {
         final Path dir = file.toPath();
         dir.resolve("parent/child").toFile().mkdirs();
         Files.write(dir.resolve("parent/child/file"), "".getBytes());
-        MatcherAssert.assertThat(
-            "Can't list files in a directory represented by a file",
+        new Assertion<>(
+            "must list files in a directory represented by a file",
             new Directory(file),
             // @checkstyle MagicNumber (1 line)
-            Matchers.iterableWithSize(4)
-        );
+            new HasSize(4)
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/io/HeadInputStreamTest.java
+++ b/src/test/java/org/cactoos/io/HeadInputStreamTest.java
@@ -24,7 +24,6 @@
 package org.cactoos.io;
 
 import org.cactoos.text.TextOf;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 import org.llorllale.cactoos.matchers.Assertion;
@@ -91,10 +90,10 @@ public final class HeadInputStreamTest {
             new InputOf("testAvailableLessThanTotal").stream(),
             5
         );
-        MatcherAssert.assertThat(
-            "Count of available bytes is incorrect",
+        new Assertion<>(
+            "must count available bytes",
             stream.available(),
             new IsEqual<>(5)
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/io/HeadInputTest.java
+++ b/src/test/java/org/cactoos/io/HeadInputTest.java
@@ -24,8 +24,8 @@
 package org.cactoos.io;
 
 import org.cactoos.text.TextOf;
-import org.hamcrest.MatcherAssert;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.TextHasString;
 
 /**
@@ -39,8 +39,8 @@ public final class HeadInputTest {
 
     @Test
     public void readsHeadOfLongerInput() throws Exception {
-        MatcherAssert.assertThat(
-            "HeadInput couldn't limit a number of read bytes",
+        new Assertion<>(
+            "must limit exactly the number of read bytes",
             new TextOf(
                 new HeadInput(
                     new InputOf("readsHeadOfLongerInput"),
@@ -48,14 +48,14 @@ public final class HeadInputTest {
                 )
             ),
             new TextHasString("reads")
-        );
+        ).affirm();
     }
 
     @Test
     public void readsHeadOfShorterInput() throws Exception {
         final String input = "readsHeadOfShorterInput";
-        MatcherAssert.assertThat(
-            "HeadInput incorrectly limited a number of read bytes",
+        new Assertion<>(
+            "must limit to at most the number of available bytes",
             new TextOf(
                 new HeadInput(
                     new InputOf(input),
@@ -63,6 +63,6 @@ public final class HeadInputTest {
                 )
             ),
             new TextHasString(input)
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/io/InputAsBytesTest.java
+++ b/src/test/java/org/cactoos/io/InputAsBytesTest.java
@@ -27,10 +27,14 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import org.cactoos.iterable.Endless;
 import org.cactoos.iterable.HeadOf;
+import org.cactoos.iterable.IterableOf;
 import org.cactoos.text.TextOf;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.AllOf;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.EndsWith;
+import org.llorllale.cactoos.matchers.StartsWith;
 
 /**
  * Test case for {@link InputAsBytes}.
@@ -39,14 +43,15 @@ import org.junit.Test;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
+@SuppressWarnings("unchecked")
 public final class InputAsBytesTest {
 
     @Test
     public void readsLargeInMemoryContent() throws Exception {
         final int multiplier = 5_000;
         final String body = "1234567890";
-        MatcherAssert.assertThat(
-            "Can't read large content from in-memory Input",
+        new Assertion<>(
+            "must read large content from in-memory Input",
             new InputAsBytes(
                 new InputOf(
                     String.join(
@@ -57,8 +62,8 @@ public final class InputAsBytesTest {
                     )
                 )
             ).asBytes().length,
-            Matchers.equalTo(body.length() * multiplier)
-        );
+            new IsEqual<>(body.length() * multiplier)
+        ).affirm();
     }
 
     @Test
@@ -66,42 +71,44 @@ public final class InputAsBytesTest {
     public void readsLargeContent() throws Exception {
         final int size = 100_000;
         try (final InputStream slow = new SlowInputStream(size)) {
-            MatcherAssert.assertThat(
-                "Can't read large content from Input",
+            new Assertion<>(
+                "must read large content from Input",
                 new InputAsBytes(
                     new InputOf(slow)
                 ).asBytes().length,
-                Matchers.equalTo(size)
-            );
+                new IsEqual<>(size)
+            ).affirm();
         }
     }
 
     @Test
     public void readsInputIntoBytes() throws Exception {
-        MatcherAssert.assertThat(
-            "Can't read bytes from Input",
-            new String(
+        new Assertion<>(
+            "must read bytes from Input",
+            new TextOf(
                 new InputAsBytes(
                     new InputOf(
                         new BytesOf(
                             new TextOf("Hello, друг!")
                         )
                     )
-                ).asBytes(),
+                ),
                 StandardCharsets.UTF_8
             ),
-            Matchers.allOf(
-                Matchers.startsWith("Hello, "),
-                Matchers.endsWith("друг!")
+            new AllOf<>(
+                new IterableOf<>(
+                    new StartsWith("Hello, "),
+                    new EndsWith("друг!")
+                )
             )
-        );
+        ).affirm();
     }
 
     @Test
     public void readsInputIntoBytesWithSmallBuffer() throws Exception {
-        MatcherAssert.assertThat(
-            "Can't read bytes from Input with a small reading buffer",
-            new String(
+        new Assertion<>(
+            "must read bytes from Input with a small reading buffer",
+            new TextOf(
                 new InputAsBytes(
                     new InputOf(
                         new BytesOf(
@@ -109,14 +116,16 @@ public final class InputAsBytesTest {
                         )
                     ),
                     2
-                ).asBytes(),
+                ),
                 StandardCharsets.UTF_8
             ),
-            Matchers.allOf(
-                Matchers.startsWith("Hello,"),
-                Matchers.endsWith("товарищ!")
+            new AllOf<>(
+                new IterableOf<>(
+                    new StartsWith("Hello,"),
+                    new EndsWith("товарищ!")
+                )
             )
-        );
+        ).affirm();
     }
 
 }

--- a/src/test/java/org/cactoos/io/package-info.java
+++ b/src/test/java/org/cactoos/io/package-info.java
@@ -26,5 +26,9 @@
  * Input/Output, tests.
  *
  * @since 0.1
+ * @todo #1152:30min Continue replacing usage of MatcherAssert.assertThat with
+ *  Assertion from cactoos-matchers. Once there is no more usage of
+ *  MatcherAssert.assertThat, add the signature of MatcherAssert.assertThat to
+ *  forbidden-apis.txt
  */
 package org.cactoos.io;


### PR DESCRIPTION
This is for #1152.

I created the new todo for continuing into the `package-info.java` file in tests since it made more sense.