### PR TITLE
(#1212) Fix Setof implementation and test

### DIFF
--- a/src/main/java/org/cactoos/set/SetOf.java
+++ b/src/main/java/org/cactoos/set/SetOf.java
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import org.cactoos.iterable.IterableOf;
-import org.cactoos.scalar.And;
 
 /**
  * Iterable as {@link Set}.
@@ -60,8 +59,9 @@ public final class SetOf<T> extends SetEnvelope<T> {
     public SetOf(final Iterable<T> src) {
         super(() -> {
             final Set<T> tmp = new HashSet<>();
-            new And(tmp::add, src)
-                .value();
+            for (final T elem : src) {
+                tmp.add(elem);
+            }
             return Collections.unmodifiableSet(tmp);
         });
     }

--- a/src/test/java/org/cactoos/set/SetOfTest.java
+++ b/src/test/java/org/cactoos/set/SetOfTest.java
@@ -24,26 +24,21 @@
 package org.cactoos.set;
 
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
  * Test case for {@link SetOf}.
  *
  * @since 0.49.2
- * @checkstyle MagicNumber (500 line)
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class SetOfTest {
 
-    /**
-     * Ensures that SetOf behaves as set, which means no duplicates.
-     */
     @Test
     public void behavesAsSet() {
         MatcherAssert.assertThat(
-            "Can't behave as a set",
-            new SetOf<>(1, 2, 2),
-            new BehavesAsSet<>(2)
+            new SetOf<>(1, 2, 2, 0),
+            Matchers.containsInAnyOrder(1, 2, 0)
         );
     }
 }


### PR DESCRIPTION
Using `And` in `SetOf` was wrong. It stops processing set elements once it finds a duplicate.
A simple `foreach` loop does the job.

Test for `SetOf` was also broken. It only checked if there were no duplicates. It didn't check if all elements required are present. A simple `Matchers.containsInAnyOrder` call does the job better than the `BehavesAsSet` class.