### PR TITLE
For #1346: fixing sonar execution

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -13,7 +13,7 @@ install: |
 merge:
   script: |
     pdd -f /dev/null
-    mvn clean install -Pqulice --errors --settings ../settings.xml
+    mvn clean install -Pqulice -Psonar --errors --settings ../settings.xml
     mvn clean site -Psite --errors --settings ../settings.xml
 deploy:
   script: |

--- a/pom.xml
+++ b/pom.xml
@@ -331,6 +331,11 @@ The MIT License (MIT)
           </plugin>
         </plugins>
       </build>
+      <properties>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.organization>yegor256-github</sonar.organization>
+        <sonar.projectKey>cactoos</sonar.projectKey>
+      </properties>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
For #1346: fixing sonar execution
- added sonar configurations to `pom.xml`
- configured sonar to run on rultor merges