### PR TITLE
1308 fixed IterableOf.equals and add required tests

### DIFF
--- a/src/main/java/org/cactoos/iterable/IterableOf.java
+++ b/src/main/java/org/cactoos/iterable/IterableOf.java
@@ -31,6 +31,7 @@ import org.cactoos.Scalar;
 import org.cactoos.func.UncheckedFunc;
 import org.cactoos.iterator.IteratorOf;
 import org.cactoos.scalar.And;
+import org.cactoos.scalar.False;
 import org.cactoos.scalar.Folded;
 import org.cactoos.scalar.Or;
 import org.cactoos.scalar.Sticky;
@@ -155,13 +156,13 @@ public final class IterableOf<X> implements Iterable<X> {
                     () -> Iterable.class.isAssignableFrom(other.getClass()),
                     () -> {
                         final Iterable<?> compared = (Iterable<?>) other;
-                        final Iterator<?> iterator = compared.iterator();
-                        return new Unchecked<>(
-                            new And(
-                                (X input) -> input.equals(iterator.next()),
-                                this
-                            )
-                        ).value();
+                        final Iterator<X> ftr = this.iterator();
+                        final Iterator<?> str = compared.iterator();
+                        boolean failed = false;
+                        while (ftr.hasNext() && str.hasNext() && (!failed)) {
+                            failed = !ftr.next().equals(str.next());
+                        }
+                        return !failed && !ftr.hasNext() && !str.hasNext();
                     }
                 )
             )

--- a/src/main/java/org/cactoos/iterable/IterableOf.java
+++ b/src/main/java/org/cactoos/iterable/IterableOf.java
@@ -31,7 +31,6 @@ import org.cactoos.Scalar;
 import org.cactoos.func.UncheckedFunc;
 import org.cactoos.iterator.IteratorOf;
 import org.cactoos.scalar.And;
-import org.cactoos.scalar.False;
 import org.cactoos.scalar.Folded;
 import org.cactoos.scalar.Or;
 import org.cactoos.scalar.Sticky;

--- a/src/main/java/org/cactoos/iterable/IterableOf.java
+++ b/src/main/java/org/cactoos/iterable/IterableOf.java
@@ -31,10 +31,11 @@ import org.cactoos.Scalar;
 import org.cactoos.func.UncheckedFunc;
 import org.cactoos.iterator.IteratorOf;
 import org.cactoos.scalar.And;
-import org.cactoos.scalar.Checked;
+import org.cactoos.scalar.FallbackFrom;
 import org.cactoos.scalar.False;
 import org.cactoos.scalar.Folded;
 import org.cactoos.scalar.Or;
+import org.cactoos.scalar.ScalarWithFallback;
 import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.SumOfInt;
 import org.cactoos.scalar.True;
@@ -159,21 +160,21 @@ public final class IterableOf<X> implements Iterable<X> {
                     () -> Iterable.class.isAssignableFrom(other.getClass()),
                     () -> {
                         final Iterable<X> compared = (Iterable<X>) other;
-                        boolean equals;
-                        try {
-                            equals = new Checked<>(
-                                new And(
-                                    (X value) -> new True().value(),
-                                    new Matched<>(
-                                        this,
-                                        compared
-                                    )
-                                ), e -> new IllegalStateException()
-                            ).value();
-                        } catch (final IllegalStateException exception) {
-                            equals = new False().value();
-                        }
-                        return equals;
+                        return new ScalarWithFallback<>(
+                            new And(
+                                (X value) -> new True().value(),
+                                new Matched<>(
+                                    this,
+                                    compared
+                                )
+                            ),
+                            new IterableOf<>(
+                                new FallbackFrom<>(
+                                    IllegalStateException.class,
+                                    ex -> new False().value()
+                                )
+                            )
+                        ).value();
                     }
                 )
             )

--- a/src/main/java/org/cactoos/iterable/IterableOf.java
+++ b/src/main/java/org/cactoos/iterable/IterableOf.java
@@ -31,10 +31,13 @@ import org.cactoos.Scalar;
 import org.cactoos.func.UncheckedFunc;
 import org.cactoos.iterator.IteratorOf;
 import org.cactoos.scalar.And;
+import org.cactoos.scalar.Checked;
+import org.cactoos.scalar.False;
 import org.cactoos.scalar.Folded;
 import org.cactoos.scalar.Or;
 import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.SumOfInt;
+import org.cactoos.scalar.True;
 import org.cactoos.scalar.Unchecked;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
@@ -146,6 +149,7 @@ public final class IterableOf<X> implements Iterable<X> {
 
     @Override
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("EQ_UNUSUAL")
+    @SuppressWarnings (value = "unchecked")
     public boolean equals(final Object other) {
         return new Unchecked<>(
             new Or(
@@ -154,14 +158,22 @@ public final class IterableOf<X> implements Iterable<X> {
                     () -> other != null,
                     () -> Iterable.class.isAssignableFrom(other.getClass()),
                     () -> {
-                        final Iterable<?> compared = (Iterable<?>) other;
-                        final Iterator<X> ftr = this.iterator();
-                        final Iterator<?> str = compared.iterator();
-                        boolean failed = false;
-                        while (ftr.hasNext() && str.hasNext() && (!failed)) {
-                            failed = !ftr.next().equals(str.next());
+                        final Iterable<X> compared = (Iterable<X>) other;
+                        boolean equals;
+                        try {
+                            equals = new Checked<>(
+                                new And(
+                                    (X value) -> new True().value(),
+                                    new Matched<>(
+                                        this,
+                                        compared
+                                    )
+                                ), e -> new IllegalStateException()
+                            ).value();
+                        } catch (final IllegalStateException exception) {
+                            equals = new False().value();
                         }
-                        return !failed && !ftr.hasNext() && !str.hasNext();
+                        return equals;
                     }
                 )
             )

--- a/src/main/java/org/cactoos/iterable/IterableOf.java
+++ b/src/main/java/org/cactoos/iterable/IterableOf.java
@@ -162,7 +162,7 @@ public final class IterableOf<X> implements Iterable<X> {
                         final Iterable<X> compared = (Iterable<X>) other;
                         return new ScalarWithFallback<>(
                             new And(
-                                (X value) -> new True().value(),
+                                (X value) -> true,
                                 new Matched<>(
                                     this,
                                     compared
@@ -171,7 +171,7 @@ public final class IterableOf<X> implements Iterable<X> {
                             new IterableOf<>(
                                 new FallbackFrom<>(
                                     IllegalStateException.class,
-                                    ex -> new False().value()
+                                    ex -> false
                                 )
                             )
                         ).value();

--- a/src/main/java/org/cactoos/iterable/Matched.java
+++ b/src/main/java/org/cactoos/iterable/Matched.java
@@ -73,8 +73,8 @@ public final class Matched<X> implements Iterable<X> {
                 final Iterator<X> ftr = fst.iterator();
                 final Iterator<X> str = snd.iterator();
                 final List<X> rslt = new LinkedList<>();
-                while (ftr.hasNext()) {
-                    if (!str.hasNext()) {
+                while (ftr.hasNext() || str.hasNext()) {
+                    if (!str.hasNext() || !ftr.hasNext()) {
                         throw new IllegalStateException(
                             "Size mismatch of iterators"
                         );

--- a/src/test/java/org/cactoos/iterable/IterableOfTest.java
+++ b/src/test/java/org/cactoos/iterable/IterableOfTest.java
@@ -35,6 +35,7 @@ import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNot;
 import org.junit.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.IsTrue;
 
 /**
  * Test case for {@link IterableOf}.
@@ -103,6 +104,24 @@ public final class IterableOfTest {
             ),
             new IsEqual<>(new Joined<>(first, second, third))
         );
+    }
+
+    @Test
+    public void isNotEqualsToIterableWithMoreElements() {
+        new Assertion<>(
+            "Must compare iterables and second one is bigger",
+            new IterableOf<>("a", "b").equals(new IterableOf<>("a")),
+            new IsNot<>(new IsTrue())
+        ).affirm();
+    }
+
+    @Test
+    public void isNotEqualsToIterableWithLessElements() {
+        new Assertion<>(
+            "Must compare iterables and first one is bigger",
+            new IterableOf<>("a").equals(new IterableOf<>("a", "b")),
+            new IsNot<>(new IsTrue())
+        ).affirm();
     }
 
     @Test

--- a/src/test/java/org/cactoos/iterable/MatchedTest.java
+++ b/src/test/java/org/cactoos/iterable/MatchedTest.java
@@ -28,6 +28,8 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link Matched}.
@@ -49,6 +51,32 @@ public final class MatchedTest {
             ),
             Matchers.hasItems(1, 2, 3)
         );
+    }
+
+    @Test
+    public void noCorrelationWithBiggerSecondIterable() throws IllegalStateException {
+        new Assertion<>(
+            "All elements have correlation function as `endsWith`",
+            () -> new Matched<>(
+                (fst, snd) -> fst.endsWith("elem") && snd.endsWith("elem"),
+                new IterableOf<>("1st elem", "2nd elem"),
+                new IterableOf<>("`A` elem", "`B` elem", "'C' elem")
+            ).iterator(),
+            new Throws<>(IllegalStateException.class)
+        ).affirm();
+    }
+
+    @Test
+    public void noCorrelationWithSmallerSecondIterable() throws IllegalStateException {
+        new Assertion<>(
+            "All elements have correlation function as `endsWith`",
+            () -> new Matched<>(
+                (fst, snd) -> fst.endsWith("elem") && snd.endsWith("elem"),
+                new IterableOf<>("1st elem", "2nd elem", "3rd elem"),
+                new IterableOf<>("`A` elem", "`B` elem")
+            ).iterator(),
+            new Throws<>(IllegalStateException.class)
+        ).affirm();
     }
 
     @Test


### PR DESCRIPTION
#1308
Fixed the problem when two Iterates of different sizes returned the wrong result on method equals.