### PR TITLE
(#1292) SetOf and Sorted are real in memory sets

### DIFF
--- a/src/main/java/org/cactoos/set/SetOf.java
+++ b/src/main/java/org/cactoos/set/SetOf.java
@@ -26,14 +26,9 @@ package org.cactoos.set;
 import java.util.HashSet;
 import java.util.Set;
 import org.cactoos.iterable.IterableOf;
-import org.cactoos.scalar.Unchecked;
 
 /**
- * Iterable as {@link Set}.
- *
- * <p>This class should be used very carefully. You must understand that
- * it will fetch the entire content of the encapsulated {@link Set} on each
- * method call. It doesn't cache the data anyhow. </p>
+ * Iterable as {@link Set} based on {@link HashSet}.
  *
  * <p>There is no thread-safety guarantee.
  *
@@ -57,14 +52,7 @@ public final class SetOf<T> extends SetEnvelope<T> {
      * @param src An {@link Iterable}
      */
     public SetOf(final Iterable<T> src) {
-        super(
-            new Unchecked<>(
-                () -> {
-                    final Set<T> tmp = new HashSet<>();
-                    src.forEach(tmp::add);
-                    return tmp;
-                }
-            ).value()
-        );
+        super(new HashSet<>());
+        src.forEach(super::add);
     }
 }

--- a/src/main/java/org/cactoos/set/Sorted.java
+++ b/src/main/java/org/cactoos/set/Sorted.java
@@ -27,19 +27,17 @@ import java.util.Comparator;
 import java.util.Set;
 import java.util.TreeSet;
 import org.cactoos.iterable.IterableOf;
-import org.cactoos.scalar.Unchecked;
 
 /**
- * Sorted Iterable as {@link Set}.
- *
- * <p>This class should be used very carefully. You must understand that
- * it will fetch the entire content of the encapsulated {@link Set} on each
- * method call. It doesn't cache the data anyhow. </p>
+ * Iterable as Sorted {@link Set} based on {@link TreeSet}.
  *
  * <p>There is no thread-safety guarantee.
  *
  * @param <T> Set type
  * @since 1.0.0
+ * @todo #1292:30min This class should also implements SortedSet
+ *  from the java collection framework by delegating to the
+ *  wrapped set. Some tests must be added for it.
  */
 public final class Sorted<T> extends SetEnvelope<T> {
 
@@ -58,15 +56,9 @@ public final class Sorted<T> extends SetEnvelope<T> {
      * @param cmp Comparator
      * @param src An {@link Iterable}
      */
+    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
     public Sorted(final Comparator<T> cmp, final Iterable<T> src) {
-        super(
-            new Unchecked<>(
-                () -> {
-                    final Set<T> set = new TreeSet<>(cmp);
-                    src.forEach(set::add);
-                    return set;
-                }
-            ).value()
-        );
+        super(new TreeSet<>(cmp));
+        src.forEach(super::add);
     }
 }

--- a/src/main/java/org/cactoos/set/package-info.java
+++ b/src/main/java/org/cactoos/set/package-info.java
@@ -26,8 +26,5 @@
  * Sets.
  *
  * @since 0.49.2
- * @todo #1242:30min The SetOf class should be implemented as an in-memory set,
- *  for example based on HashSet. See ListOf for an example and #1242 for the
- *  rationale behind this design.
  */
 package org.cactoos.set;


### PR DESCRIPTION
This is for #1292. 

I also did Sorted since it seemed a good idea and there wasn't much work.

I'm not clear why I had to ignore `PMD.ConstructorOnlyInitializesOrCallOtherConstructors` though while it is not needed for `ListOf` or `SetOf`... ! 