### PR TITLE
(#1218) Replaced Collections.emptyList with ListOf

### DIFF
--- a/src/test/java/org/cactoos/collection/JoinedTest.java
+++ b/src/test/java/org/cactoos/collection/JoinedTest.java
@@ -23,7 +23,6 @@
  */
 package org.cactoos.collection;
 
-import java.util.Collections;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.list.ListOf;
 import org.hamcrest.collection.IsCollectionWithSize;
@@ -40,9 +39,6 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle MagicNumber (500 line)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @todo #898:15min Replace Collections.emptyList() with the {@link ListOf}
- *  That is because it is necessary to get rid of the static methods
- *  as much as possible
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public final class JoinedTest {
@@ -78,7 +74,7 @@ public final class JoinedTest {
         new Assertion<>(
             "Size must be 0",
             new Joined<String>(
-                Collections.emptyList()
+                new ListOf<String>()
             ),
             new IsCollectionWithSize<>(new IsEqual<>(0))
         ).affirm();
@@ -101,7 +97,7 @@ public final class JoinedTest {
         new Assertion<>(
             "Must be empty",
             new Joined<String>(
-                Collections.emptyList()
+                new ListOf<String>()
             ),
             new IsEmptyCollection<>()
         ).affirm();


### PR DESCRIPTION
This is for #1218 

Resolved puzzle `898-4936d4fd`

Updated class `org.cactoos.collection.JoinedTest` to remove reference to `Collections.emptyList()` static method reference.