### PR TITLE
Added a ForEachWithIndex class

### DIFF
--- a/src/main/java/org/cactoos/func/ForEachWithIndex.java
+++ b/src/main/java/org/cactoos/func/ForEachWithIndex.java
@@ -1,0 +1,80 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2020 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.func;
+
+import org.cactoos.BiFunc;
+import org.cactoos.BiProc;
+import org.cactoos.Func;
+import org.cactoos.Proc;
+import org.cactoos.scalar.And;
+import org.cactoos.scalar.AndWithIndex;
+
+/**
+ * Executes a {@link org.cactoos.BiProc} for each element of an
+ * {@link java.lang.Iterable}
+ *
+ * <p>
+ * This class can be effectively used to iterate through a collection similar to how
+ * {@link java.util.stream.Stream#forEach(java.util.function.Consumer)} works except
+ * this class also passes the index of the current element to the proc:
+ * </p>
+ *
+ * {@code
+ * new ForEachWithIndex(
+ *    new BiProcOf<>((input, index) -> System.out.printf("%d: \'%s\' ", index + 1, input)),
+ * ).execute(
+ *    new IterableOf<>("Mary", "John", "William", "Napkin")
+ * ); // will print 1: 'Mary' 2: 'John' 3: 'William' 4: 'Napkin' to standard output
+ * }
+ * <p>
+ * There is no thread-safety guarantee.
+ *
+ * @param <X> The type to iterate over
+ * @since 1.0
+ */
+public final class ForEachWithIndex<X> implements Proc<Iterable<X>> {
+
+    /**
+     * The proc.
+     */
+    private final BiFunc<X, Integer, Boolean> func;
+
+    /**
+     * Ctor.
+     *
+     * @param proc The proc to execute
+     */
+    public ForEachWithIndex(final BiProc<X, Integer> proc) {
+        this.func = new BiFuncOf<>(
+            proc, true
+        );
+    }
+
+    @Override
+    public void exec(final Iterable<X> input) throws Exception {
+        new AndWithIndex(
+            this.func, input
+        ).value();
+    }
+}

--- a/src/main/java/org/cactoos/func/ForEachWithIndex.java
+++ b/src/main/java/org/cactoos/func/ForEachWithIndex.java
@@ -25,9 +25,7 @@ package org.cactoos.func;
 
 import org.cactoos.BiFunc;
 import org.cactoos.BiProc;
-import org.cactoos.Func;
 import org.cactoos.Proc;
-import org.cactoos.scalar.And;
 import org.cactoos.scalar.AndWithIndex;
 
 /**

--- a/src/test/java/org/cactoos/func/ForEachWithIndexTest.java
+++ b/src/test/java/org/cactoos/func/ForEachWithIndexTest.java
@@ -34,7 +34,7 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @since 1.0
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public class ForEachWithIndexTest {
+public final class ForEachWithIndexTest {
 
     @Test
     public void testBiProcIterable() throws Exception {
@@ -47,7 +47,7 @@ public class ForEachWithIndexTest {
             )
         );
         new Assertion<>(
-            "String does not contain mapped Iterable elements",
+            "String must contain mapped Iterable elements",
             builder.toString(),
             new IsEqual<>(
                 "1: 'Mary' 2: 'John' 3: 'William' 4: 'Napkin' "

--- a/src/test/java/org/cactoos/func/ForEachWithIndexTest.java
+++ b/src/test/java/org/cactoos/func/ForEachWithIndexTest.java
@@ -24,17 +24,9 @@
 package org.cactoos.func;
 
 import org.cactoos.iterable.IterableOf;
-import org.cactoos.list.ListOf;
-import org.cactoos.map.MapEntry;
-import org.cactoos.map.MapOf;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 import org.llorllale.cactoos.matchers.Assertion;
-
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Test case for {@link ForEachWithIndex}.

--- a/src/test/java/org/cactoos/func/ForEachWithIndexTest.java
+++ b/src/test/java/org/cactoos/func/ForEachWithIndexTest.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2020 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.func;
+
+import org.cactoos.iterable.IterableOf;
+import org.cactoos.list.ListOf;
+import org.cactoos.map.MapEntry;
+import org.cactoos.map.MapOf;
+import org.hamcrest.core.IsEqual;
+import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Test case for {@link ForEachWithIndex}.
+ *
+ * @since 1.0
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public class ForEachWithIndexTest {
+
+    @Test
+    public void testBiProcIterable() throws Exception {
+        final StringBuilder builder = new StringBuilder();
+        new ForEachWithIndex<>(
+            (input, index) -> builder.append(String.format("%d: '%s' ", index + 1, input))
+        ).exec(
+            new IterableOf<>(
+                "Mary", "John", "William", "Napkin"
+            )
+        );
+        new Assertion<>(
+            "String does not contain mapped Iterable elements",
+            builder.toString(),
+            new IsEqual<>(
+                "1: 'Mary' 2: 'John' 3: 'William' 4: 'Napkin' "
+            )
+        ).affirm();
+    }
+
+}


### PR DESCRIPTION
There was no ticket for this, but I wanted it, and it seemed to be within the scope of the overarching objectives of the library. It's my way of donating without money to give.

I copied `ForEach` and modified it to use `BiFunc`, `BiProc`, and `AndWithIndex` to give us a `ForEachWithIndex`. I also copied the `ForEachTest` and modified it to ensure the class behaves as expected.

Tests passed locally.