### PR TITLE
(#1212) Fixed SetOf, which discarded all elements after duplicated occurrence

### DIFF
--- a/src/main/java/org/cactoos/set/SetOf.java
+++ b/src/main/java/org/cactoos/set/SetOf.java
@@ -26,6 +26,7 @@ package org.cactoos.set;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import org.cactoos.Proc;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.scalar.And;
 
@@ -60,7 +61,7 @@ public final class SetOf<T> extends SetEnvelope<T> {
     public SetOf(final Iterable<T> src) {
         super(() -> {
             final Set<T> tmp = new HashSet<>();
-            new And(tmp::add, src)
+            new And((Proc<T>) tmp::add, src)
                 .value();
             return Collections.unmodifiableSet(tmp);
         });

--- a/src/main/java/org/cactoos/set/SetOf.java
+++ b/src/main/java/org/cactoos/set/SetOf.java
@@ -26,9 +26,7 @@ package org.cactoos.set;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import org.cactoos.Proc;
 import org.cactoos.iterable.IterableOf;
-import org.cactoos.scalar.And;
 
 /**
  * Iterable as {@link Set}.
@@ -61,8 +59,7 @@ public final class SetOf<T> extends SetEnvelope<T> {
     public SetOf(final Iterable<T> src) {
         super(() -> {
             final Set<T> tmp = new HashSet<>();
-            new And((Proc<T>) tmp::add, src)
-                .value();
+            src.forEach(tmp::add);
             return Collections.unmodifiableSet(tmp);
         });
     }

--- a/src/test/java/org/cactoos/set/SetOfTest.java
+++ b/src/test/java/org/cactoos/set/SetOfTest.java
@@ -25,6 +25,7 @@ package org.cactoos.set;
 
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.Joined;
+import org.cactoos.text.TextOf;
 import org.hamcrest.Matcher;
 import org.hamcrest.core.AllOf;
 import org.hamcrest.core.IsCollectionContaining;
@@ -46,7 +47,7 @@ public final class SetOfTest {
     @Test
     public void behaveAsSetWithOriginalDuplicationsInTheTail() {
         new Assertion<>(
-            "Must keep unique numbers",
+            "Must keep unique integer numbers",
             new SetOf<>(1, 2, 2),
             new AllOf<>(
                 new IterableOf<Matcher<? super SetOf<Integer>>>(
@@ -61,7 +62,7 @@ public final class SetOfTest {
     @Test
     public void behaveAsSetWithOriginalDuplicationsInTheHead() {
         new Assertion<>(
-            "Must keep unique numbers",
+            "Must keep unique integer numbers",
             new SetOf<>(1, 1, 2, 3),
             new AllOf<>(
                 new IterableOf<Matcher<? super SetOf<Integer>>>(
@@ -77,7 +78,7 @@ public final class SetOfTest {
     @Test
     public void behaveAsSetWithOriginalDuplicationsInTheMiddle() {
         new Assertion<>(
-            "Must keep unique numbers",
+            "Must keep unique integer numbers",
             new SetOf<>(1, 2, 2, 3),
             new AllOf<>(
                 new IterableOf<Matcher<? super SetOf<Integer>>>(
@@ -91,7 +92,7 @@ public final class SetOfTest {
     }
 
     @Test
-    public void behaveAsSetWithOriginalMergedCollectionsWithDuplicates() {
+    public void behaveAsSetMergedCollectionsOfLiteralsWithDuplicates() {
         new Assertion<>(
             "Must keep unique string literals",
             new SetOf<String>(
@@ -108,6 +109,65 @@ public final class SetOfTest {
                     new IsCollectionContaining<>(new IsEqual<>("cc")),
                     new IsCollectionContaining<>(new IsEqual<>("dd")),
                     new IsCollectionContaining<>(new IsEqual<>("ff"))
+                )
+            )
+        ).affirm();
+    }
+
+    @Test
+    public void behaveAsSetWithOriginalDuplicationsOfCharsInTheMiddle() {
+        new Assertion<>(
+            "Must keep unique characters",
+            new SetOf<>('a', 'b', 'b', 'c', 'a', 'b', 'd'),
+            new AllOf<>(
+                new IterableOf<Matcher<? super SetOf<Character>>>(
+                    new HasSize(4),
+                    new IsCollectionContaining<>(new IsEqual<>('a')),
+                    new IsCollectionContaining<>(new IsEqual<>('b')),
+                    new IsCollectionContaining<>(new IsEqual<>('c')),
+                    new IsCollectionContaining<>(new IsEqual<>('d'))
+                )
+            )
+        ).affirm();
+    }
+
+    @Test
+    public void behaveAsSetWithOriginalDuplicationsOfDoublesInTheMiddle() {
+        new Assertion<>(
+            "Must keep unique double numbers",
+            new SetOf<>(1.5d, 2.4d, 1.5d, 2.4d, 2.4d, 1.5d),
+            new AllOf<>(
+                new IterableOf<Matcher<? super SetOf<Double>>>(
+                    new HasSize(2),
+                    new IsCollectionContaining<>(new IsEqual<>(1.5d)),
+                    new IsCollectionContaining<>(new IsEqual<>(2.4d))
+                )
+            )
+        ).affirm();
+    }
+
+    @Test
+    public void behaveAsSetWithOriginalDuplicationsOfTextsInTheMiddle() {
+        new Assertion<>(
+            "Must keep unique TextOf objects",
+            new SetOf<>(
+                new TextOf("12345"),
+                new TextOf("67890"),
+                new TextOf("12345"),
+                new TextOf("00000")
+            ),
+            new AllOf<>(
+                new IterableOf<Matcher<? super SetOf<TextOf>>>(
+                    new HasSize(3),
+                    new IsCollectionContaining<>(
+                        new IsEqual<>(new TextOf("12345"))
+                    ),
+                    new IsCollectionContaining<>(
+                        new IsEqual<>(new TextOf("67890"))
+                    ),
+                    new IsCollectionContaining<>(
+                        new IsEqual<>(new TextOf("00000"))
+                    )
                 )
             )
         ).affirm();

--- a/src/test/java/org/cactoos/set/SetOfTest.java
+++ b/src/test/java/org/cactoos/set/SetOfTest.java
@@ -23,27 +23,59 @@
  */
 package org.cactoos.set;
 
-import org.hamcrest.MatcherAssert;
+import org.cactoos.iterable.IterableOf;
+import org.cactoos.iterable.Joined;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.HasValues;
 
 /**
  * Test case for {@link SetOf}.
- *
  * @since 0.49.2
  * @checkstyle MagicNumber (500 line)
+ * @checkstyle JavadocMethodCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class SetOfTest {
 
-    /**
-     * Ensures that SetOf behaves as set, which means no duplicates.
-     */
     @Test
-    public void behavesAsSet() {
-        MatcherAssert.assertThat(
-            "Can't behave as a set",
+    public void behaveAsSetWithOriginalDuplicationsInTheTail() {
+        new Assertion<>(
+            "Must keep unique numbers",
             new SetOf<>(1, 2, 2),
-            new BehavesAsSet<>(2)
-        );
+            new HasValues<>(1, 2)
+        ).affirm();
+    }
+
+    @Test
+    public void behaveAsSetWithOriginalDuplicationsInTheHead() {
+        new Assertion<>(
+            "Must keep unique numbers",
+            new SetOf<>(1, 1, 2, 3),
+            new HasValues<>(1, 2, 3)
+        ).affirm();
+    }
+
+    @Test
+    public void behaveAsSetWithOriginalDuplicationsInTheMiddle() {
+        new Assertion<>(
+            "Must keep unique numbers",
+            new SetOf<>(1, 2, 2, 3),
+            new HasValues<>(1, 2, 3)
+        ).affirm();
+    }
+
+    @Test
+    public void behaveAsSetWithOriginalMergedCollectionsWithDuplicates() {
+        new Assertion<>(
+            "Must keep unique string literals",
+            new SetOf<>(
+                new Joined<>(
+                    new IterableOf<>("cc"),
+                    new IterableOf<>("aa", "bb", "cc", "dd")
+                )
+            ),
+            new HasValues<>("dd", "aa", "bb", "cc")
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/set/SetOfTest.java
+++ b/src/test/java/org/cactoos/set/SetOfTest.java
@@ -25,15 +25,20 @@ package org.cactoos.set;
 
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.Joined;
+import org.hamcrest.Matcher;
+import org.hamcrest.core.AllOf;
+import org.hamcrest.core.IsCollectionContaining;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 import org.llorllale.cactoos.matchers.Assertion;
-import org.llorllale.cactoos.matchers.HasValues;
+import org.llorllale.cactoos.matchers.HasSize;
 
 /**
  * Test case for {@link SetOf}.
  * @since 0.49.2
  * @checkstyle MagicNumber (500 line)
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class SetOfTest {
@@ -43,7 +48,13 @@ public final class SetOfTest {
         new Assertion<>(
             "Must keep unique numbers",
             new SetOf<>(1, 2, 2),
-            new HasValues<>(1, 2)
+            new AllOf<>(
+                new IterableOf<Matcher<? super SetOf<Integer>>>(
+                    new HasSize(2),
+                    new IsCollectionContaining<>(new IsEqual<>(1)),
+                    new IsCollectionContaining<>(new IsEqual<>(2))
+                )
+            )
         ).affirm();
     }
 
@@ -52,7 +63,14 @@ public final class SetOfTest {
         new Assertion<>(
             "Must keep unique numbers",
             new SetOf<>(1, 1, 2, 3),
-            new HasValues<>(1, 2, 3)
+            new AllOf<>(
+                new IterableOf<Matcher<? super SetOf<Integer>>>(
+                    new HasSize(3),
+                    new IsCollectionContaining<>(new IsEqual<>(1)),
+                    new IsCollectionContaining<>(new IsEqual<>(2)),
+                    new IsCollectionContaining<>(new IsEqual<>(3))
+                )
+            )
         ).affirm();
     }
 
@@ -61,7 +79,14 @@ public final class SetOfTest {
         new Assertion<>(
             "Must keep unique numbers",
             new SetOf<>(1, 2, 2, 3),
-            new HasValues<>(1, 2, 3)
+            new AllOf<>(
+                new IterableOf<Matcher<? super SetOf<Integer>>>(
+                    new HasSize(3),
+                    new IsCollectionContaining<>(new IsEqual<>(1)),
+                    new IsCollectionContaining<>(new IsEqual<>(2)),
+                    new IsCollectionContaining<>(new IsEqual<>(3))
+                )
+            )
         ).affirm();
     }
 
@@ -69,13 +94,22 @@ public final class SetOfTest {
     public void behaveAsSetWithOriginalMergedCollectionsWithDuplicates() {
         new Assertion<>(
             "Must keep unique string literals",
-            new SetOf<>(
-                new Joined<>(
-                    new IterableOf<>("cc"),
+            new SetOf<String>(
+                new Joined<String>(
+                    new IterableOf<>("cc", "ff"),
                     new IterableOf<>("aa", "bb", "cc", "dd")
                 )
             ),
-            new HasValues<>("dd", "aa", "bb", "cc")
+            new AllOf<>(
+                new IterableOf<Matcher<? super SetOf<String>>>(
+                    new HasSize(5),
+                    new IsCollectionContaining<>(new IsEqual<>("aa")),
+                    new IsCollectionContaining<>(new IsEqual<>("bb")),
+                    new IsCollectionContaining<>(new IsEqual<>("cc")),
+                    new IsCollectionContaining<>(new IsEqual<>("dd")),
+                    new IsCollectionContaining<>(new IsEqual<>("ff"))
+                )
+            )
         ).affirm();
     }
 }


### PR DESCRIPTION
This pull request is for issue [1212](https://github.com/yegor256/cactoos/issues/1212)

`org.cactoos.set.SetOf` was causing an issue when the original collection/array contained duplicate values, which resulted the cut off of the collection just right after first duplicated value.
