### PR TITLE
Cleanup fix iterable/iterator of bytes

### DIFF
--- a/src/main/java/org/cactoos/io/BytesOf.java
+++ b/src/main/java/org/cactoos/io/BytesOf.java
@@ -34,10 +34,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import org.cactoos.Bytes;
 import org.cactoos.Input;
 import org.cactoos.Text;
-import org.cactoos.iterable.IterableOfBytes;
+import org.cactoos.iterable.IterableOf;
 import org.cactoos.list.ListOf;
 
 /**
@@ -338,7 +339,7 @@ public final class BytesOf implements Bytes {
      * @param iterator Iterator of bytes
      */
     public BytesOf(final Iterator<Byte> iterator) {
-        this(new IterableOfBytes(iterator));
+        this(new IterableOf<>(iterator));
     }
 
     /**
@@ -347,7 +348,14 @@ public final class BytesOf implements Bytes {
      * @param bytes Iterable of bytes
      */
     public BytesOf(final Iterable<Byte> bytes) {
-        this(new ListOf<>(bytes));
+        this(() -> {
+            final List<Byte> concrete = new ListOf<>(bytes);
+            final ByteBuffer buf = ByteBuffer.allocate(
+                concrete.size()
+            );
+            concrete.forEach(buf::put);
+            return buf.array();
+        });
     }
 
     /**

--- a/src/main/java/org/cactoos/iterable/IterableOfBytes.java
+++ b/src/main/java/org/cactoos/iterable/IterableOfBytes.java
@@ -23,9 +23,9 @@
  */
 package org.cactoos.iterable;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Iterator;
+import org.cactoos.Bytes;
 import org.cactoos.Text;
+import org.cactoos.io.BytesOf;
 import org.cactoos.iterator.IteratorOfBytes;
 
 /**
@@ -37,18 +37,10 @@ public final class IterableOfBytes extends IterableEnvelope<Byte> {
 
     /**
      * Ctor.
-     * @param bytes Bytes
+     * @param txt Text
      */
-    public IterableOfBytes(final byte... bytes) {
-        this(new IteratorOfBytes(bytes));
-    }
-
-    /**
-     * Ctor.
-     * @param bytes Iterator
-     */
-    public IterableOfBytes(final Iterator<Byte> bytes) {
-        super(new IterableOf<>(bytes));
+    public IterableOfBytes(final Text txt) {
+        this(new BytesOf(txt));
     }
 
     /**
@@ -56,14 +48,22 @@ public final class IterableOfBytes extends IterableEnvelope<Byte> {
      * @param str String
      */
     public IterableOfBytes(final String str) {
-        this(str.getBytes(StandardCharsets.UTF_8));
+        this(new BytesOf(str));
     }
 
     /**
      * Ctor.
-     * @param txt Text
+     * @param bytes Bytes
      */
-    public IterableOfBytes(final Text txt) {
-        this(txt.toString());
+    public IterableOfBytes(final byte... bytes) {
+        this(new BytesOf(bytes));
+    }
+
+    /**
+     * Ctor.
+     * @param bytes Bytes to iterate
+     */
+    public IterableOfBytes(final Bytes bytes) {
+        super(new IterableOf<>(() -> new IteratorOfBytes(bytes)));
     }
 }

--- a/src/main/java/org/cactoos/iterable/IterableOfChars.java
+++ b/src/main/java/org/cactoos/iterable/IterableOfChars.java
@@ -35,14 +35,6 @@ public final class IterableOfChars extends IterableEnvelope<Character> {
 
     /**
      * Ctor.
-     * @param chars Characters
-     */
-    public IterableOfChars(final char... chars) {
-        super(new IterableOf<>(() -> new IteratorOfChars(chars)));
-    }
-
-    /**
-     * Ctor.
      * @param str String
      */
     public IterableOfChars(final String str) {
@@ -55,5 +47,13 @@ public final class IterableOfChars extends IterableEnvelope<Character> {
      */
     public IterableOfChars(final Text txt) {
         this(txt.toString());
+    }
+
+    /**
+     * Ctor.
+     * @param chars Characters
+     */
+    public IterableOfChars(final char... chars) {
+        super(new IterableOf<>(() -> new IteratorOfChars(chars)));
     }
 }

--- a/src/main/java/org/cactoos/iterator/IteratorOfBytes.java
+++ b/src/main/java/org/cactoos/iterator/IteratorOfBytes.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.cactoos.Bytes;
 import org.cactoos.Text;
 import org.cactoos.io.BytesOf;
+import org.cactoos.io.UncheckedBytes;
 
 /**
  * Iterator that returns a set of bytes.
@@ -51,38 +52,35 @@ public final class IteratorOfBytes implements Iterator<Byte> {
 
     /**
      * Ctor.
-     * @param itms Items to iterate
-     */
-    public IteratorOfBytes(final byte... itms) {
-        this.items = itms;
-        this.position = new AtomicInteger(0);
-    }
-
-    /**
-     * Ctor.
      * @param txt Text to iterate
-     * @throws Exception If fails
      */
-    public IteratorOfBytes(final Text txt) throws Exception {
+    public IteratorOfBytes(final Text txt) {
         this(new BytesOf(txt));
     }
 
     /**
      * Ctor.
-     * @param bytes Bytes to iterate
-     * @throws Exception If fails
+     * @param str String to iterate
      */
-    public IteratorOfBytes(final Bytes bytes) throws Exception {
-        this(bytes.asBytes());
+    public IteratorOfBytes(final String str) {
+        this(new BytesOf(str));
     }
 
     /**
      * Ctor.
-     * @param str String to iterate
-     * @throws Exception If fails
+     * @param bytes Bytes to iterate
      */
-    public IteratorOfBytes(final String str) throws Exception {
-        this(new BytesOf(str));
+    public IteratorOfBytes(final Bytes bytes) {
+        this(new UncheckedBytes(bytes).asBytes());
+    }
+
+    /**
+     * Ctor.
+     * @param itms Items to iterate
+     */
+    public IteratorOfBytes(final byte... itms) {
+        this.items = itms;
+        this.position = new AtomicInteger(0);
     }
 
     @Override

--- a/src/test/java/org/cactoos/io/BytesOfTest.java
+++ b/src/test/java/org/cactoos/io/BytesOfTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.cactoos.Text;
 import org.cactoos.iterable.Endless;
 import org.cactoos.iterable.HeadOf;
+import org.cactoos.iterable.IterableOfBytes;
 import org.cactoos.iterator.IteratorOfBytes;
 import org.cactoos.text.Joined;
 import org.cactoos.text.TextOf;
@@ -181,8 +182,20 @@ final class BytesOfTest {
                 new IteratorOfBytes(text)
             ).asBytes(),
             new IsEqual<>(
-                new BytesOf(text.asString()).asBytes()
+                new BytesOf(text).asBytes()
             )
+        ).affirm();
+    }
+
+    @Test
+    void asBytesFromIterable() throws Exception {
+        final Text text = new TextOf("Good bye");
+        new Assertion<>(
+            "Must convert iterable into bytes",
+            new BytesOf(
+                new IterableOfBytes(text)
+            ).asBytes(),
+            new IsEqual<>(new BytesOf(text).asBytes())
         ).affirm();
     }
 


### PR DESCRIPTION
There is no ticket for this.

I noticed that IterableOfBytes was broken because it would reuse the same iterator each time.

I also fixed the constructor order and made `BytesOf(Iterable)` be lazy.