### PR TITLE
(#1182) Remove some more static call to assert

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@ The MIT License (MIT)
     <dependency>
       <groupId>org.llorllale</groupId>
       <artifactId>cactoos-matchers</artifactId>
-      <version>0.17</version>
+      <version>0.18</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/org/cactoos/io/OutputStreamToTest.java
+++ b/src/test/java/org/cactoos/io/OutputStreamToTest.java
@@ -26,10 +26,10 @@ package org.cactoos.io;
 import java.io.IOException;
 import java.nio.file.Path;
 import org.cactoos.text.TextOf;
-import org.hamcrest.MatcherAssert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.TextIs;
 
 /**
@@ -50,8 +50,8 @@ public final class OutputStreamToTest {
     public void writesLargeContentToFile() throws IOException {
         final Path temp = this.folder.newFile("cactoos-1.txt-1")
             .toPath();
-        MatcherAssert.assertThat(
-            "Can't copy Input to Output and return Input",
+        new Assertion<>(
+            "Must copy Input to Output and return Input",
             new TextOf(
                 new Sticky(
                     new TeeInput(
@@ -63,7 +63,7 @@ public final class OutputStreamToTest {
             new TextIs(
                 new TextOf(temp)
             )
-        );
+        ).affirm();
     }
 
 }

--- a/src/test/java/org/cactoos/io/OutputToTest.java
+++ b/src/test/java/org/cactoos/io/OutputToTest.java
@@ -28,10 +28,10 @@ import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import org.cactoos.scalar.LengthOf;
-import org.hamcrest.MatcherAssert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.InputHasContent;
 
 /**
@@ -55,11 +55,11 @@ public final class OutputToTest {
         final Path path = temp.resolve("one/two/three/file.txt");
         final String content = "Hello, товарищ!";
         new LengthOf(new TeeInput(content, new OutputTo(path))).intValue();
-        MatcherAssert.assertThat(
-            "Can't write into path",
+        new Assertion<>(
+            "Must write into path",
             new InputOf(path),
             new InputHasContent(content)
-        );
+        ).affirm();
     }
 
     @Test
@@ -70,11 +70,11 @@ public final class OutputToTest {
         new LengthOf(
             new TeeInput(txt, new SyncOutput(new OutputTo(path.toFile())))
         ).intValue();
-        MatcherAssert.assertThat(
-            "Can't write into file",
+        new Assertion<>(
+            "Must write into file",
             new InputOf(path.toFile()),
             new InputHasContent(txt)
-        );
+        ).affirm();
     }
 
     @Test
@@ -82,11 +82,11 @@ public final class OutputToTest {
         final String txt = "Hello, writer!";
         final StringWriter output = new StringWriter();
         new LengthOf(new TeeInput(txt, new OutputTo(output))).intValue();
-        MatcherAssert.assertThat(
-            "Can't write into writer",
+        new Assertion<>(
+            "Must write into writer",
             new InputOf(output.getBuffer()),
             new InputHasContent(txt)
-        );
+        ).affirm();
     }
 
     @Test
@@ -96,11 +96,11 @@ public final class OutputToTest {
         new LengthOf(
             new TeeInput(txt, new OutputTo(output, StandardCharsets.UTF_8))
         ).intValue();
-        MatcherAssert.assertThat(
-            "Can't write into writer with charset",
+        new Assertion<>(
+            "Must write into writer with charset",
             new InputOf(output.getBuffer()),
             new InputHasContent(txt)
-        );
+        ).affirm();
     }
 
     @Test
@@ -110,11 +110,11 @@ public final class OutputToTest {
         new LengthOf(
             new TeeInput(txt, new OutputTo(output, StandardCharsets.UTF_8))
         ).intValue();
-        MatcherAssert.assertThat(
-            "Can't write into writer with charset by name",
+        new Assertion<>(
+            "Must write into writer with charset by name",
             new InputOf(output.getBuffer()),
             new InputHasContent(txt)
-        );
+        ).affirm();
     }
 
     @Test
@@ -127,11 +127,11 @@ public final class OutputToTest {
                 new OutputTo(output, StandardCharsets.UTF_8, 1)
             )
         ).intValue();
-        MatcherAssert.assertThat(
-            "Can't write into writer with charset and size",
+        new Assertion<>(
+            "Must write into writer with charset and size",
             new InputOf(output.getBuffer()),
             new InputHasContent(txt)
-        );
+        ).affirm();
     }
 
     @Test
@@ -144,11 +144,11 @@ public final class OutputToTest {
                 new OutputTo(output, 1)
             )
         ).intValue();
-        MatcherAssert.assertThat(
-            "Can't write into writer with size",
+        new Assertion<>(
+            "Must write into writer with size",
             new InputOf(output.getBuffer()),
             new InputHasContent(txt)
-        );
+        ).affirm();
     }
 
     @Test
@@ -161,11 +161,11 @@ public final class OutputToTest {
                 new OutputTo(output, StandardCharsets.UTF_8.name(), 1)
             )
         ).intValue();
-        MatcherAssert.assertThat(
-            "Can't write into writer with charset by name and size",
+        new Assertion<>(
+            "Must write into writer with charset by name and size",
             new InputOf(output.getBuffer()),
             new InputHasContent(txt)
-        );
+        ).affirm();
     }
 
     @Test
@@ -178,10 +178,10 @@ public final class OutputToTest {
                 new OutputTo(output, StandardCharsets.UTF_8.newDecoder(), 1)
             )
         ).intValue();
-        MatcherAssert.assertThat(
-            "Can't write into writer with decoder and size",
+        new Assertion<>(
+            "Must write into writer with decoder and size",
             new InputOf(output.getBuffer()),
             new InputHasContent(txt)
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/io/ReaderAsBytesTest.java
+++ b/src/test/java/org/cactoos/io/ReaderAsBytesTest.java
@@ -24,20 +24,20 @@
 package org.cactoos.io;
 
 import java.io.StringReader;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import org.cactoos.text.TextOf;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.IsTrue;
+import org.llorllale.cactoos.matchers.TextIs;
 
 /**
  * Test case for {@link ReaderAsBytes}.
  *
  * @since 0.12
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class ReaderAsBytesTest {
     /**
@@ -49,37 +49,25 @@ public final class ReaderAsBytesTest {
     @Test
     public void readsString() throws Exception {
         final String source = "hello, друг!";
-        MatcherAssert.assertThat(
-            "Can't read string through a reader",
+        new Assertion<>(
+            "Must read string through a reader",
             new TextOf(
                 new ReaderAsBytes(
                     new StringReader(source)
                 )
-            ).asString(),
-            Matchers.equalTo(source)
-        );
+            ),
+            new TextIs(source)
+        ).affirm();
     }
 
     @Test
-    public void readsAsBytesAndDeletesTempFile() throws Exception {
-        final Path file = this.folder.newFile().toPath();
-        new ReaderAsBytes(
-            new ReaderOf(file)
-        ).asBytes();
-        Files.delete(file);
-        MatcherAssert.assertThat(
-            Files.exists(file),
-            Matchers.equalTo(false)
-        );
-    }
-
-    @Test
-    public void readsEmptyClosableReaderAsBytes() throws Exception {
+    public void readsAndClosesReader() throws Exception {
         final EmptyClosableReader reader = new EmptyClosableReader();
         new ReaderAsBytes(reader).asBytes();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "Must close the reader after reading it",
             reader.isClosed(),
-            Matchers.equalTo(true)
-        );
+            new IsTrue()
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/io/ReaderOfTest.java
+++ b/src/test/java/org/cactoos/io/ReaderOfTest.java
@@ -26,13 +26,12 @@ package org.cactoos.io;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import org.cactoos.Input;
 import org.cactoos.text.TextOf;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsEqual;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.TextIs;
 
 /**
  * Test case for {@link ReaderOf}.
@@ -49,102 +48,102 @@ public final class ReaderOfTest {
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
-    @Test(expected = NullPointerException.class)
-    public void readsNull() throws Exception {
-        MatcherAssert.assertThat(
-            new TextOf(new ReaderOf((Input) null)).asString(),
-            new IsEqual<>("")
-        );
-    }
-
     @Test
     public void readsEmpty() throws Exception {
-        MatcherAssert.assertThat(
-            new TextOf(new ReaderOf("")).asString(),
-            new IsEqual<>("")
-        );
+        final String empty = "";
+        new Assertion<>(
+            "Must read empty string",
+            new TextOf(new ReaderOf(empty)),
+            new TextIs(empty)
+        ).affirm();
     }
 
     @Test
     public void readsCharVarArg() throws Exception {
-        MatcherAssert.assertThat(
-            new TextOf(new ReaderOf('a', 'b', 'c')).asString(),
-            new IsEqual<>("abc")
-        );
+        new Assertion<>(
+            "Must read chars var args",
+            new TextOf(new ReaderOf('a', 'b', 'c')),
+            new TextIs("abc")
+        ).affirm();
     }
 
     @Test
     public void readsCharArrayWithCharset() throws Exception {
         final String message =
             "char array on äÄ üÜ öÖ ß жш";
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "Must read chars var args with charset",
             new TextOf(
                 new ReaderOf(
                     message.toCharArray(),
                     StandardCharsets.UTF_8
                 )
-            ).asString(),
-            new IsEqual<>(message)
-        );
+            ),
+            new TextIs(message)
+        ).affirm();
     }
 
     @Test
     public void readsCharArrayWithCharsetByName() throws Exception {
         final String message =
             "char array with charset on äÄ üÜ öÖ ß жш";
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "Must read chars array with charset",
             new TextOf(
                 new ReaderOf(
                     message.toCharArray(),
                     StandardCharsets.UTF_8.name()
                 )
-            ).asString(),
-            new IsEqual<>(message)
-        );
+            ),
+            new TextIs(message)
+        ).affirm();
     }
 
     @Test
     public void readsByteArray() throws Exception {
         final String message =
             "byte array on äÄ üÜ öÖ ß жш";
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "Must read bytes array",
             new TextOf(
                 new ReaderOf(
                     message.getBytes(StandardCharsets.UTF_8)
                 )
-            ).asString(),
-            new IsEqual<>(message)
-        );
+            ),
+            new TextIs(message)
+        ).affirm();
     }
 
     @Test
     public void readsByteArrayWithCharset() throws Exception {
         final String message =
             "byte array with charset on äÄ üÜ öÖ ß жш";
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "Must read bytes array with charset",
             new TextOf(
                 new ReaderOf(
                     message.getBytes(StandardCharsets.UTF_8),
                     StandardCharsets.UTF_8
                 )
-            ).asString(),
-            new IsEqual<>(message)
-        );
+            ),
+            new TextIs(message)
+        ).affirm();
     }
 
     @Test
     public void readsByteArrayWithCharsetByName() throws Exception {
         final String message =
             "bte array with charset by name on äÄ üÜ öÖ ß жш";
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "Must read bytes array with charset by name",
             new TextOf(
                 new ReaderOf(
                     message.getBytes(StandardCharsets.UTF_8),
                     StandardCharsets.UTF_8.name()
                 )
-            ).asString(),
-            new IsEqual<>(message)
-        );
+            ),
+            new TextIs(message)
+        ).affirm();
     }
 
     @Test
@@ -156,10 +155,11 @@ public final class ReaderOfTest {
             input.toPath(),
             message.getBytes(StandardCharsets.UTF_8)
         );
-        MatcherAssert.assertThat(
-            new TextOf(new ReaderOf(input)).asString(),
-            new IsEqual<>(message)
-        );
+        new Assertion<>(
+            "Must read from path",
+            new TextOf(new ReaderOf(input)),
+            new TextIs(message)
+        ).affirm();
     }
 
     @Test
@@ -171,10 +171,11 @@ public final class ReaderOfTest {
             input.toPath(),
             message.getBytes(StandardCharsets.UTF_8)
         );
-        MatcherAssert.assertThat(
-            new TextOf(new ReaderOf(input)).asString(),
-            new IsEqual<>(message)
-        );
+        new Assertion<>(
+            "Must read from file",
+            new TextOf(new ReaderOf(input)),
+            new TextIs(message)
+        ).affirm();
     }
 
     @Test
@@ -186,16 +187,17 @@ public final class ReaderOfTest {
             input.toPath(),
             message.getBytes(StandardCharsets.UTF_8)
         );
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "Must read from url",
             new TextOf(
                 new ReaderOf(
                     input
                         .toURI()
                         .toURL()
                 )
-            ).asString(),
-            new IsEqual<>(message)
-        );
+            ),
+            new TextIs(message)
+        ).affirm();
     }
 
     @Test
@@ -207,209 +209,225 @@ public final class ReaderOfTest {
             input.toPath(),
             message.getBytes(StandardCharsets.UTF_8)
         );
-        MatcherAssert.assertThat(
-            new TextOf(new ReaderOf(input.toURI())).asString(),
-            new IsEqual<>(message)
-        );
+        new Assertion<>(
+            "Must read from uri",
+            new TextOf(new ReaderOf(input.toURI())),
+            new TextIs(message)
+        ).affirm();
     }
 
     @Test
     public void readsBytes() throws Exception {
         final String input =
             "Bytes on äÄ üÜ öÖ ß жш";
-        MatcherAssert.assertThat(
-            new TextOf(new ReaderOf(new BytesOf(input))).asString(),
-            new IsEqual<>(input)
-        );
+        new Assertion<>(
+            "Must read from bytes",
+            new TextOf(new ReaderOf(new BytesOf(input))),
+            new TextIs(input)
+        ).affirm();
     }
 
     @Test
     public void readsText() throws Exception {
         final String input =
             "Text on äÄ üÜ öÖ ß жш";
-        MatcherAssert.assertThat(
-            new TextOf(new ReaderOf(new TextOf(input))).asString(),
-            new IsEqual<>(input)
-        );
+        new Assertion<>(
+            "Must read from text",
+            new TextOf(new ReaderOf(new TextOf(input))),
+            new TextIs(input)
+        ).affirm();
     }
 
     @Test
     public void readsTextWithCharset() throws Exception {
         final String input =
             "Text with charset on äÄ üÜ öÖ ß жш";
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "Must read from text with charset",
             new TextOf(
                 new ReaderOf(
                     new TextOf(input),
                     StandardCharsets.UTF_8
                 )
-            ).asString(),
-            new IsEqual<>(input)
-        );
+            ),
+            new TextIs(input)
+        ).affirm();
     }
 
     @Test
     public void readsTextWithCharsetByName() throws Exception {
         final String input =
             "Text with charset by name on äÄ üÜ öÖ ß жш";
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "Must read from text with charset by name",
             new TextOf(
                 new ReaderOf(
                     new TextOf(input),
                     StandardCharsets.UTF_8.name()
                 )
-            ).asString(),
-            new IsEqual<>(input)
-        );
+            ),
+            new TextIs(input)
+        ).affirm();
     }
 
     @Test
     public void readsCharSequence() throws Exception {
         final String input =
             "char sequence on äÄ üÜ öÖ ß жш";
-        MatcherAssert.assertThat(
-            new TextOf(new ReaderOf(input)).asString(),
-            new IsEqual<>(input)
-        );
+        new Assertion<>(
+            "Must read from char sequence",
+            new TextOf(new ReaderOf(input)),
+            new TextIs(input)
+        ).affirm();
     }
 
     @Test
     public void readsCharSequenceWithCharset() throws Exception {
         final String input =
             "char sequence with charset on äÄ üÜ öÖ ß жш";
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "Must read from char sequance with charset",
             new TextOf(
                 new ReaderOf(
                     input,
                     StandardCharsets.UTF_8
                 )
-            ).asString(),
-            new IsEqual<>(input)
-        );
+            ),
+            new TextIs(input)
+        ).affirm();
     }
 
     @Test
     public void readsCharSequenceWithCharsetByName() throws Exception {
         final String input =
             "char sequence with charset by name on äÄ üÜ öÖ ß жш";
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "Must read from char sequence with charset by name",
             new TextOf(
                 new ReaderOf(
                     input,
                     StandardCharsets.UTF_8.name()
                 )
-            ).asString(),
-            new IsEqual<>(input)
-        );
+            ),
+            new TextIs(input)
+        ).affirm();
     }
 
     @Test
     public void readsInput() throws Exception {
         final String input =
             "Input on äÄ üÜ öÖ ß жш";
-        MatcherAssert.assertThat(
-            new TextOf(new ReaderOf(new InputOf(input))).asString(),
-            new IsEqual<>(input)
-        );
+        new Assertion<>(
+            "Must read from input",
+            new TextOf(new ReaderOf(new InputOf(input))),
+            new TextIs(input)
+        ).affirm();
     }
 
     @Test
     public void readsInputWithCharset() throws Exception {
         final String input =
             "Input with charset on äÄ üÜ öÖ ß жш";
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "Must read from input with charset",
             new TextOf(
                 new ReaderOf(
                     new InputOf(input),
                     StandardCharsets.UTF_8
                 )
-            ).asString(),
-            new IsEqual<>(input)
-        );
+            ),
+            new TextIs(input)
+        ).affirm();
     }
 
     @Test
     public void readsInputWithCharsetByName() throws Exception {
         final String input =
             "Input with charset by name on äÄ üÜ öÖ ß жш";
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "Must read from input with charset by name",
             new TextOf(
                 new ReaderOf(
                     new InputOf(input),
                     StandardCharsets.UTF_8.name()
                 )
-            ).asString(),
-            new IsEqual<>(input)
-        );
+            ),
+            new TextIs(input)
+        ).affirm();
     }
 
     @Test
     public void readsInputWithCharsetDecoder() throws Exception {
         final String input =
             "Input with charset decoder on äÄ üÜ öÖ ß жш";
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "Must read from input with charset decoder",
             new TextOf(
                 new ReaderOf(
                     new InputOf(input),
                     StandardCharsets.UTF_8.newDecoder()
                 )
-            ).asString(),
-            new IsEqual<>(input)
-        );
+            ),
+            new TextIs(input)
+        ).affirm();
     }
 
     @Test
     public void readsInputStream() throws Exception {
         final String input =
             "InputStream on äÄ üÜ öÖ ß жш";
-        MatcherAssert.assertThat(
-            new TextOf(new ReaderOf(new InputStreamOf(input))).asString(),
-            new IsEqual<>(input)
-        );
+        new Assertion<>(
+            "Must read from stream",
+            new TextOf(new ReaderOf(new InputStreamOf(input))),
+            new TextIs(input)
+        ).affirm();
     }
 
     @Test
     public void readsInputStreamWithCharset() throws Exception {
         final String input =
             "InputStream with charset on äÄ üÜ öÖ ß жш";
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "Must read from stream with charset",
             new TextOf(
                 new ReaderOf(
                     new InputStreamOf(input),
                     StandardCharsets.UTF_8
                 )
-            ).asString(),
-            new IsEqual<>(input)
-        );
+            ),
+            new TextIs(input)
+        ).affirm();
     }
 
     @Test
     public void readsInputStreamWithCharsetByName() throws Exception {
         final String input =
             "InputStream with charset by name on äÄ üÜ öÖ ß жш";
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "Must read from stream with charset by name",
             new TextOf(
                 new ReaderOf(
                     new InputStreamOf(input),
                     StandardCharsets.UTF_8.name()
                 )
-            ).asString(),
-            new IsEqual<>(input)
-        );
+            ),
+            new TextIs(input)
+        ).affirm();
     }
 
     @Test
     public void readsInputStreamWithCharsetDecoder() throws Exception {
         final String input =
             "InputStream with charset decoder on äÄ üÜ öÖ ß жш";
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "Must read from stream with charset decoder",
             new TextOf(
                 new ReaderOf(
                     new InputStreamOf(input),
                     StandardCharsets.UTF_8.newDecoder()
                 )
-            ).asString(),
-            new IsEqual<>(input)
-        );
+            ),
+            new TextIs(input)
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/io/package-info.java
+++ b/src/test/java/org/cactoos/io/package-info.java
@@ -26,7 +26,7 @@
  * Input/Output, tests.
  *
  * @since 0.1
- * @todo #1152:30min Continue replacing usage of MatcherAssert.assertThat with
+ * @todo #1182:30min Continue replacing usage of MatcherAssert.assertThat with
  *  Assertion from cactoos-matchers. Once there is no more usage of
  *  MatcherAssert.assertThat, add the signature of MatcherAssert.assertThat to
  *  forbidden-apis.txt


### PR DESCRIPTION
This is for #1182 

I had to increment cactoos-matchers version to benefit from bugfixes (llorllale/cactoos-matchers#132) that were preventing tests to pass with `Assertion`.