### PR TITLE
(#1151) qulice update to fix build errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,9 +163,9 @@ The MIT License (MIT)
               <excludes combine.children="append">
                 <exclude>checkstyle:/src/site/resources/.*</exclude>
                 <!--
-                 @todo #1151:30min To fix qulice build erros is necessary update it.
-                  But there're a lot of files don't pass in the new qulice checks.
-                  So, let's fix some of them and remove the exclusion here.
+                 @todo #1151:30min After updated qulice-maven-plugin there're a
+                  lot of files which don't pass in the qulice checks. So, let's
+                  fix them and remove the their exclusion bellow.
                  -->
                 <exclude>checkstyle:/src/main/java/org/cactoos/bytes/Base64Bytes.java</exclude>
                 <exclude>checkstyle:/src/main/java/org/cactoos/bytes/BytesBase64.java</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -158,10 +158,108 @@ The MIT License (MIT)
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.17.3</version>
+            <version>0.18.19</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>checkstyle:/src/site/resources/.*</exclude>
+                <!--
+                 @todo #1151:30min To fix qulice build erros is necessary update it.
+                  But there're a lot of files don't pass in the new qulice checks.
+                  So, let's fix some of them and remove the exclusion here.
+                 -->
+                <exclude>checkstyle:/src/main/java/org/cactoos/bytes/Base64Bytes.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/bytes/BytesBase64.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/bytes/NoNulls.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/collection/Filtered.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/collection/Mapped.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/collection/Sorted.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/func/BiFuncNoNulls.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/func/BiProcNoNulls.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/func/FuncNoNulls.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/func/ProcNoNulls.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/func/Timed.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/io/BytesOf.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/io/DigestEnvelope.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/io/Directory.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/io/InputAsBytes.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/io/InputNoNulls.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/io/OutputNoNulls.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/io/ResourceOf.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/io/Zip.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/iterable/IterableOf.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/iterable/Sorted.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/iterable/Synced.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/iterator/HeadOf.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/iterator/Partitioned.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/iterator/Skipped.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/iterator/Sorted.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/iterator/Synced.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/iterator/TailOf.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/list/Mapped.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/list/Sorted.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/map/MapEnvelope.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/map/MapOf.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/map/Solid.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/map/Sticky.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/map/Synced.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/scalar/And.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/scalar/AndInThreads.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/scalar/AndWithIndex.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/scalar/EqualsNullable.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/scalar/Folded.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/scalar/ItemAt.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/scalar/LengthOf.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/scalar/MaxOf.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/scalar/MinOf.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/scalar/NoNulls.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/scalar/Or.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/scalar/PropertiesOf.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/scalar/Retry.java</exclude>
+                <exclude>checkstyle:/src/main/java/org/cactoos/text/FormattedText.java</exclude>
+                <exclude>checkstyle:/src/test/java/org/cactoos/collection/CollectionEnvelopeTest.java</exclude>
+                <exclude>checkstyle:/src/test/java/org/cactoos/func/ProcOfTest.java</exclude>
+                <exclude>checkstyle:/src/test/java/org/cactoos/io/BytesOfTest.java</exclude>
+                <exclude>checkstyle:/src/test/java/org/cactoos/io/FakeHandler.java</exclude>
+                <exclude>checkstyle:/src/test/java/org/cactoos/io/GzipOutputTest.java</exclude>
+                <exclude>checkstyle:/src/test/java/org/cactoos/io/InputAsBytesTest.java</exclude>
+                <exclude>checkstyle:/src/test/java/org/cactoos/io/InputOfTest.java</exclude>
+                <exclude>checkstyle:/src/test/java/org/cactoos/io/LoggingOutputTest.java</exclude>
+                <exclude>checkstyle:/src/test/java/org/cactoos/io/TeeInputStreamTest.java</exclude>
+                <exclude>checkstyle:/src/test/java/org/cactoos/io/TempFileTest.java</exclude>
+                <exclude>checkstyle:/src/test/java/org/cactoos/io/TempFolderTest.java</exclude>
+                <exclude>checkstyle:/src/test/java/org/cactoos/io/WriterAsOutputStreamTest.java</exclude>
+                <exclude>checkstyle:/src/test/java/org/cactoos/io/WriterAsOutputTest.java</exclude>
+                <exclude>checkstyle:/src/test/java/org/cactoos/io/ZipTest.java</exclude>
+                <exclude>checkstyle:/src/test/java/org/cactoos/iterable/IterableOfTest.java</exclude>
+                <exclude>checkstyle:/src/test/java/org/cactoos/list/NoNullsTest.java</exclude>
+                <exclude>checkstyle:/src/test/java/org/cactoos/map/MapEnvelopeTest.java</exclude>
+                <exclude>checkstyle:/src/test/java/org/cactoos/scalar/EqualityTest.java</exclude>
+                <exclude>checkstyle:/src/test/java/org/cactoos/scalar/RetryTest.java</exclude>
+                <exclude>checkstyle:/src/test/java/org/cactoos/scalar/SumOfTest.java</exclude>
+                <exclude>checkstyle:/src/test/java/org/cactoos/text/TextEnvelopeTest.java</exclude>
+                <exclude>pmd:/src/test/java/org/cactoos/func/IoCheckedBiFuncTest.java</exclude>
+                <exclude>pmd:/src/test/java/org/cactoos/func/IoCheckedBiProcTest.java</exclude>
+                <exclude>pmd:/src/test/java/org/cactoos/func/IoCheckedFuncTest.java</exclude>
+                <exclude>pmd:/src/test/java/org/cactoos/func/IoCheckedProcTest.java</exclude>
+                <exclude>pmd:/src/test/java/org/cactoos/io/CheckedBytesTest.java</exclude>
+                <exclude>pmd:/src/test/java/org/cactoos/io/CheckedInputTest.java</exclude>
+                <exclude>pmd:/src/test/java/org/cactoos/io/CheckedOutputTest.java</exclude>
+                <exclude>pmd:/src/test/java/org/cactoos/io/GzipOutputTest.java</exclude>
+                <exclude>pmd:/src/test/java/org/cactoos/io/HeadInputStreamTest.java</exclude>
+                <exclude>pmd:/src/test/java/org/cactoos/io/InputAsBytesTest.java</exclude>
+                <exclude>pmd:/src/test/java/org/cactoos/io/LoggingOutputTest.java</exclude>
+                <exclude>pmd:/src/test/java/org/cactoos/io/StickyTest.java</exclude>
+                <exclude>pmd:/src/test/java/org/cactoos/io/TempFileTest.java</exclude>
+                <exclude>pmd:/src/test/java/org/cactoos/io/TempFolderTest.java</exclude>
+                <exclude>pmd:/src/test/java/org/cactoos/io/WriterAsOutputStreamTest.java</exclude>
+                <exclude>pmd:/src/test/java/org/cactoos/io/WriterAsOutputTest.java</exclude>
+                <exclude>pmd:/src/test/java/org/cactoos/io/ZipTest.java</exclude>
+                <exclude>pmd:/src/test/java/org/cactoos/map/MapEntryTest.java</exclude>
+                <exclude>pmd:/src/test/java/org/cactoos/scalar/EqualsTest.java</exclude>
+                <exclude>pmd:/src/test/java/org/cactoos/scalar/IoCheckedTest.java</exclude>
+                <exclude>pmd:/src/test/java/org/cactoos/scalar/NumberOfTest.java</exclude>
+                <exclude>pmd:/src/test/java/org/cactoos/scalar/SumOfTest.java</exclude>
+                <exclude>pmd:/src/test/java/org/cactoos/text/FormattedTextTest.java</exclude>
                 <exclude>findbugs:org.cactoos.text.TextEnvelopeTest</exclude>
                 <exclude>findbugs:org.cactoos.text.ComparableText</exclude>
                 <exclude>findbugs:org.cactoos.collection.CollectionEnvelope</exclude>
@@ -191,7 +289,7 @@ The MIT License (MIT)
                 done. The newly covered classes should be added to the include
                 configuration property below. At the end, the configuration
                 property below should be completely removed so that calls
-                to forbidden APIs always fail the build for every classes.  
+                to forbidden APIs always fail the build for every classes.
                -->
               <includes>
                 <include>org/cactoos/bytes/*.class</include>


### PR DESCRIPTION
For #1151 

- qulice update to fix build errors
- leave a puzzle to fix all files don't pass in the updated qulice
- we should fix them and remove from `pom.xml`