### PR TITLE
(#1172) Added `dist: trusty` to fix broken Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 sudo: false
 cache:
   directories:


### PR DESCRIPTION
This is a fix to #1172.

Just a quick fix without migration to OpenJDK builds.