### PR TITLE
1343 - replacing static MatcherAssert.assertThat with Assertion object

### DIFF
--- a/src/test/java/org/cactoos/io/TeeInputFromCharArrayTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputFromCharArrayTest.java
@@ -60,7 +60,7 @@ public final class TeeInputFromCharArrayTest {
                 StandardCharsets.UTF_8
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 
     @Test

--- a/src/test/java/org/cactoos/io/TeeInputFromCharArrayTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputFromCharArrayTest.java
@@ -53,7 +53,7 @@ public final class TeeInputFromCharArrayTest {
             "Hello, товарищ file #1 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-            "char array can't be copied to the file with charset UTF_8",
+            "char array must be copied to the file with charset UTF_8",
             new TeeInput(
                 input.toCharArray(),
                 output,
@@ -70,14 +70,14 @@ public final class TeeInputFromCharArrayTest {
             "Hello, товарищ file #2 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-            "char array can't be copied to the file with UTF_8 charset's name",
+            "char array must be copied to the file with UTF_8 charset's name",
             new TeeInput(
                 input.toCharArray(),
                 output,
                 StandardCharsets.UTF_8.name()
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 
     @Test
@@ -86,13 +86,13 @@ public final class TeeInputFromCharArrayTest {
             "Hello, товарищ output #1 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-            "char array can't be copied to the output",
+            "char array must be copied to the output",
             new TeeInput(
                 input.toCharArray(),
                 new OutputTo(output)
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 
     @Test
@@ -101,14 +101,14 @@ public final class TeeInputFromCharArrayTest {
             "Hello, товарищ output #2 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-            "char array can't be copied to the output with UTF_8 charset",
+            "char array must be copied to the output with UTF_8 charset",
             new TeeInput(
                 input.toCharArray(),
                 new OutputTo(output),
                 StandardCharsets.UTF_8
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 
     @Test
@@ -118,14 +118,14 @@ public final class TeeInputFromCharArrayTest {
             "Hello, товарищ output #3 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-            "char array can't be copied to the output with UTF_8 charset's name",
+            "char array must be copied to the output with UTF_8 charset's name",
             new TeeInput(
                 input.toCharArray(),
                 new OutputTo(output),
                 StandardCharsets.UTF_8.name()
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 
     @Test
@@ -134,13 +134,13 @@ public final class TeeInputFromCharArrayTest {
             "Hello, товарищ path #1 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-            "char array can't be copied to the path",
+            "char array must be copied to the path",
             new TeeInput(
                 input.toCharArray(),
                 output.toPath()
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 
     @Test
@@ -149,14 +149,14 @@ public final class TeeInputFromCharArrayTest {
             "Hello, товарищ path #2 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-            "char array can't be copied to the path with UTF_8 charset",
+            "char array must be copied to the path with UTF_8 charset",
             new TeeInput(
                 input.toCharArray(),
                 output.toPath(),
                 StandardCharsets.UTF_8
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 
     @Test
@@ -166,14 +166,14 @@ public final class TeeInputFromCharArrayTest {
             "Hello, товарищ path #3 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-            "char array can't be copied to the path with UTF_8 charset's name",
+            "char array must be copied to the path with UTF_8 charset's name",
             new TeeInput(
                 input.toCharArray(),
                 output.toPath(),
                 StandardCharsets.UTF_8.name()
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 
     @Test
@@ -182,12 +182,12 @@ public final class TeeInputFromCharArrayTest {
         final String input =
             "Hello, товарищ file äÄ üÜ öÖ and ß";
         new Assertion<>(
-            "char array can't be copied to the file",
+            "char array must be copied to the file",
             new TeeInput(
                 input.toCharArray(),
                 output
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/io/TeeInputFromCharArrayTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputFromCharArrayTest.java
@@ -26,10 +26,10 @@ package org.cactoos.io;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import org.hamcrest.MatcherAssert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.InputHasContent;
 
 /**
@@ -52,7 +52,8 @@ public final class TeeInputFromCharArrayTest {
         final String input =
             "Hello, товарищ file #1 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "char array can't be copied to the file with charset UTF_8",
             new TeeInput(
                 input.toCharArray(),
                 output,
@@ -68,7 +69,8 @@ public final class TeeInputFromCharArrayTest {
         final String input =
             "Hello, товарищ file #2 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "char array can't be copied to the file with UTF_8 charset's name",
             new TeeInput(
                 input.toCharArray(),
                 output,
@@ -83,7 +85,8 @@ public final class TeeInputFromCharArrayTest {
         final String input =
             "Hello, товарищ output #1 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "char array can't be copied to the output",
             new TeeInput(
                 input.toCharArray(),
                 new OutputTo(output)
@@ -97,7 +100,8 @@ public final class TeeInputFromCharArrayTest {
         final String input =
             "Hello, товарищ output #2 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "char array can't be copied to the output with UTF_8 charset",
             new TeeInput(
                 input.toCharArray(),
                 new OutputTo(output),
@@ -113,7 +117,8 @@ public final class TeeInputFromCharArrayTest {
         final String input =
             "Hello, товарищ output #3 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "char array can't be copied to the output with UTF_8 charset's name",
             new TeeInput(
                 input.toCharArray(),
                 new OutputTo(output),
@@ -128,7 +133,8 @@ public final class TeeInputFromCharArrayTest {
         final String input =
             "Hello, товарищ path #1 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "char array can't be copied to the path",
             new TeeInput(
                 input.toCharArray(),
                 output.toPath()
@@ -142,7 +148,8 @@ public final class TeeInputFromCharArrayTest {
         final String input =
             "Hello, товарищ path #2 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "char array can't be copied to the path with UTF_8 charset",
             new TeeInput(
                 input.toCharArray(),
                 output.toPath(),
@@ -158,7 +165,8 @@ public final class TeeInputFromCharArrayTest {
         final String input =
             "Hello, товарищ path #3 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "char array can't be copied to the path with UTF_8 charset's name",
             new TeeInput(
                 input.toCharArray(),
                 output.toPath(),
@@ -173,7 +181,8 @@ public final class TeeInputFromCharArrayTest {
         final File output = this.folder.newFile();
         final String input =
             "Hello, товарищ file äÄ üÜ öÖ and ß";
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "char array can't be copied to the file",
             new TeeInput(
                 input.toCharArray(),
                 output

--- a/src/test/java/org/cactoos/io/TeeInputFromCharSequenceTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputFromCharSequenceTest.java
@@ -53,13 +53,13 @@ public final class TeeInputFromCharSequenceTest {
             "Hello, товарищ file #1 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-            "char sequence can't be copied to the file",
+            "char sequence must be copied to the file",
             new TeeInput(
                 input,
                 output
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 
     @Test
@@ -68,14 +68,14 @@ public final class TeeInputFromCharSequenceTest {
             "Hello, товарищ file #2 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-            "char sequence can't be copied to the file with UTF_8 charset",
+            "char sequence must be copied to the file with UTF_8 charset",
             new TeeInput(
                 input,
                 output,
                 StandardCharsets.UTF_8
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 
     @Test
@@ -85,14 +85,14 @@ public final class TeeInputFromCharSequenceTest {
             "Hello, товарищ file #3 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-            "char sequence can't be copied to the file with UTF_8 charset's name",
+            "char sequence must be copied to the file with UTF_8 charset's name",
             new TeeInput(
                 input,
                 output,
                 StandardCharsets.UTF_8.name()
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 
     @Test
@@ -101,13 +101,13 @@ public final class TeeInputFromCharSequenceTest {
             "Hello, товарищ path #1 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-            "char sequence can't be copied to the path",
+            "char sequence must be copied to the path",
             new TeeInput(
                 input,
                 output.toPath()
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 
     @Test
@@ -116,14 +116,14 @@ public final class TeeInputFromCharSequenceTest {
             "Hello, товарищ path #2 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-            "char sequence can't be copied to the path with UTF_8 charset",
+            "char sequence must be copied to the path with UTF_8 charset",
             new TeeInput(
                 input,
                 output.toPath(),
                 StandardCharsets.UTF_8
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 
     @Test
@@ -133,14 +133,14 @@ public final class TeeInputFromCharSequenceTest {
             "Hello, товарищ path #3 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-            "char sequence can't be copied to the path with UTF_8 charset's name",
+            "char sequence must be copied to the path with UTF_8 charset's name",
             new TeeInput(
                 input,
                 output.toPath(),
                 StandardCharsets.UTF_8.name()
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 
     @Test
@@ -149,13 +149,13 @@ public final class TeeInputFromCharSequenceTest {
             "Hello, товарищ output #1 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-            "char sequence can't be copied to the output",
+            "char sequence must be copied to the output",
             new TeeInput(
                 input,
                 new OutputTo(output)
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 
     @Test
@@ -164,14 +164,14 @@ public final class TeeInputFromCharSequenceTest {
             "Hello, товарищ output #2 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-            "char sequence can't be copied to the output with UTF_8 charset",
+            "char sequence must be copied to the output with UTF_8 charset",
             new TeeInput(
                 input,
                 new OutputTo(output),
                 StandardCharsets.UTF_8
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 
     @Test
@@ -181,13 +181,13 @@ public final class TeeInputFromCharSequenceTest {
             "Hello, товарищ output #3 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-            "char sequence can't be copied to the output with UTF_8 charset's name",
+            "char sequence must be copied to the output with UTF_8 charset's name",
             new TeeInput(
                 input,
                 new OutputTo(output),
                 StandardCharsets.UTF_8.name()
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/io/TeeInputFromCharSequenceTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputFromCharSequenceTest.java
@@ -26,10 +26,10 @@ package org.cactoos.io;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import org.hamcrest.MatcherAssert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.InputHasContent;
 
 /**
@@ -52,7 +52,8 @@ public final class TeeInputFromCharSequenceTest {
         final String input =
             "Hello, товарищ file #1 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "char sequence can't be copied to the file",
             new TeeInput(
                 input,
                 output
@@ -66,7 +67,8 @@ public final class TeeInputFromCharSequenceTest {
         final String input =
             "Hello, товарищ file #2 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "char sequence can't be copied to the file with UTF_8 charset",
             new TeeInput(
                 input,
                 output,
@@ -82,7 +84,8 @@ public final class TeeInputFromCharSequenceTest {
         final String input =
             "Hello, товарищ file #3 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "char sequence can't be copied to the file with UTF_8 charset's name",
             new TeeInput(
                 input,
                 output,
@@ -97,10 +100,11 @@ public final class TeeInputFromCharSequenceTest {
         final String input =
             "Hello, товарищ path #1 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "char sequence can't be copied to the path",
             new TeeInput(
                 input,
-                output
+                output.toPath()
             ),
             new InputHasContent(input)
         );
@@ -111,7 +115,8 @@ public final class TeeInputFromCharSequenceTest {
         final String input =
             "Hello, товарищ path #2 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "char sequence can't be copied to the path with UTF_8 charset",
             new TeeInput(
                 input,
                 output.toPath(),
@@ -127,7 +132,8 @@ public final class TeeInputFromCharSequenceTest {
         final String input =
             "Hello, товарищ path #3 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "char sequence can't be copied to the path with UTF_8 charset's name",
             new TeeInput(
                 input,
                 output.toPath(),
@@ -142,7 +148,8 @@ public final class TeeInputFromCharSequenceTest {
         final String input =
             "Hello, товарищ output #1 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "char sequence can't be copied to the output",
             new TeeInput(
                 input,
                 new OutputTo(output)
@@ -156,7 +163,8 @@ public final class TeeInputFromCharSequenceTest {
         final String input =
             "Hello, товарищ output #2 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "char sequence can't be copied to the output with UTF_8 charset",
             new TeeInput(
                 input,
                 new OutputTo(output),
@@ -172,7 +180,8 @@ public final class TeeInputFromCharSequenceTest {
         final String input =
             "Hello, товарищ output #3 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "char sequence can't be copied to the output with UTF_8 charset's name",
             new TeeInput(
                 input,
                 new OutputTo(output),

--- a/src/test/java/org/cactoos/io/TeeInputFromTextTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputFromTextTest.java
@@ -69,7 +69,7 @@ public final class TeeInputFromTextTest {
             "Hello, товарищ path #2 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-                "text can't be copied to the path with UTF_8 charset",
+            "text can't be copied to the path with UTF_8 charset",
             new TeeInput(
                 new TextOf(input),
                 output.toPath(),
@@ -148,7 +148,7 @@ public final class TeeInputFromTextTest {
             "Hello, товарищ output #1 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-                "text can't be copied to the output",
+            "text can't be copied to the output",
             new TeeInput(
                 new TextOf(input),
                 new OutputTo(output)

--- a/src/test/java/org/cactoos/io/TeeInputFromTextTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputFromTextTest.java
@@ -27,10 +27,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.cactoos.text.TextOf;
-import org.hamcrest.MatcherAssert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.InputHasContent;
 
 /**
@@ -53,7 +53,8 @@ public final class TeeInputFromTextTest {
         final String input =
             "Hello, товарищ path #1 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "text can't be copied to the path",
             new TeeInput(
                 new TextOf(input),
                 output.toPath()
@@ -67,7 +68,8 @@ public final class TeeInputFromTextTest {
         final String input =
             "Hello, товарищ path #2 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+                "text can't be copied to the path with UTF_8 charset",
             new TeeInput(
                 new TextOf(input),
                 output.toPath(),
@@ -82,7 +84,8 @@ public final class TeeInputFromTextTest {
         final String input =
             "Hello, товарищ path #3 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "text can't be copied to the path with UTF_8 charset's name",
             new TeeInput(
                 new TextOf(input),
                 output.toPath(),
@@ -97,7 +100,8 @@ public final class TeeInputFromTextTest {
         final String input =
             "Hello, товарищ file #1 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "text can't be copied to the file",
             new TeeInput(
                 new TextOf(input),
                 output
@@ -111,7 +115,8 @@ public final class TeeInputFromTextTest {
         final String input =
             "Hello, товарищ file #2 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "text can't be copied to the file with UTF_8 charset",
             new TeeInput(
                 new TextOf(input),
                 output,
@@ -126,7 +131,8 @@ public final class TeeInputFromTextTest {
         final String input =
             "Hello, товарищ file #3 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "text can't be copied to the file with UTF_8 charset's name",
             new TeeInput(
                 new TextOf(input),
                 output,
@@ -141,7 +147,8 @@ public final class TeeInputFromTextTest {
         final String input =
             "Hello, товарищ output #1 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+                "text can't be copied to the output",
             new TeeInput(
                 new TextOf(input),
                 new OutputTo(output)
@@ -155,7 +162,8 @@ public final class TeeInputFromTextTest {
         final String input =
             "Hello, товарищ output #2 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "text can't be copied to the output with UTF_8 charset",
             new TeeInput(
                 new TextOf(input),
                 new OutputTo(output),
@@ -170,7 +178,8 @@ public final class TeeInputFromTextTest {
         final String input =
             "Hello, товарищ output #3 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
-        MatcherAssert.assertThat(
+        new Assertion<>(
+            "text can't be copied to the output with UTF_8 charset's name",
             new TeeInput(
                 new TextOf(input),
                 new OutputTo(output),

--- a/src/test/java/org/cactoos/io/TeeInputFromTextTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputFromTextTest.java
@@ -54,13 +54,13 @@ public final class TeeInputFromTextTest {
             "Hello, товарищ path #1 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-            "text can't be copied to the path",
+            "text must be copied to the path",
             new TeeInput(
                 new TextOf(input),
                 output.toPath()
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 
     @Test
@@ -69,14 +69,14 @@ public final class TeeInputFromTextTest {
             "Hello, товарищ path #2 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-            "text can't be copied to the path with UTF_8 charset",
+            "text must be copied to the path with UTF_8 charset",
             new TeeInput(
                 new TextOf(input),
                 output.toPath(),
                 StandardCharsets.UTF_8
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 
     @Test
@@ -85,14 +85,14 @@ public final class TeeInputFromTextTest {
             "Hello, товарищ path #3 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-            "text can't be copied to the path with UTF_8 charset's name",
+            "text must be copied to the path with UTF_8 charset's name",
             new TeeInput(
                 new TextOf(input),
                 output.toPath(),
                 StandardCharsets.UTF_8.name()
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 
     @Test
@@ -101,13 +101,13 @@ public final class TeeInputFromTextTest {
             "Hello, товарищ file #1 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-            "text can't be copied to the file",
+            "text must be copied to the file",
             new TeeInput(
                 new TextOf(input),
                 output
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 
     @Test
@@ -116,14 +116,14 @@ public final class TeeInputFromTextTest {
             "Hello, товарищ file #2 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-            "text can't be copied to the file with UTF_8 charset",
+            "text must be copied to the file with UTF_8 charset",
             new TeeInput(
                 new TextOf(input),
                 output,
                 StandardCharsets.UTF_8
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 
     @Test
@@ -132,14 +132,14 @@ public final class TeeInputFromTextTest {
             "Hello, товарищ file #3 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-            "text can't be copied to the file with UTF_8 charset's name",
+            "text must be copied to the file with UTF_8 charset's name",
             new TeeInput(
                 new TextOf(input),
                 output,
                 StandardCharsets.UTF_8.name()
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 
     @Test
@@ -148,13 +148,13 @@ public final class TeeInputFromTextTest {
             "Hello, товарищ output #1 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-            "text can't be copied to the output",
+            "text must be copied to the output",
             new TeeInput(
                 new TextOf(input),
                 new OutputTo(output)
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 
     @Test
@@ -163,14 +163,14 @@ public final class TeeInputFromTextTest {
             "Hello, товарищ output #2 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-            "text can't be copied to the output with UTF_8 charset",
+            "text must be copied to the output with UTF_8 charset",
             new TeeInput(
                 new TextOf(input),
                 new OutputTo(output),
                 StandardCharsets.UTF_8
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 
     @Test
@@ -179,13 +179,13 @@ public final class TeeInputFromTextTest {
             "Hello, товарищ output #3 äÄ üÜ öÖ and ß";
         final File output = this.folder.newFile();
         new Assertion<>(
-            "text can't be copied to the output with UTF_8 charset's name",
+            "text must be copied to the output with UTF_8 charset's name",
             new TeeInput(
                 new TextOf(input),
                 new OutputTo(output),
                 StandardCharsets.UTF_8.name()
             ),
             new InputHasContent(input)
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/io/package-info.java
+++ b/src/test/java/org/cactoos/io/package-info.java
@@ -26,9 +26,5 @@
  * Input/Output, tests.
  *
  * @since 0.1
- * @todo #1343:30min Continue replacing usage of MatcherAssert.assertThat with
- *  Assertion from cactoos-matchers. Once there is no more usage of
- *  MatcherAssert.assertThat, add the signature of MatcherAssert.assertThat to
- *  forbidden-apis.txt
  */
 package org.cactoos.io;

--- a/src/test/java/org/cactoos/io/package-info.java
+++ b/src/test/java/org/cactoos/io/package-info.java
@@ -26,7 +26,7 @@
  * Input/Output, tests.
  *
  * @since 0.1
- * @todo #1340:30min Continue replacing usage of MatcherAssert.assertThat with
+ * @todo #1343:30min Continue replacing usage of MatcherAssert.assertThat with
  *  Assertion from cactoos-matchers. Once there is no more usage of
  *  MatcherAssert.assertThat, add the signature of MatcherAssert.assertThat to
  *  forbidden-apis.txt

--- a/src/test/java/org/cactoos/scalar/package-info.java
+++ b/src/test/java/org/cactoos/scalar/package-info.java
@@ -25,7 +25,7 @@
 /**
  * Scalars, tests.
  *
- * @todo #1350:30min Continue replacing usage of MatcherAssert.assertThat with
+ * @todo #1343:30min Continue replacing usage of MatcherAssert.assertThat with
  *  Assertion from cactoos-matchers. Once there is no more usage of
  *  MatcherAssert.assertThat, add the signature of MatcherAssert.assertThat to
  *  forbidden-apis.txt

--- a/src/test/java/org/cactoos/scalar/package-info.java
+++ b/src/test/java/org/cactoos/scalar/package-info.java
@@ -25,6 +25,10 @@
 /**
  * Scalars, tests.
  *
+ * @todo #1350:30min Continue replacing usage of MatcherAssert.assertThat with
+ *  Assertion from cactoos-matchers. Once there is no more usage of
+ *  MatcherAssert.assertThat, add the signature of MatcherAssert.assertThat to
+ *  forbidden-apis.txt
  * @since 0.12
  */
 package org.cactoos.scalar;

--- a/src/test/java/org/cactoos/set/BehavesAsSet.java
+++ b/src/test/java/org/cactoos/set/BehavesAsSet.java
@@ -59,7 +59,7 @@ public final class BehavesAsSet<T> extends TypeSafeMatcher<Set<T>> {
             "Does not contain duplicates",
             this.occurrences(item.iterator()),
             new IsEqual<>(1)
-        );
+        ).affirm();
         return new BehavesAsCollection<>(this.sample).matchesSafely(item);
     }
 

--- a/src/test/java/org/cactoos/set/BehavesAsSet.java
+++ b/src/test/java/org/cactoos/set/BehavesAsSet.java
@@ -27,9 +27,9 @@ import java.util.Iterator;
 import java.util.Set;
 import org.cactoos.collection.BehavesAsCollection;
 import org.hamcrest.Description;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.core.IsEqual;
+import org.llorllale.cactoos.matchers.Assertion;
 
 /**
  * Matcher for set.
@@ -55,7 +55,7 @@ public final class BehavesAsSet<T> extends TypeSafeMatcher<Set<T>> {
 
     @Override
     public boolean matchesSafely(final Set<T> item) {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Does not contain duplicates",
             this.occurrences(item.iterator()),
             new IsEqual<>(1)

--- a/src/test/java/org/cactoos/text/AbbreviatedTest.java
+++ b/src/test/java/org/cactoos/text/AbbreviatedTest.java
@@ -43,7 +43,7 @@ public final class AbbreviatedTest {
             // @checkstyle MagicNumber (1 line)
             new Abbreviated(msg, 8),
             new TextHasString(msg)
-        );
+        ).affirm();
     }
 
     @Test
@@ -53,7 +53,7 @@ public final class AbbreviatedTest {
             // @checkstyle MagicNumber (1 line)
             new Abbreviated("hello world", 8),
             new TextHasString("hello...")
-        );
+        ).affirm();
     }
 
     @Test
@@ -63,7 +63,7 @@ public final class AbbreviatedTest {
             // @checkstyle MagicNumber (1 line)
             new Abbreviated("oo programming", 10),
             new TextHasString("oo prog...")
-        );
+        ).affirm();
     }
 
     @Test
@@ -74,7 +74,7 @@ public final class AbbreviatedTest {
             // @checkstyle MagicNumber (1 line)
             new Abbreviated(msg, 15),
             new TextHasString(msg)
-        );
+        ).affirm();
     }
 
     @Test
@@ -85,7 +85,7 @@ public final class AbbreviatedTest {
             // @checkstyle MagicNumber (1 line)
             new Abbreviated(msg, 17),
             new TextHasString(msg)
-        );
+        ).affirm();
     }
 
     @Test
@@ -96,7 +96,7 @@ public final class AbbreviatedTest {
             // @checkstyle MagicNumber (1 line)
             new Abbreviated(msg, 15),
             new TextHasString(msg)
-        );
+        ).affirm();
     }
 
     @Test
@@ -107,7 +107,7 @@ public final class AbbreviatedTest {
             // @checkstyle MagicNumber (1 line)
             new Abbreviated(msg, 50),
             new TextHasString(msg)
-        );
+        ).affirm();
     }
 
     @Test
@@ -121,7 +121,7 @@ public final class AbbreviatedTest {
             new TextHasString(
                 "The quick brown fox jumps over the lazy black dog and after that returned to ..."
             )
-        );
+        ).affirm();
     }
 
 }

--- a/src/test/java/org/cactoos/text/AbbreviatedTest.java
+++ b/src/test/java/org/cactoos/text/AbbreviatedTest.java
@@ -23,8 +23,8 @@
  */
 package org.cactoos.text;
 
-import org.hamcrest.MatcherAssert;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.TextHasString;
 
 /**
@@ -38,7 +38,7 @@ public final class AbbreviatedTest {
     @Test
     public void abbreviatesAnEmptyText() {
         final String msg = "";
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't abbreviate an msg text",
             // @checkstyle MagicNumber (1 line)
             new Abbreviated(msg, 8),
@@ -48,7 +48,7 @@ public final class AbbreviatedTest {
 
     @Test
     public void abbreviatesText() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't abbreviate a text",
             // @checkstyle MagicNumber (1 line)
             new Abbreviated("hello world", 8),
@@ -58,7 +58,7 @@ public final class AbbreviatedTest {
 
     @Test
     public void abbreviatesTextOneCharSmaller() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't abbreviate a text one char smaller",
             // @checkstyle MagicNumber (1 line)
             new Abbreviated("oo programming", 10),
@@ -69,7 +69,7 @@ public final class AbbreviatedTest {
     @Test
     public void abbreviatesTextWithSameLength() {
         final String msg = "elegant objects";
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't abbreviate a text with same length",
             // @checkstyle MagicNumber (1 line)
             new Abbreviated(msg, 15),
@@ -80,7 +80,7 @@ public final class AbbreviatedTest {
     @Test
     public void abbreviatesTextOneCharBigger() {
         final String msg = "the old mcdonald";
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't abbreviate a text one char bigger",
             // @checkstyle MagicNumber (1 line)
             new Abbreviated(msg, 17),
@@ -91,7 +91,7 @@ public final class AbbreviatedTest {
     @Test
     public void abbreviatesTextTwoCharsBigger() {
         final String msg = "hi everybody!";
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't abbreviate a text two chars bigger",
             // @checkstyle MagicNumber (1 line)
             new Abbreviated(msg, 15),
@@ -102,7 +102,7 @@ public final class AbbreviatedTest {
     @Test
     public void abbreviatesTextWithWidthBiggerThanLength() {
         final String msg = "cactoos framework";
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't abbreviate a text with width bigger than length",
             // @checkstyle MagicNumber (1 line)
             new Abbreviated(msg, 50),
@@ -113,7 +113,7 @@ public final class AbbreviatedTest {
     @Test
     public void abbreviatesTextBiggerThanDefaultMaxWidth() {
         // @checkstyle LineLengthCheck (10 line)
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't abbreviate a text bigger than default max width",
             new Abbreviated(
                 "The quick brown fox jumps over the lazy black dog and after that returned to the cave"

--- a/src/test/java/org/cactoos/text/Base64DecodedTest.java
+++ b/src/test/java/org/cactoos/text/Base64DecodedTest.java
@@ -25,8 +25,8 @@
 package org.cactoos.text;
 
 import java.io.IOException;
-import org.hamcrest.MatcherAssert;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.TextHasString;
 
 /**
@@ -42,7 +42,7 @@ public final class Base64DecodedTest {
      */
     @Test
     public void checkDecode() throws IOException {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't decodes text using the Base64 encoding scheme",
             new Base64Decoded(
                 "SGVsbG8h"

--- a/src/test/java/org/cactoos/text/Base64DecodedTest.java
+++ b/src/test/java/org/cactoos/text/Base64DecodedTest.java
@@ -50,6 +50,6 @@ public final class Base64DecodedTest {
             new TextHasString(
                 "Hello!"
             )
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/text/Base64EncodedTest.java
+++ b/src/test/java/org/cactoos/text/Base64EncodedTest.java
@@ -25,8 +25,8 @@
 package org.cactoos.text;
 
 import java.io.IOException;
-import org.hamcrest.MatcherAssert;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.TextHasString;
 
 /**
@@ -41,7 +41,7 @@ public final class Base64EncodedTest {
      */
     @Test
     public void checkEncode() throws IOException {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't encodes text using the Base64 encoding scheme",
             new Base64Encoded(
                 "Hello!"

--- a/src/test/java/org/cactoos/text/Base64EncodedTest.java
+++ b/src/test/java/org/cactoos/text/Base64EncodedTest.java
@@ -49,6 +49,6 @@ public final class Base64EncodedTest {
             new TextHasString(
                 "SGVsbG8h"
             )
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/text/FormattedTextTest.java
+++ b/src/test/java/org/cactoos/text/FormattedTextTest.java
@@ -48,7 +48,7 @@ public final class FormattedTextTest {
                 "%d. Formatted %s", 1, "text"
             ),
             new TextHasString("1. Formatted text")
-        );
+        ).affirm();
     }
 
     @Test
@@ -61,7 +61,7 @@ public final class FormattedTextTest {
                 new String("string")
             ),
             new TextHasString("1. Number as string")
-        );
+        ).affirm();
     }
 
     @Test(expected = UnknownFormatConversionException.class)
@@ -81,7 +81,7 @@ public final class FormattedTextTest {
                 new ListOf<>(1, "txt")
             ),
             new TextHasString("1. Formatted as txt")
-        );
+        ).affirm();
     }
 
     @Test(expected = IllegalFormatConversionException.class)
@@ -102,7 +102,7 @@ public final class FormattedTextTest {
                 "%,d", Locale.GERMAN, 1_234_567_890
             ),
             new TextHasString("1.234.567.890")
-        );
+        ).affirm();
     }
 
     @Test
@@ -114,6 +114,6 @@ public final class FormattedTextTest {
                 new TextOf("Cactoos")
             ),
             new TextHasString("Format with text: Cactoos")
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/text/FormattedTextTest.java
+++ b/src/test/java/org/cactoos/text/FormattedTextTest.java
@@ -28,8 +28,8 @@ import java.util.IllegalFormatConversionException;
 import java.util.Locale;
 import java.util.UnknownFormatConversionException;
 import org.cactoos.list.ListOf;
-import org.hamcrest.MatcherAssert;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.TextHasString;
 
 /**
@@ -42,7 +42,7 @@ public final class FormattedTextTest {
 
     @Test
     public void formatsText() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't format a text",
             new FormattedText(
                 "%d. Formatted %s", 1, "text"
@@ -53,7 +53,7 @@ public final class FormattedTextTest {
 
     @Test
     public void formatsTextWithObjects() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't format a text with objects",
             new FormattedText(
                 new TextOf("%d. Number as %s"),
@@ -74,7 +74,7 @@ public final class FormattedTextTest {
 
     @Test
     public void formatsTextWithCollection() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't format a text with a collection",
             new FormattedText(
                 new TextOf("%d. Formatted as %s"),
@@ -95,7 +95,7 @@ public final class FormattedTextTest {
 
     @Test
     public void formatsWithLocale() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't format a text with Locale",
             new FormattedText(
                 // @checkstyle MagicNumber (1 line)
@@ -107,7 +107,7 @@ public final class FormattedTextTest {
 
     @Test
     public void formatsWithText() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't format a string with text",
             new FormattedText(
                 "Format with text: %s",

--- a/src/test/java/org/cactoos/text/HexOfTest.java
+++ b/src/test/java/org/cactoos/text/HexOfTest.java
@@ -25,8 +25,8 @@ package org.cactoos.text;
 
 import java.io.IOException;
 import org.cactoos.io.BytesOf;
-import org.hamcrest.MatcherAssert;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.TextHasString;
 
 /**
@@ -38,7 +38,7 @@ public final class HexOfTest {
 
     @Test
     public void empytString() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't represent an empty string as hexadecimal",
             new HexOf(
                 new BytesOf("")
@@ -49,7 +49,7 @@ public final class HexOfTest {
 
     @Test
     public void notEmpytString() throws IOException {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't represent a string as hexadecimal",
             new HexOf(
                 new BytesOf("What's up, друг?")

--- a/src/test/java/org/cactoos/text/HexOfTest.java
+++ b/src/test/java/org/cactoos/text/HexOfTest.java
@@ -44,7 +44,7 @@ public final class HexOfTest {
                 new BytesOf("")
             ),
             new TextHasString("")
-        );
+        ).affirm();
     }
 
     @Test
@@ -55,6 +55,6 @@ public final class HexOfTest {
                 new BytesOf("What's up, друг?")
             ),
             new TextHasString("5768617427732075702c20d0b4d180d183d0b33f")
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/text/IsBlankTest.java
+++ b/src/test/java/org/cactoos/text/IsBlankTest.java
@@ -42,7 +42,7 @@ public final class IsBlankTest {
                 new TextOf("")
             ),
             new ScalarHasValue<>(Boolean.TRUE)
-        );
+        ).affirm();
     }
 
     @Test
@@ -53,7 +53,7 @@ public final class IsBlankTest {
                 new TextOf("  ")
             ),
             new ScalarHasValue<>(Boolean.TRUE)
-        );
+        ).affirm();
     }
 
     @Test
@@ -64,6 +64,6 @@ public final class IsBlankTest {
                 new TextOf("not empty")
             ),
             new ScalarHasValue<>(Boolean.FALSE)
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/text/IsBlankTest.java
+++ b/src/test/java/org/cactoos/text/IsBlankTest.java
@@ -23,8 +23,8 @@
  */
 package org.cactoos.text;
 
-import org.hamcrest.MatcherAssert;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.ScalarHasValue;
 
 /**
@@ -36,7 +36,7 @@ public final class IsBlankTest {
 
     @Test
     public void determinesEmptyText() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't determine an empty text",
             new IsBlank(
                 new TextOf("")
@@ -47,7 +47,7 @@ public final class IsBlankTest {
 
     @Test
     public void determinesBlankText() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't determine an empty text with spaces",
             new IsBlank(
                 new TextOf("  ")
@@ -58,7 +58,7 @@ public final class IsBlankTest {
 
     @Test
     public void determinesNotBlankText() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't detect a nonempty text",
             new IsBlank(
                 new TextOf("not empty")

--- a/src/test/java/org/cactoos/text/StrictTest.java
+++ b/src/test/java/org/cactoos/text/StrictTest.java
@@ -24,7 +24,6 @@
 package org.cactoos.text;
 
 import java.util.regex.Pattern;
-import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.TextIs;
@@ -61,7 +60,7 @@ public final class StrictTest {
      */
     @Test
     public void returnsUnchangedIfPredicateIsPositive() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Given strings are not equal",
             new Strict(s -> true, new TextOf("text")),
             new TextIs("text")
@@ -93,7 +92,7 @@ public final class StrictTest {
      */
     @Test
     public void returnsUnchangedIfMatchedWithPattern() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Given strings are not equal",
             new Strict(
                 Pattern.compile("^[a-zA-Z0-9]+$"),

--- a/src/test/java/org/cactoos/text/StrictTest.java
+++ b/src/test/java/org/cactoos/text/StrictTest.java
@@ -64,7 +64,7 @@ public final class StrictTest {
             "Given strings are not equal",
             new Strict(s -> true, new TextOf("text")),
             new TextIs("text")
-        );
+        ).affirm();
     }
 
     /**
@@ -99,6 +99,6 @@ public final class StrictTest {
                 new TextOf("text1")
             ),
             new TextIs("text1")
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/text/TextEnvelopeTest.java
+++ b/src/test/java/org/cactoos/text/TextEnvelopeTest.java
@@ -26,10 +26,10 @@ package org.cactoos.text;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import org.cactoos.Scalar;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNot;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 
 /**
  * Tests for {@link TextEnvelope}.
@@ -44,7 +44,7 @@ public final class TextEnvelopeTest {
     @Test
     public void testAsString() throws Exception {
         final String text = "asString";
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Envelope value does not match String value",
             new TextEnvelopeDummy(text).asString(),
             new IsEqual<>(text)
@@ -59,7 +59,7 @@ public final class TextEnvelopeTest {
     @Test
     public void testEquals() {
         final String text = "equals";
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Envelope does not match text representing the same value",
             new TextEnvelopeDummy(text),
             new IsEqual<>(new TextOf(text))
@@ -73,7 +73,7 @@ public final class TextEnvelopeTest {
      */
     @Test
     public void testEqualsOtherText() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Envelope does not match another text representing the same value",
             new TextEnvelopeDummy("isequaltoanothertext"),
             new IsEqual<>(
@@ -89,7 +89,7 @@ public final class TextEnvelopeTest {
      */
     @Test
     public void testDoesNotEqualsNonTextObject() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Envelope does not match another object which is not a string",
             new TextEnvelopeDummy("is not equals to null"),
             new IsNot<>(
@@ -105,7 +105,7 @@ public final class TextEnvelopeTest {
     @Test
     @SuppressWarnings("PMD.EqualsNull")
     public void testDoesNotEqualsFalse() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Envelope does not equals null",
             new TextEnvelopeDummy("is not equals to not Text object")
                 .equals(null),
@@ -121,7 +121,7 @@ public final class TextEnvelopeTest {
     @Test
     public void testHashCode() {
         final String hash = "hashCode";
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Enveloped hashCode does not match its represented String hashcode",
             new TextEnvelopeDummy(hash).hashCode(),
             new IsEqual<>(hash.hashCode())

--- a/src/test/java/org/cactoos/text/TextEnvelopeTest.java
+++ b/src/test/java/org/cactoos/text/TextEnvelopeTest.java
@@ -48,7 +48,7 @@ public final class TextEnvelopeTest {
             "Envelope value does not match String value",
             new TextEnvelopeDummy(text).asString(),
             new IsEqual<>(text)
-        );
+        ).affirm();
     }
 
     /**
@@ -63,7 +63,7 @@ public final class TextEnvelopeTest {
             "Envelope does not match text representing the same value",
             new TextEnvelopeDummy(text),
             new IsEqual<>(new TextOf(text))
-        );
+        ).affirm();
     }
 
     /**
@@ -79,7 +79,7 @@ public final class TextEnvelopeTest {
             new IsEqual<>(
                 new Joined("", "is", "equal", "to", "another", "text")
             )
-        );
+        ).affirm();
     }
 
     /**
@@ -95,7 +95,7 @@ public final class TextEnvelopeTest {
             new IsNot<>(
                 new IsEqual<>(new Object())
             )
-        );
+        ).affirm();
     }
 
     /**
@@ -110,7 +110,7 @@ public final class TextEnvelopeTest {
             new TextEnvelopeDummy("is not equals to not Text object")
                 .equals(null),
             new IsEqual<>(false)
-        );
+        ).affirm();
     }
 
     /**
@@ -125,7 +125,7 @@ public final class TextEnvelopeTest {
             "Enveloped hashCode does not match its represented String hashcode",
             new TextEnvelopeDummy(hash).hashCode(),
             new IsEqual<>(hash.hashCode())
-        );
+        ).affirm();
     }
 
     /**

--- a/src/test/java/org/cactoos/text/TextOfTest.java
+++ b/src/test/java/org/cactoos/text/TextOfTest.java
@@ -76,7 +76,7 @@ public final class TextOfTest {
                 Matchers.startsWith("привет, "),
                 Matchers.endsWith("друг!")
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -90,7 +90,7 @@ public final class TextOfTest {
                 Matchers.startsWith("Hello, "),
                 Matchers.endsWith("друг! with default charset")
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -106,7 +106,7 @@ public final class TextOfTest {
                 Matchers.startsWith("Hi,"),
                 Matchers.endsWith("товарищ! with small buffer")
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -136,7 +136,7 @@ public final class TextOfTest {
                 Matchers.startsWith("Hello,"),
                 Matchers.endsWith("товарищ! with default charset")
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -154,7 +154,7 @@ public final class TextOfTest {
                     StandardCharsets.UTF_8
                 )
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -169,7 +169,7 @@ public final class TextOfTest {
                     StandardCharsets.UTF_8
                 )
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -184,7 +184,7 @@ public final class TextOfTest {
                 Matchers.startsWith("O que sera"),
                 Matchers.endsWith(" que sera")
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -196,7 +196,7 @@ public final class TextOfTest {
                 bytes
             ).asString(),
             Matchers.equalTo(new String(bytes, StandardCharsets.UTF_8))
-        );
+        ).affirm();
     }
 
     @Test
@@ -212,7 +212,7 @@ public final class TextOfTest {
                 Matchers.startsWith(starts),
                 Matchers.endsWith(ends)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -228,7 +228,7 @@ public final class TextOfTest {
                 Matchers.startsWith(starts),
                 Matchers.endsWith(ends)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -247,7 +247,7 @@ public final class TextOfTest {
                     "\tat org.cactoos.text.TextOfTest"
                 )
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -262,7 +262,7 @@ public final class TextOfTest {
             Matchers.equalTo(
                 new String(content.getBytes(), StandardCharsets.UTF_8)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -275,7 +275,7 @@ public final class TextOfTest {
             "Can't read multiline inputStream",
             new TextOf(stream).asString(),
             Matchers.equalTo(content)
-        );
+        ).affirm();
     }
 
     @Test
@@ -288,7 +288,7 @@ public final class TextOfTest {
             "Can't read multiline inputStream with carriage return",
             new TextOf(stream).asString(),
             Matchers.equalTo(content)
-        );
+        ).affirm();
     }
 
     @Test
@@ -302,7 +302,7 @@ public final class TextOfTest {
             "Can't read closed input stream",
             new TextOf(stream).asString(),
             Matchers.equalTo(content)
-        );
+        ).affirm();
     }
 
     @Test
@@ -315,7 +315,7 @@ public final class TextOfTest {
             "Can't read empty input stream",
             new TextOf(stream).asString(),
             Matchers.equalTo(content)
-        );
+        ).affirm();
     }
 
     @Test
@@ -326,7 +326,7 @@ public final class TextOfTest {
                 new IOException("").getStackTrace()
             ),
             new TextHasString("org.cactoos.text.TextOfTest")
-        );
+        ).affirm();
     }
 
     @Test
@@ -373,7 +373,7 @@ public final class TextOfTest {
             "Can't format a LocalDate with ISO format.",
             new TextOf(LocalDate.now()).asString(),
             new IsNot<>(new IsBlank())
-        );
+        ).affirm();
     }
 
     @Test

--- a/src/test/java/org/cactoos/text/TextOfTest.java
+++ b/src/test/java/org/cactoos/text/TextOfTest.java
@@ -41,7 +41,6 @@ import java.util.Locale;
 import java.util.TimeZone;
 import org.cactoos.io.BytesOf;
 import org.cactoos.io.InputOf;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsNot;
 import org.hamcrest.core.IsNull;
@@ -65,7 +64,7 @@ public final class TextOfTest {
 
     @Test
     public void readsInputIntoText() throws Exception {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't read text from Input",
             new Synced(
                 new TextOf(
@@ -82,7 +81,7 @@ public final class TextOfTest {
 
     @Test
     public void readsInputIntoTextWithDefaultCharset() throws Exception {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't read text from Input with default charset",
             new TextOf(
                 new InputOf("Hello, друг! with default charset")
@@ -96,7 +95,7 @@ public final class TextOfTest {
 
     @Test
     public void readsInputIntoTextWithSmallBuffer() throws Exception {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't read text with a small reading buffer",
             new TextOf(
                 new InputOf("Hi, товарищ! with small buffer"),
@@ -127,7 +126,7 @@ public final class TextOfTest {
     @Test
     public void readsInputIntoTextWithSmallBufferAndDefaultCharset()
         throws Exception {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't read text with a small reading buffer and default charset",
             new TextOf(
                 new InputOf("Hello, товарищ! with default charset"),
@@ -143,7 +142,7 @@ public final class TextOfTest {
     @Test
     public void readsFromReader() throws Exception {
         final String source = "hello, друг!";
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't read string through a reader",
             new TextOf(
                 new StringReader(source),
@@ -161,7 +160,7 @@ public final class TextOfTest {
     @Test
     public void readsFromReaderWithDefaultEncoding() throws Exception {
         final String source = "hello, друг! with default encoding";
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't read string with default encoding through a reader",
             new TextOf(new StringReader(source)).asString(),
             Matchers.equalTo(
@@ -175,7 +174,7 @@ public final class TextOfTest {
 
     @Test
     public void readsEncodedArrayOfCharsIntoText() throws Exception {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't read array of encoded chars into text.",
             new TextOf(
                 'O', ' ', 'q', 'u', 'e', ' ', 's', 'e', 'r', 'a',
@@ -191,7 +190,7 @@ public final class TextOfTest {
     @Test
     public void readsAnArrayOfBytes() throws Exception {
         final byte[] bytes = new byte[] {(byte) 0xCA, (byte) 0xFE};
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't read array of bytes",
             new TextOf(
                 bytes
@@ -204,7 +203,7 @@ public final class TextOfTest {
     public void readsStringBuilder() throws Exception {
         final String starts = "Name it, ";
         final String ends = "then it exists!";
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't process a string builder",
             new TextOf(
                 new StringBuilder(starts).append(ends)
@@ -220,7 +219,7 @@ public final class TextOfTest {
     public void readsStringBuffer() throws Exception {
         final String starts = "In our daily life, ";
         final String ends = "we can smile!";
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't process a string builder hahahaha",
             new TextOf(
                 new StringBuffer(starts).append(ends)
@@ -234,7 +233,7 @@ public final class TextOfTest {
 
     @Test
     public void printsStackTrace() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't print exception stacktrace",
             new TextOf(
                 new IOException(
@@ -257,7 +256,7 @@ public final class TextOfTest {
         final InputStream stream = new ByteArrayInputStream(
             content.getBytes(StandardCharsets.UTF_8.name())
         );
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't read inputStream",
             new TextOf(stream).asString(),
             Matchers.equalTo(
@@ -272,7 +271,7 @@ public final class TextOfTest {
         final InputStream stream = new ByteArrayInputStream(
             content.getBytes(StandardCharsets.UTF_8.name())
         );
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't read multiline inputStream",
             new TextOf(stream).asString(),
             Matchers.equalTo(content)
@@ -285,7 +284,7 @@ public final class TextOfTest {
         final InputStream stream = new ByteArrayInputStream(
             content.getBytes(StandardCharsets.UTF_8.name())
         );
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't read multiline inputStream with carriage return",
             new TextOf(stream).asString(),
             Matchers.equalTo(content)
@@ -299,7 +298,7 @@ public final class TextOfTest {
             content.getBytes(StandardCharsets.UTF_8.name())
         );
         stream.close();
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't read closed input stream",
             new TextOf(stream).asString(),
             Matchers.equalTo(content)
@@ -312,7 +311,7 @@ public final class TextOfTest {
         final InputStream stream = new ByteArrayInputStream(
             content.getBytes(StandardCharsets.UTF_8.name())
         );
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't read empty input stream",
             new TextOf(stream).asString(),
             Matchers.equalTo(content)
@@ -321,7 +320,7 @@ public final class TextOfTest {
 
     @Test
     public void printsStackTraceFromArray() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't print exception stacktrace from array",
             new TextOf(
                 new IOException("").getStackTrace()


### PR DESCRIPTION
1343

- Changed calling static method _MatcherAssert.assertThat_ for **Assertion** object
- Remove unused imports after that
- _copiesFromCharSequenceToPath_ method was the duplicates of _copiesFromCharSequenceToFile_
and I've changed it, now it calls what it supposed to call.