### PR TITLE
Rultor config + latest jcabi-parent

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -1,15 +1,12 @@
 docker:
-  image: yegor256/rultor-image:1.3
+  image: g4s8/rultor:alpine3.10
 assets:
   settings.xml: yegor256/home#assets/cactoos/settings.xml
   pubring.gpg: yegor256/home#assets/pubring.gpg
   secring.gpg: yegor256/home#assets/secring.gpg
 architect:
-- victornoel
-- yegor256
-install: |
-  sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
-  pdd -f /dev/null
+  - victornoel
+  - yegor256
 merge:
   script: |
     pdd -f /dev/null
@@ -23,11 +20,9 @@ release:
   sensitive:
     - settings.xml
   script: |-
-    export GPG_TTY=$(tty)
+    [[ "${tag}" =~ ^[0-9]+(\.[0-9]+)*$ ]] || exit -1
     gpg --import /home/r/pubring.gpg
     gpg --allow-secret-key-import --no-tty --batch --import /home/r/secring.gpg
-    [[ "${tag}" =~ ^[0-9]+(\.[0-9]+)*$ ]] || exit -1
-    mvn versions:set "-DnewVersion=${tag}"
+    mvn versions:set "-DnewVersion=${tag}" --settings ../settings.xml
     git commit -am "${tag}"
-    mvn clean deploy -P cactoos -Psonar -Pqulice -Psonatype --errors --settings ../settings.xml
-    rm -f settings.xml
+    mvn clean deploy -Psonar -Pqulice -Psonatype --errors --settings ../settings.xml

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ The MIT License (MIT)
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>parent</artifactId>
-    <version>0.50.0</version>
+    <version>0.50.5</version>
   </parent>
   <groupId>org.cactoos</groupId>
   <artifactId>cactoos</artifactId>
@@ -81,9 +81,6 @@ The MIT License (MIT)
       <url>https://github.com/yegor256/cactoos</url>
     </site>
   </distributionManagement>
-  <properties>
-    <junit-platform.version>5.6.2</junit-platform.version>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>org.takes</groupId>
@@ -122,7 +119,6 @@ The MIT License (MIT)
     <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
-      <version>${junit-platform.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -157,17 +153,6 @@ The MIT License (MIT)
               </configuration>
             </execution>
           </executions>
-        </plugin>
-        <plugin>
-          <artifactId>maven-site-plugin</artifactId>
-          <version>3.9.1</version>
-          <dependencies>
-            <dependency>
-              <groupId>org.apache.maven.doxia</groupId>
-              <artifactId>doxia-module-markdown</artifactId>
-              <version>1.9.1</version>
-            </dependency>
-          </dependencies>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Final touch for #1411.

New rultor config comes from succeeding in a releasing a new version of cactoos-matchers and upgrading jcabi-parent allows to remove useless config in the pom.