### PR TITLE
(#1185) List Envelope is just an envelope

### DIFF
--- a/src/main/java/org/cactoos/list/Joined.java
+++ b/src/main/java/org/cactoos/list/Joined.java
@@ -26,6 +26,7 @@ package org.cactoos.list;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.cactoos.iterable.IterableOf;
 
 /**
  * Joined list.
@@ -42,9 +43,8 @@ public final class Joined<X> extends ListEnvelope<X> {
      * @param src Source lists
      */
     @SafeVarargs
-    @SuppressWarnings("PMD.UseVarargs")
     public Joined(final List<X>... src) {
-        this(new ListOf<>(src));
+        this(new IterableOf<>(src));
     }
 
     /**
@@ -53,8 +53,9 @@ public final class Joined<X> extends ListEnvelope<X> {
      * @param items List
      * @since 0.32
      */
+    @SuppressWarnings("unchecked")
     public Joined(final X item, final List<X> items) {
-        super(() -> new Joined<X>(new ListOf<X>(item), items));
+        super(new Joined<>(new ListOf<>(item), items));
     }
 
     /**
@@ -62,10 +63,11 @@ public final class Joined<X> extends ListEnvelope<X> {
      * @param src Source lists
      */
     public Joined(final Iterable<List<X>> src) {
-        super(() -> Collections.unmodifiableList(
-            new ListOf<>(src).stream()
-                .flatMap(List::stream)
-                .collect(Collectors.toList())
+        super(
+            Collections.unmodifiableList(
+                new ListOf<>(src).stream()
+                    .flatMap(List::stream)
+                    .collect(Collectors.toList())
             )
         );
     }

--- a/src/main/java/org/cactoos/list/ListEnvelope.java
+++ b/src/main/java/org/cactoos/list/ListEnvelope.java
@@ -26,9 +26,7 @@ package org.cactoos.list;
 import java.util.Collection;
 import java.util.List;
 import java.util.ListIterator;
-import org.cactoos.Scalar;
 import org.cactoos.collection.CollectionEnvelope;
-import org.cactoos.scalar.Unchecked;
 
 /**
  * {@link List} envelope that allows mutations.
@@ -38,11 +36,6 @@ import org.cactoos.scalar.Unchecked;
  * @param <T> Element type
  * @since 0.23
  * @checkstyle AbstractClassNameCheck (500 lines)
- * @todo #947:30min ListEnvelope should only delegates all the methods
- *  of List to the wrapped List. See IterableEnvelope for an example.
- *  If needed ListOf should have some methods that were previously here
- *  and implement List instead of extending ListEnvelope.
- *  Again see IterableOf for an example.
  */
 @SuppressWarnings(
     {
@@ -65,14 +58,6 @@ public abstract class ListEnvelope<T> extends CollectionEnvelope<T> implements
     public ListEnvelope(final List<T> list) {
         super(list);
         this.list = list;
-    }
-
-    /**
-     * Ctor.
-     * @param slr The scalar
-     */
-    public ListEnvelope(final Scalar<List<T>> slr) {
-        this(new Unchecked<>(slr).value());
     }
 
     @Override

--- a/src/main/java/org/cactoos/list/ListOf.java
+++ b/src/main/java/org/cactoos/list/ListOf.java
@@ -23,11 +23,15 @@
  */
 package org.cactoos.list;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.ListIterator;
+import org.cactoos.Scalar;
 import org.cactoos.iterable.IterableOf;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Iterable as {@link List}.
@@ -45,7 +49,11 @@ import org.cactoos.iterable.IterableOf;
  * @see Sticky
  * @since 0.1
  */
-public final class ListOf<T> extends ListEnvelope<T> {
+public final class ListOf<T> implements List<T> {
+    /**
+     * List.
+     */
+    private final Unchecked<List<T>> list;
 
     /**
      * Ctor.
@@ -71,13 +79,148 @@ public final class ListOf<T> extends ListEnvelope<T> {
      * @param src An {@link Iterable}
      */
     public ListOf(final Iterable<T> src) {
-        super(() -> {
+        this(() -> {
             final List<T> temp = new LinkedList<>();
-            for (final T item : src) {
-                temp.add(item);
-            }
+            src.forEach(temp::add);
             return Collections.unmodifiableList(temp);
         });
     }
 
+    /**
+     * Ctor.
+     * @param slr The scalar
+     */
+    public ListOf(final Scalar<List<T>> slr) {
+        this.list = new Unchecked<>(slr);
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return this.list.value().iterator();
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return this.list.value().equals(other);
+    }
+
+    @Override
+    public int hashCode() {
+        return this.list.value().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return this.list.value().toString();
+    }
+
+    @Override
+    public int size() {
+        return this.list.value().size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return this.list.value().isEmpty();
+    }
+
+    @Override
+    public boolean contains(final Object object) {
+        return this.list.value().contains(object);
+    }
+
+    @Override
+    public Object[] toArray() {
+        return this.list.value().toArray();
+    }
+
+    @Override
+    public <X> X[] toArray(final X[] array) {
+        return this.list.value().toArray(array);
+    }
+
+    @Override
+    public boolean add(final T item) {
+        return this.list.value().add(item);
+    }
+
+    @Override
+    public boolean remove(final Object object) {
+        return this.list.value().remove(object);
+    }
+
+    @Override
+    public boolean containsAll(final Collection<?> col) {
+        return this.list.value().containsAll(col);
+    }
+
+    @Override
+    public boolean addAll(final Collection<? extends T> col) {
+        return this.list.value().addAll(col);
+    }
+
+    @Override
+    public boolean removeAll(final Collection<?> col) {
+        return this.list.value().removeAll(col);
+    }
+
+    @Override
+    public boolean retainAll(final Collection<?> col) {
+        return this.list.value().retainAll(col);
+    }
+
+    @Override
+    public void clear() {
+        this.list.value().clear();
+    }
+
+    @Override
+    public boolean addAll(final int index, final Collection<? extends T> col) {
+        return this.list.value().addAll(index, col);
+    }
+
+    @Override
+    public T get(final int index) {
+        return this.list.value().get(index);
+    }
+
+    @Override
+    public T set(final int index, final T element) {
+        return this.list.value().set(index, element);
+    }
+
+    @Override
+    public void add(final int index, final T element) {
+        this.list.value().add(index, element);
+    }
+
+    @Override
+    public T remove(final int index) {
+        return this.list.value().remove(index);
+    }
+
+    @Override
+    public int indexOf(final Object element) {
+        return this.list.value().indexOf(element);
+    }
+
+    @Override
+    public int lastIndexOf(final Object element) {
+        return this.list.value().lastIndexOf(element);
+    }
+
+    @Override
+    public ListIterator<T> listIterator() {
+        return this.list.value().listIterator();
+    }
+
+    @Override
+    public ListIterator<T> listIterator(final int index) {
+        return this.list.value().listIterator(index);
+    }
+
+    @Override
+    public List<T> subList(final int start, final int end) {
+        return this.list.value().subList(start, end);
+    }
 }

--- a/src/main/java/org/cactoos/list/Mapped.java
+++ b/src/main/java/org/cactoos/list/Mapped.java
@@ -42,7 +42,7 @@ public final class Mapped<X, Y> extends ListEnvelope<Y> {
      * @param src Source iterable
      */
     public Mapped(final Func<X, Y> fnc, final Iterable<X> src) {
-        super(() -> new ListOf<Y>(
+        super(new ListOf<>(
             new org.cactoos.iterable.Mapped<>(fnc, src)
         ));
     }

--- a/src/main/java/org/cactoos/list/Shuffled.java
+++ b/src/main/java/org/cactoos/list/Shuffled.java
@@ -23,10 +23,10 @@
  */
 package org.cactoos.list;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import org.cactoos.iterable.IterableOf;
 
 /**
  * Shuffled list.
@@ -51,29 +51,24 @@ public final class Shuffled<T> extends ListEnvelope<T> {
      */
     @SafeVarargs
     public Shuffled(final T... src) {
-        this(new ListOf<>(src));
-    }
-
-    /**
-     * Ctor.
-     * @param src The underlying collection
-     */
-    @SuppressWarnings("unchecked")
-    public Shuffled(final Iterable<T> src) {
-        this(new ListOf<>(src));
+        this(new IterableOf<>(src));
     }
 
     /**
      * Ctor.
      * @param src Source
      */
-    public Shuffled(final Collection<T> src) {
-        super(() -> {
-            final List<T> items = new LinkedList<>();
-            items.addAll(src);
-            Collections.shuffle(items);
-            return Collections.unmodifiableList(items);
-        });
+    public Shuffled(final Iterable<T> src) {
+        super(
+            new ListOf<>(
+                () -> {
+                    final List<T> items = new LinkedList<>();
+                    src.forEach(items::add);
+                    Collections.shuffle(items);
+                    return Collections.unmodifiableList(items);
+                }
+            )
+        );
     }
 
 }

--- a/src/main/java/org/cactoos/list/Solid.java
+++ b/src/main/java/org/cactoos/list/Solid.java
@@ -50,8 +50,10 @@ public final class Solid<X> extends ListEnvelope<X> {
      */
     public Solid(final Iterable<X> items) {
         super(
-            new org.cactoos.scalar.Solid<>(
-                () -> new Synced<>(new Sticky<>(items))
+            new ListOf<>(
+                new org.cactoos.scalar.Solid<>(
+                    () -> new Synced<>(new Sticky<>(items))
+                )
             )
         );
     }

--- a/src/main/java/org/cactoos/list/Sorted.java
+++ b/src/main/java/org/cactoos/list/Sorted.java
@@ -23,11 +23,11 @@
  */
 package org.cactoos.list;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedList;
 import java.util.List;
+import org.cactoos.iterable.IterableOf;
 
 /**
  * Sorted list.
@@ -52,7 +52,7 @@ public final class Sorted<T> extends ListEnvelope<T> {
      */
     @SafeVarargs
     public Sorted(final T... src) {
-        this(new ListOf<>(src));
+        this(new IterableOf<>(src));
     }
 
     /**
@@ -66,7 +66,7 @@ public final class Sorted<T> extends ListEnvelope<T> {
      */
     @SuppressWarnings("unchecked")
     public Sorted(final Iterable<T> src) {
-        this((Comparator<T>) Comparator.naturalOrder(), new ListOf<>(src));
+        this((Comparator<T>) Comparator.naturalOrder(), src);
     }
 
     /**
@@ -76,7 +76,7 @@ public final class Sorted<T> extends ListEnvelope<T> {
      */
     @SafeVarargs
     public Sorted(final Comparator<T> cmp, final T... src) {
-        this(cmp, new ListOf<>(src));
+        this(cmp, new IterableOf<>(src));
     }
 
     /**
@@ -84,12 +84,16 @@ public final class Sorted<T> extends ListEnvelope<T> {
      * @param cmp The comparator
      * @param src The underlying collection
      */
-    public Sorted(final Comparator<T> cmp, final Collection<T> src) {
-        super(() -> {
-            final List<T> items = new ArrayList<>(src.size());
-            items.addAll(src);
-            items.sort(cmp);
-            return Collections.unmodifiableList(items);
-        });
+    public Sorted(final Comparator<T> cmp, final Iterable<T> src) {
+        super(
+            new ListOf<>(
+                () -> {
+                    final List<T> items = new LinkedList<>();
+                    src.forEach(items::add);
+                    items.sort(cmp);
+                    return Collections.unmodifiableList(items);
+                }
+            )
+        );
     }
 }

--- a/src/main/java/org/cactoos/list/Sticky.java
+++ b/src/main/java/org/cactoos/list/Sticky.java
@@ -23,17 +23,12 @@
  */
 package org.cactoos.list;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import org.cactoos.iterable.IterableOf;
-import org.cactoos.iterable.Matched;
 
 /**
  * List decorator that goes through the list only once.
- *
- * <p>The list is read only.</p>
  *
  * <p>There is no thread-safety guarantee.
  *
@@ -53,24 +48,18 @@ public final class Sticky<X> extends ListEnvelope<X> {
 
     /**
      * Ctor.
-     * @param items The array
-     */
-    public Sticky(final Iterable<X> items) {
-        this(new ListOf<>(items));
-    }
-
-    /**
-     * Ctor.
      * @param list The iterable
      */
-    public Sticky(final Collection<X> list) {
+    public Sticky(final Iterable<X> list) {
         super(
-            new org.cactoos.scalar.Sticky<>(
-                () -> {
-                    final List<X> temp = new LinkedList<>();
-                    temp.addAll(list);
-                    return Collections.unmodifiableList(temp);
-                }
+            new ListOf<>(
+                new org.cactoos.scalar.Sticky<>(
+                    () -> {
+                        final List<X> temp = new LinkedList<>();
+                        list.forEach(temp::add);
+                        return temp;
+                    }
+                )
             )
         );
     }

--- a/src/main/java/org/cactoos/list/Synced.java
+++ b/src/main/java/org/cactoos/list/Synced.java
@@ -23,7 +23,6 @@
  */
 package org.cactoos.list;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -59,24 +58,18 @@ public final class Synced<X> extends ListEnvelope<X> {
 
     /**
      * Ctor.
-     * @param items The array
-     */
-    public Synced(final Iterable<X> items) {
-        this(new ListOf<>(items));
-    }
-
-    /**
-     * Ctor.
      * @param list The iterable
      */
-    public Synced(final Collection<X> list) {
+    public Synced(final Iterable<X> list) {
         super(
-            new org.cactoos.scalar.Synced<>(
-                () -> {
-                    final List<X> temp = new LinkedList<>();
-                    temp.addAll(list);
-                    return Collections.synchronizedList(temp);
-                }
+            new ListOf<>(
+                new org.cactoos.scalar.Synced<>(
+                    () -> {
+                        final List<X> temp = new LinkedList<>();
+                        list.forEach(temp::add);
+                        return Collections.synchronizedList(temp);
+                    }
+                )
             )
         );
     }

--- a/src/test/java/org/cactoos/func/ForEachInThreadsTest.java
+++ b/src/test/java/org/cactoos/func/ForEachInThreadsTest.java
@@ -26,6 +26,7 @@ package org.cactoos.func;
 import java.util.ArrayList;
 import java.util.List;
 import org.cactoos.list.ListOf;
+import org.cactoos.list.Sticky;
 import org.cactoos.list.Synced;
 import org.hamcrest.collection.IsIterableContainingInAnyOrder;
 import org.junit.Test;
@@ -37,15 +38,16 @@ import org.llorllale.cactoos.matchers.MatcherOf;
  *
  * @since 1.0
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public class ForEachInThreadsTest {
 
     @Test
     @SuppressWarnings("unchecked")
     public void testProcIterable() throws Exception {
-        final List<Integer> list = new Synced<>(
-            new ArrayList<>(
-                2
+        final List<Integer> list = new Sticky<>(
+            new Synced<>(
+                new ArrayList<>(2)
             )
         );
         new ForEachInThreads<Integer>(

--- a/src/test/java/org/cactoos/list/ImmutableTest.java
+++ b/src/test/java/org/cactoos/list/ImmutableTest.java
@@ -26,6 +26,7 @@ package org.cactoos.list;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.ListIterator;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNot;
 import org.junit.Test;
@@ -53,6 +54,97 @@ public class ImmutableTest {
             "Must reflect inner list in the decorator",
             immutable,
             new IsEqual<>(strings)
+        ).affirm();
+    }
+
+    @Test
+    public void returnsListIteratorWithUnsupportedRemove() {
+        new Assertion<>(
+            "Must return a list iterator that does not support remove()",
+            () -> {
+                final List<String> list = new Immutable<>(new ListOf<>("one"));
+                final ListIterator<String> iterator = list.listIterator();
+                iterator.next();
+                iterator.remove();
+                return true;
+            },
+            new Throws<>(UnsupportedOperationException.class)
+        ).affirm();
+    }
+
+    @Test
+    public void returnsListIteratorWithUnsupportedAdd() {
+        new Assertion<>(
+            "Must return a list iterator that does not support add()",
+            () -> {
+                final List<String> list = new Immutable<>(new ListOf<>("one"));
+                final ListIterator<String> iterator = list.listIterator();
+                iterator.next();
+                iterator.add("two");
+                return true;
+            },
+            new Throws<>(UnsupportedOperationException.class)
+        ).affirm();
+    }
+
+    @Test
+    public void subListReturnsListIteratorWithUnsupportedRemove() {
+        new Assertion<>(
+            "Must return a subtlist with a list iterator that does not support remove()",
+            () -> {
+                final List<String> list = new Immutable<>(new ListOf<>("one"));
+                final ListIterator<String> iterator = list.subList(0, 1).listIterator();
+                iterator.next();
+                iterator.remove();
+                return true;
+            },
+            new Throws<>(UnsupportedOperationException.class)
+        ).affirm();
+    }
+
+    @Test
+    public void subListReturnsListIteratorWithUnsupportedAdd() {
+        new Assertion<>(
+            "Must return a subtlist with a list iterator that does not support add()",
+            () -> {
+                final List<String> list = new Immutable<>(new ListOf<>("one"));
+                final ListIterator<String> iterator = list.subList(0, 1).listIterator();
+                iterator.next();
+                iterator.add("two");
+                return true;
+            },
+            new Throws<>(UnsupportedOperationException.class)
+        ).affirm();
+    }
+
+    @Test()
+    public void subListReturnsListIteratorWithUnsupportedSet() {
+        new Assertion<>(
+            "subList.listIterator().set() must throw exception",
+            () -> {
+                final ListIterator<String> iterator = new Immutable<>(
+                    new ListOf<>("one", "two", "three")
+                ).subList(0, 2).listIterator(0);
+                iterator.next();
+                iterator.set("zero");
+                return new Object();
+            },
+            new Throws<>(
+                "List Iterator is read-only and doesn't allow rewriting items",
+                UnsupportedOperationException.class
+            )
+        ).affirm();
+    }
+
+    @Test()
+    public void returnsSubListWithUnsupportedSet() {
+        new Assertion<>(
+            "subList.set() must throw exception",
+            () -> new Immutable<>(new ListOf<>("one")).subList(0, 1).set(0, "zero"),
+            new Throws<>(
+                "#set(): the list is read-only",
+                UnsupportedOperationException.class
+            )
         ).affirm();
     }
 
@@ -453,9 +545,9 @@ public class ImmutableTest {
     public void testHashCode() {
         new Assertion<>(
             "hashCode() must be equal to hashCode of the corresponding List",
-            new Immutable<>(new ListOf<>(1, 2, 3)).hashCode(),
+            new Immutable<>(new ListOf<>(1, 2)).hashCode(),
             new IsEqual<>(
-                new ListOf<>(1, 2, 3).hashCode()
+                new ListOf<>(1, 2).hashCode()
             )
         ).affirm();
     }

--- a/src/test/java/org/cactoos/list/ListEnvelopeTest.java
+++ b/src/test/java/org/cactoos/list/ListEnvelopeTest.java
@@ -23,7 +23,6 @@
  */
 package org.cactoos.list;
 
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.ListIterator;
@@ -215,13 +214,13 @@ public final class ListEnvelopeTest {
 
     private static final class StringList extends ListEnvelope<String> {
         StringList(final String... elements) {
-            super(() -> new Immutable<>(Arrays.asList(elements)));
+            super(new Immutable<>(new ListOf<>(elements)));
         }
     }
 
     private static final class MutableStringList extends ListEnvelope<String> {
         MutableStringList(final String... elements) {
-            super(() -> new LinkedList<>(Arrays.asList(elements)));
+            super(new LinkedList<>(new ListOf<>(elements)));
         }
     }
 }

--- a/src/test/java/org/cactoos/list/ListIteratorOfTest.java
+++ b/src/test/java/org/cactoos/list/ListIteratorOfTest.java
@@ -1,0 +1,83 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2020 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.list;
+
+import org.hamcrest.core.IsEqual;
+import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+
+/**
+ * Test cases for {@link ListIteratorOf}.
+ *
+ * @since 0.35
+ * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle MagicNumberCheck (500 lines)
+ */
+public final class ListIteratorOfTest {
+    @Test
+    public void mustReturnPreviousIndex() {
+        new Assertion<>(
+            "List Iterator must return previous index",
+            new ListIteratorOf<>(
+                new ListOf<>(1)
+            ).previousIndex(),
+            new IsEqual<>(-1)
+        ).affirm();
+    }
+
+    @Test
+    public void mustReturnPreviousElement() {
+        new Assertion<>(
+            "List Iterator must return previous element",
+            new ListIteratorOf<>(
+                new ListOf<>(3, 7),
+                1
+            ).previous(),
+            new IsEqual<>(3)
+        ).affirm();
+    }
+
+    @Test
+    public void mustReturnNextIndex() {
+        new Assertion<>(
+            "List iterator must return next index",
+            new ListIteratorOf<>(
+                new ListOf<>(1)
+            ).nextIndex(),
+            new IsEqual<>(0)
+        ).affirm();
+    }
+
+    @Test
+    public void mustReturnNextElement() {
+        new Assertion<>(
+            "List iterator must return next item",
+            new ListIteratorOf<>(
+                new ListOf<>(5, 11, 13),
+                1
+            ).next(),
+            new IsEqual<>(11)
+        ).affirm();
+    }
+}

--- a/src/test/java/org/cactoos/list/StickyTest.java
+++ b/src/test/java/org/cactoos/list/StickyTest.java
@@ -23,7 +23,6 @@
  */
 package org.cactoos.list;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -152,51 +151,6 @@ public final class StickyTest {
             list.size(),
             new IsEqual<>(2)
         );
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testAdd() throws Exception {
-        new Sticky<>(1, 2).add(1);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testRemove() throws Exception {
-        new Sticky<>(1, 2).remove(1);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testAddAll() throws Exception {
-        new Sticky<>(1, 2).addAll(new ArrayList<>(2));
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testRemoveAll() throws Exception {
-        new Sticky<>(1, 2).removeAll(new ArrayList<>(2));
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testRetainAll() throws Exception {
-        new Sticky<>(1, 2).retainAll(new ArrayList<>(2));
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testClear() throws Exception {
-        new Sticky<>(1, 2).clear();
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testSet() throws Exception {
-        new Sticky<>(1, 2).set(1, 1);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testAddIndex() throws Exception {
-        new Sticky<>(1, 2).add(1, 1);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testRemoveIndex() throws Exception {
-        new Sticky<>(1, 2).remove(1);
     }
 
     @Test

--- a/src/test/java/org/cactoos/scalar/AndInThreadsTest.java
+++ b/src/test/java/org/cactoos/scalar/AndInThreadsTest.java
@@ -33,6 +33,7 @@ import org.cactoos.func.ProcNoNulls;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.Mapped;
 import org.cactoos.list.ListOf;
+import org.cactoos.list.Sticky;
 import org.cactoos.list.Synced;
 import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
@@ -99,8 +100,8 @@ public final class AndInThreadsTest {
 
     @Test
     public void iteratesList() {
-        final List<String> list = new Synced<>(
-            new ArrayList<>(2)
+        final List<String> list = new Sticky<>(
+            new Synced<>(new ArrayList<>(2))
         );
         MatcherAssert.assertThat(
             "Can't iterate a list with a procedure",
@@ -182,8 +183,8 @@ public final class AndInThreadsTest {
 
     @Test
     public void worksWithExecServiceProcValues() throws Exception {
-        final List<Integer> list = new Synced<>(
-            new ArrayList<>(2)
+        final List<Integer> list = new Sticky<>(
+            new Synced<>(new ArrayList<>(2))
         );
         final ExecutorService service = Executors.newSingleThreadExecutor();
         new AndInThreads(
@@ -212,8 +213,8 @@ public final class AndInThreadsTest {
 
     @Test
     public void worksWithExecServiceProcIterable() throws Exception {
-        final List<Integer> list = new Synced<>(
-            new ArrayList<>(2)
+        final List<Integer> list = new Sticky<>(
+            new Synced<>(new ArrayList<>(2))
         );
         final ExecutorService service = Executors.newSingleThreadExecutor();
         new AndInThreads(


### PR DESCRIPTION
This is for #1185.

I had to remove the unmodifiable wrapper in `Sticky` for things to work as expected. This is coherent with work planned in #1233 to remove them from all `List` implementations.

I also simplified the constructors of the `List` implementations since `List` and `Collection` implements `Iterable`.