### PR TITLE
(#1186) Add Makefile to run build in Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,9 +309,26 @@ Ask your questions related to cactoos library on [Stackoverflow](https://stackov
 Just fork the repo and send us a pull request.
 
 Make sure your branch builds without any warnings/issues:
-
 ```
-mvn clean install -Pqulice
+mvn clean verify -Pqulice
+```
+
+To run a build similar to the CI with Docker only, use:
+```
+docker run \
+	--tty \
+	--interactive \
+	--workdir=/main \
+	--volume=${PWD}:/main \
+	--volume=cactoos-mvn-cache:/root/.m2 \
+	--rm \
+	maven:3-jdk-8 \
+	bash -c "mvn clean install site -Pqulice -Psite --errors; chown -R $(id -u):$(id -g) target/"
+```
+
+To remove the cache used by Docker-based build:
+```
+docker volume rm cactoos-mvn-cache
 ```
 
 We also lint the git commit log. We highly recommend you install [this](https://github.com/llorllale/go-gitlint)


### PR DESCRIPTION
This is for #1186.

Compared to what was proposed in the ticket:
- removed extraneous useless options
- add `--interactive` to stop container on ctrl+C
- use `maven:3-jdk-8` image instead of `yegor/java8`, which is one of the worst image I have ever seen ;) (it weight 3.6Gi, and has something like 20 layers).
- do the build in one go