### PR TITLE
(#1239) HeadInput is renamed to HeadOf

### DIFF
--- a/src/main/java/org/cactoos/io/HeadOf.java
+++ b/src/main/java/org/cactoos/io/HeadOf.java
@@ -31,7 +31,7 @@ import org.cactoos.Input;
  *
  * @since 0.31
  */
-public final class HeadInput implements Input {
+public final class HeadOf implements Input {
 
     /**
      * The original input.
@@ -48,7 +48,7 @@ public final class HeadInput implements Input {
      * @param orig The original input.
      * @param len Limit of bytes that can be read from the beginning.
      */
-    public HeadInput(final Input orig, final int len) {
+    public HeadOf(final Input orig, final int len) {
         this.origin = orig;
         this.length = len;
     }

--- a/src/test/java/org/cactoos/io/HeadOfTest.java
+++ b/src/test/java/org/cactoos/io/HeadOfTest.java
@@ -52,6 +52,20 @@ public final class HeadOfTest {
     }
 
     @Test
+    public void readsEmptyHeadOfInput() throws Exception {
+        new Assertion<>(
+            "must limit to 0 the number of read bytes",
+            new TextOf(
+                new HeadOf(
+                    new InputOf("readsEmptyHeadOfInput"),
+                    0
+                )
+            ),
+            new TextHasString("")
+        ).affirm();
+    }
+
+    @Test
     public void readsHeadOfShorterInput() throws Exception {
         final String input = "readsHeadOfShorterInput";
         new Assertion<>(

--- a/src/test/java/org/cactoos/io/HeadOfTest.java
+++ b/src/test/java/org/cactoos/io/HeadOfTest.java
@@ -29,20 +29,20 @@ import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.TextHasString;
 
 /**
- * Test cases for {@link HeadInput}.
+ * Test cases for {@link HeadOf}.
  *
  * @since 0.31
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle MagicNumberCheck (500 lines)
  */
-public final class HeadInputTest {
+public final class HeadOfTest {
 
     @Test
     public void readsHeadOfLongerInput() throws Exception {
         new Assertion<>(
             "must limit exactly the number of read bytes",
             new TextOf(
-                new HeadInput(
+                new HeadOf(
                     new InputOf("readsHeadOfLongerInput"),
                     5
                 )
@@ -57,7 +57,7 @@ public final class HeadInputTest {
         new Assertion<>(
             "must limit to at most the number of available bytes",
             new TextOf(
-                new HeadInput(
+                new HeadOf(
                     new InputOf(input),
                     35
                 )


### PR DESCRIPTION
This is for #1239, as per discussed with ARC, we rename `HeadInput` to `HeadOf` to homogenize naming.