### PR TITLE
(#1236) Immutable decorators are just simple decorators

### DIFF
--- a/src/main/java/org/cactoos/collection/Immutable.java
+++ b/src/main/java/org/cactoos/collection/Immutable.java
@@ -27,7 +27,7 @@ import java.util.Collection;
 import java.util.Iterator;
 
 /**
- * Collection that doesn't allow any modifications.
+ * Decorator that doesn't allow any mutation of the wrapped {@link Collection}.
  *
  * <p>There is no thread-safety guarantee.</p>
  *
@@ -36,11 +36,6 @@ import java.util.Iterator;
  * @todo #898:30min Replace all the Collections.unmodifiableCollection
  *  with the {@link org.cactoos.collection.Immutable} from the cactoos codebase.
  *  That should be done because Elegant Object principles are against static methods.
- * @todo #1224:30min Original collection should be copied inside this
- *  immutable decorator. That should be done because otherwise true immutability
- *  cannot be achieved.
- *  see: https://github.com/yegor256/cactoos/issues/1224 and
- *  https://docs.oracle.com/javase/tutorial/essential/concurrency/immutable.html
  */
 @SuppressWarnings(
     {

--- a/src/main/java/org/cactoos/iterator/Immutable.java
+++ b/src/main/java/org/cactoos/iterator/Immutable.java
@@ -26,7 +26,7 @@ package org.cactoos.iterator;
 import java.util.Iterator;
 
 /**
- * Iterator that doesn't allow removal of elements.
+ * Decorator that doesn't allow removal from the wrapped {@link Iterator}.
  *
  * <p>There is no thread-safety guarantee.</p>
  *

--- a/src/main/java/org/cactoos/list/Immutable.java
+++ b/src/main/java/org/cactoos/list/Immutable.java
@@ -23,23 +23,13 @@
  */
 package org.cactoos.list;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
-import org.cactoos.Scalar;
-import org.cactoos.iterable.IterableOf;
-import org.cactoos.scalar.And;
-import org.cactoos.scalar.Folded;
-import org.cactoos.scalar.Or;
-import org.cactoos.scalar.SumOfInt;
-import org.cactoos.scalar.Unchecked;
-import org.cactoos.text.TextOf;
-import org.cactoos.text.UncheckedText;
 
 /**
- * {@link List} envelope that doesn't allow mutations.
+ * Decorator that doesn't allow mutations of the wrapped {@link List}.
  *
  * <p>There is no thread-safety guarantee.</p>
  *
@@ -66,43 +56,10 @@ public final class Immutable<T> implements List<T> {
 
     /**
      * Ctor.
-     * @param items Source array
-     */
-    @SafeVarargs
-    public Immutable(final T... items) {
-        this(new IterableOf<T>(items));
-    }
-
-    /**
-     * Ctor.
-     * @param src Source list
-     */
-    public Immutable(final List<T> src) {
-        this(() -> new ListOf<>(src));
-    }
-
-    /**
-     * Ctor.
-     * @param src Source iterable
-     */
-    public Immutable(final Iterable<T> src) {
-        this(() -> new ListOf<>(src));
-    }
-
-    /**
-     * Ctor.
      * @param src Source collection
      */
-    public Immutable(final Collection<T> src) {
-        this(() -> new ListOf<>(src));
-    }
-
-    /**
-     * Ctor.
-     * @param slr The scalar
-     */
-    public Immutable(final Scalar<List<T>> slr) {
-        this.list = new Unchecked<>(slr).value();
+    public Immutable(final List<T> src) {
+        this.list = src;
     }
 
     @Override
@@ -248,46 +205,17 @@ public final class Immutable<T> implements List<T> {
     }
 
     @Override
-    @SuppressFBWarnings("EQ_UNUSUAL")
     public boolean equals(final Object other) {
-        return new Unchecked<>(
-            new Or(
-                () -> other == this,
-                new And(
-                    () -> other != null,
-                    () -> List.class.isAssignableFrom(other.getClass()),
-                    () -> {
-                        final List<?> compared = (List<?>) other;
-                        final Iterator<?> iterator = compared.iterator();
-                        return new Unchecked<>(
-                            new And(
-                                (T input) -> input.equals(iterator.next()),
-                                this
-                            )
-                        ).value();
-                    }
-                )
-            )
-        ).value();
+        return this.list.equals(other);
     }
 
-    // @checkstyle MagicNumberCheck (30 lines)
     @Override
     public int hashCode() {
-        return new Unchecked<>(
-            new Folded<>(
-                42,
-                (hash, entry) -> new SumOfInt(
-                    () -> 37 * hash,
-                    entry::hashCode
-                ).value(),
-                this
-            )
-        ).value();
+        return this.list.hashCode();
     }
 
     @Override
     public String toString() {
-        return new UncheckedText(new TextOf(this)).asString();
+        return this.list.toString();
     }
 }

--- a/src/test/java/org/cactoos/list/ImmutableTest.java
+++ b/src/test/java/org/cactoos/list/ImmutableTest.java
@@ -45,15 +45,14 @@ import org.llorllale.cactoos.matchers.Throws;
 public class ImmutableTest {
 
     @Test
-    public void innerListMustNotBeChanged() {
+    public void innerListIsDecorated() {
         final List<String> strings = new ArrayList<>(Arrays.asList("a", "b", "c"));
         final List<String> immutable = new Immutable<>(strings);
-        final int original = immutable.size();
         strings.add("d");
         new Assertion<>(
-            "inner list must not be changed",
-            original,
-            new IsEqual<>(immutable.size())
+            "Must reflect inner list in the decorator",
+            immutable,
+            new IsEqual<>(strings)
         ).affirm();
     }
 
@@ -408,7 +407,7 @@ public class ImmutableTest {
     public void notEqualsToObjectOfAnotherType() {
         new Assertion<>(
             "must not equal to object of another type",
-            new Immutable<>(),
+            new Immutable<>(new ListOf<>()),
             new IsNot<>(new IsEqual<>(new Object()))
         ).affirm();
     }
@@ -417,14 +416,14 @@ public class ImmutableTest {
     public void notEqualsToListWithDifferentElements() {
         new Assertion<>(
             "must not equal to List with different elements",
-            new Immutable<>(1, 2),
+            new Immutable<>(new ListOf<>(1, 2)),
             new IsNot<>(new IsEqual<>(new ListOf<>(1, 0)))
         ).affirm();
     }
 
     @Test
     public void isEqualToItself() {
-        final List<Integer> list = new Immutable<>(1, 2);
+        final List<Integer> list = new Immutable<>(new ListOf<>(1, 2));
         new Assertion<>(
             "must be equal to itself",
             list,
@@ -436,7 +435,7 @@ public class ImmutableTest {
     public void isEqualToListWithTheSameElements() {
         new Assertion<>(
             "must be equal to List with the same elements",
-            new Immutable<>(1, 2),
+            new Immutable<>(new ListOf<>(1, 2)),
             new IsEqual<>(new ListOf<>(1, 2))
         ).affirm();
     }
@@ -445,8 +444,8 @@ public class ImmutableTest {
     public void equalToEmptyImmutable() {
         new Assertion<>(
             "empty Immutable must be equal to empty Immutable",
-            new Immutable<>(),
-            new IsEqual<>(new Immutable<>())
+            new Immutable<>(new ListOf<>()),
+            new IsEqual<>(new Immutable<>(new ListOf<>()))
         ).affirm();
     }
 
@@ -454,9 +453,9 @@ public class ImmutableTest {
     public void testHashCode() {
         new Assertion<>(
             "hashCode() must be equal to hashCode of the corresponding List",
-            new Immutable<>(1, 2, 3).hashCode(),
+            new Immutable<>(new ListOf<>(1, 2, 3)).hashCode(),
             new IsEqual<>(
-                new Immutable<>(1, 2, 3).hashCode()
+                new ListOf<>(1, 2, 3).hashCode()
             )
         ).affirm();
     }
@@ -464,9 +463,9 @@ public class ImmutableTest {
     @Test
     public void testToString() {
         new Assertion<>(
-            "toString() must be concatenation of nested elements",
-            new Immutable<>("a", "b", "c").toString(),
-            new IsEqual<>("a, b, c")
+            "toString() must be equal to toString of the corresponding List",
+            new Immutable<>(new ListOf<>("a", "b", "c")).toString(),
+            new IsEqual<>(new ListOf<>("a", "b", "c").toString())
         ).affirm();
     }
 }


### PR DESCRIPTION
This is for #1236 

Following discussion with ARC, it was decided that `Immutable` should only decorate and not introduce behaviour or internal state.

I took the liberty of applying the same to `list` and `iterator` since there was not so much to do just for `collection`.

I removed extra constructors as they are out of scope of the responsibility of an immutable decorator.