### PR TITLE
#1217: Refactor test for ListEnvelope

### DIFF
--- a/src/test/java/org/cactoos/list/ImmutableTest.java
+++ b/src/test/java/org/cactoos/list/ImmutableTest.java
@@ -564,7 +564,7 @@ public class ImmutableTest {
     @Test
     public void subListReturnsListIteratorWithSupportedSet() {
         new Assertion<>(
-            "subList.listIterator().set() must throw exception",
+            "subList's iterator must be immutable",
             () -> {
                 final ListIterator<String> iterator = new Immutable<>(
                     new ListOf<String>("one", "two", "three")

--- a/src/test/java/org/cactoos/list/ImmutableTest.java
+++ b/src/test/java/org/cactoos/list/ImmutableTest.java
@@ -560,4 +560,31 @@ public class ImmutableTest {
             new IsEqual<>(new ListOf<>("a", "b", "c").toString())
         ).affirm();
     }
+
+
+    @Test
+    public void subListReturnsListIteratorWithSupportedSet() {
+        new Assertion<>(
+            "subList.listIterator().set() must throw exception",
+            () -> {
+                final ListIterator<String> iterator = new Immutable<>(
+                    new ListOf<String>("one", "two", "three")
+                )
+                    .subList(0, 2)
+                    .listIterator(0);
+                iterator.next();
+                iterator.set("zero");
+                return new Object();
+            },
+            new Throws<>(
+                new MatcherOf<>(
+                    (String msg) -> msg.equals(
+                        "List Iterator is read-only and doesn't allow rewriting items"
+                    )
+                ),
+                UnsupportedOperationException.class
+            )
+        ).affirm();
+    }
+
 }

--- a/src/test/java/org/cactoos/list/ImmutableTest.java
+++ b/src/test/java/org/cactoos/list/ImmutableTest.java
@@ -561,7 +561,6 @@ public class ImmutableTest {
         ).affirm();
     }
 
-
     @Test
     public void subListReturnsListIteratorWithSupportedSet() {
         new Assertion<>(

--- a/src/test/java/org/cactoos/list/ListEnvelopeTest.java
+++ b/src/test/java/org/cactoos/list/ListEnvelopeTest.java
@@ -66,7 +66,7 @@ public final class ListEnvelopeTest {
         final ListEnvelope<String> list = new StringList("one");
         list.remove(0);
         new Assertion<>(
-            "must be empty",
+            "must be empty after removal of 0th element",
             list,
             new IsEmptyCollection<>()
         ).affirm();
@@ -76,7 +76,7 @@ public final class ListEnvelopeTest {
     public void indexOfIsDelegated() {
         final ListEnvelope<String> list = new StringList("one");
         new Assertion<>(
-            "must return corrent index",
+            "must return correct index of element",
             list.indexOf("one"),
             new IsEqual<>(0)
         ).affirm();
@@ -119,7 +119,7 @@ public final class ListEnvelopeTest {
         final ListEnvelope<String> list = new StringList("one");
         list.subList(0, 1).remove(0);
         new Assertion<>(
-            "must be empty after removal",
+            "must be empty after removal of 0th element via subList",
             list,
             new IsEmptyCollection<>()
         ).affirm();
@@ -130,7 +130,7 @@ public final class ListEnvelopeTest {
         final List<String> list = new StringList("one");
         list.subList(0, 1).set(0, "zero");
         new Assertion<>(
-            "subList.set() must change the original list",
+            "ListEnvelope().subList(...).set() must change the original list",
             list,
             new HasValues<>(
                 "zero"
@@ -143,7 +143,7 @@ public final class ListEnvelopeTest {
         final ListEnvelope<String> list = new StringList("one");
         list.add(0, "two");
         new Assertion<>(
-            "must add value",
+            "must add value at given index",
             list,
             new HasValues<>("two")
         ).affirm();
@@ -153,7 +153,7 @@ public final class ListEnvelopeTest {
     public void getsAtGivenIndex() {
         final ListEnvelope<String> list = new StringList("one");
         new Assertion<>(
-            "must add value",
+            "must get 0th value",
             list.get(0),
             new IsEqual<>("one")
         ).affirm();
@@ -164,7 +164,7 @@ public final class ListEnvelopeTest {
         final ListEnvelope<String> list = new StringList("one");
         list.add(1, "one");
         new Assertion<>(
-            "must be last index",
+            "must return correct last index of element",
             list.lastIndexOf("one"),
             new IsEqual<>(1)
         ).affirm();
@@ -173,7 +173,7 @@ public final class ListEnvelopeTest {
     @Test
     public void mustReturnPreviousIndex() {
         new Assertion<>(
-            "List Iterator must return previous index",
+            "List iterator must return previous index",
             new ListIteratorOf<>(
                 new ListOf<>(1)
             ).previousIndex(),
@@ -184,7 +184,7 @@ public final class ListEnvelopeTest {
     @Test
     public void mustReturnPreviousElement() {
         new Assertion<>(
-            "List Iterator must return previous element",
+            "List iterator must return previous element",
             new ListIteratorOf<>(
                 new ListOf<>(3, 7),
                 1
@@ -209,7 +209,7 @@ public final class ListEnvelopeTest {
         new Assertion<>(
             "List iterator must return next item",
             new ListIteratorOf<>(
-                new ListOf<>(5, 11, 13),
+                new  ListOf<>(5, 11, 13),
                 1
             ).next(),
             new IsEqual<>(11)

--- a/src/test/java/org/cactoos/list/ListEnvelopeTest.java
+++ b/src/test/java/org/cactoos/list/ListEnvelopeTest.java
@@ -87,7 +87,7 @@ public final class ListEnvelopeTest {
         final ListEnvelope<String> list = new StringList("one");
         list.addAll(0, new StringList("two"));
         new Assertion<>(
-            "must be empty",
+            "element must be added at 0th position",
             list,
             new IsEqual<>(new ListOf<>("two", "one"))
         ).affirm();


### PR DESCRIPTION
Per #1217:  

- Replace tests which check for `UnsupporterOperationException`
- Move `Immutable` related tests to `ImmutableTest`