### PR TITLE
(#1199) Move some Bytes classes from io to bytes package

### DIFF
--- a/src/main/java/org/cactoos/Bytes.java
+++ b/src/main/java/org/cactoos/Bytes.java
@@ -28,7 +28,7 @@ package org.cactoos;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @see org.cactoos.io.BytesOf
+ * @see org.cactoos.bytes.BytesOf
  * @since 0.1
  */
 public interface Bytes {

--- a/src/main/java/org/cactoos/bytes/BytesOf.java
+++ b/src/main/java/org/cactoos/bytes/BytesOf.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.cactoos.io;
+package org.cactoos.bytes;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -38,6 +38,7 @@ import java.util.List;
 import org.cactoos.Bytes;
 import org.cactoos.Input;
 import org.cactoos.Text;
+import org.cactoos.io.InputOf;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.list.ListOf;
 

--- a/src/main/java/org/cactoos/bytes/CheckedBytes.java
+++ b/src/main/java/org/cactoos/bytes/CheckedBytes.java
@@ -21,34 +21,45 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.cactoos.io;
+package org.cactoos.bytes;
 
-import org.cactoos.Input;
+import org.cactoos.Bytes;
+import org.cactoos.Func;
+import org.cactoos.scalar.Checked;
 
 /**
- * SHA-256 checksum calculation of {@link Input}.
+ * Bytes that throws exception of specified type.
  *
- * <p>There is no thread-safety guarantee.
- *
- * @since 0.29
+ * @param <E> Exception's type.
+ * @since 0.31
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class Sha256DigestOf extends DigestEnvelope {
+public final class CheckedBytes<E extends Exception> implements Bytes {
+
     /**
-     * Ctor.
-     * @param input The input
+     * Original bytes.
      */
-    public Sha256DigestOf(final Input input) {
-        super(input, "SHA-256");
-    }
+    private final Bytes origin;
+
+    /**
+     * Function that wraps exception of {@link #origin} to the required type.
+     */
+    private final Func<Exception, E> func;
 
     /**
      * Ctor.
-     * @param input The input
-     * @param max Buffer size
+     * @param orig Origin bytes.
+     * @param fnc Function that wraps exceptions.
      */
-    public Sha256DigestOf(final Input input, final int max) {
-        // @checkstyle MagicNumber (1 line)
-        super(input, max, "SHA-256");
+    public CheckedBytes(final Bytes orig, final Func<Exception, E> fnc) {
+        this.origin = orig;
+        this.func = fnc;
+    }
+
+    @Override
+    public byte[] asBytes() throws E {
+        return new Checked<>(
+            this.origin::asBytes,
+            this.func
+        ).value();
     }
 }

--- a/src/main/java/org/cactoos/bytes/DigestEnvelope.java
+++ b/src/main/java/org/cactoos/bytes/DigestEnvelope.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.cactoos.io;
+package org.cactoos.bytes;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/org/cactoos/bytes/EmptyBytes.java
+++ b/src/main/java/org/cactoos/bytes/EmptyBytes.java
@@ -21,45 +21,27 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.cactoos.io;
+package org.cactoos.bytes;
 
 import org.cactoos.Bytes;
-import org.cactoos.Func;
-import org.cactoos.scalar.Checked;
 
 /**
- * Bytes that throws exception of specified type.
+ * Bytes with no data.
  *
- * @param <E> Exception's type.
- * @since 0.31
+ * <p>There is no thread-safety guarantee.
+ *
+ * @since 0.2
  */
-public final class CheckedBytes<E extends Exception> implements Bytes {
+public final class EmptyBytes implements Bytes {
 
     /**
-     * Original bytes.
+     * Empty array of bytes.
      */
-    private final Bytes origin;
-
-    /**
-     * Function that wraps exception of {@link #origin} to the required type.
-     */
-    private final Func<Exception, E> func;
-
-    /**
-     * Ctor.
-     * @param orig Origin bytes.
-     * @param fnc Function that wraps exceptions.
-     */
-    public CheckedBytes(final Bytes orig, final Func<Exception, E> fnc) {
-        this.origin = orig;
-        this.func = fnc;
-    }
+    private static final byte[] EMPTY = {};
 
     @Override
-    public byte[] asBytes() throws E {
-        return new Checked<>(
-            this.origin::asBytes,
-            this.func
-        ).value();
+    public byte[] asBytes() {
+        return EmptyBytes.EMPTY;
     }
+
 }

--- a/src/main/java/org/cactoos/bytes/InputAsBytes.java
+++ b/src/main/java/org/cactoos/bytes/InputAsBytes.java
@@ -21,12 +21,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.cactoos.io;
+package org.cactoos.bytes;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import org.cactoos.Bytes;
 import org.cactoos.Input;
+import org.cactoos.io.OutputTo;
+import org.cactoos.io.TeeInput;
 
 /**
  * Input as Byte Array.
@@ -36,7 +38,7 @@ import org.cactoos.Input;
  * <p>There is no thread-safety guarantee.
  * @since 0.1
  */
-final class InputAsBytes implements Bytes {
+public final class InputAsBytes implements Bytes {
 
     /**
      * The input.

--- a/src/main/java/org/cactoos/bytes/Md5DigestOf.java
+++ b/src/main/java/org/cactoos/bytes/Md5DigestOf.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.cactoos.io;
+package org.cactoos.bytes;
 
 import org.cactoos.Input;
 

--- a/src/main/java/org/cactoos/bytes/ReaderAsBytes.java
+++ b/src/main/java/org/cactoos/bytes/ReaderAsBytes.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.cactoos.io;
+package org.cactoos.bytes;
 
 import java.io.Reader;
 import java.nio.charset.Charset;

--- a/src/main/java/org/cactoos/bytes/Sha1DigestOf.java
+++ b/src/main/java/org/cactoos/bytes/Sha1DigestOf.java
@@ -21,45 +21,34 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.cactoos.io;
+package org.cactoos.bytes;
 
-import java.io.IOException;
-import java.io.Reader;
+import org.cactoos.Input;
 
 /**
- * Empty Closable Reader
+ * SHA-1 checksum calculation of {@link Input}.
  *
- * <p>Empty {@link Reader} that can tell you if it was explicitly closed by
- * calling {@link Reader#close()} method.</p>
- *
- * <p>This class is for internal use only. Use {@link ReaderOf} instead</p>
- *
- * <p>There is no thread-safety guarantee.</p>
+ * <p>There is no thread-safety guarantee.
  *
  * @since 0.29
  */
-final class EmptyClosableReader extends Reader {
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+public final class Sha1DigestOf extends DigestEnvelope {
     /**
-     * Closed reader.
+     * Ctor.
+     * @param input The input
      */
-    private boolean closed;
-
-    @Override
-    public int read(final char[] cbuf, final int off, final int len)
-        throws IOException {
-        return -1;
-    }
-
-    @Override
-    public void close() throws IOException {
-        this.closed = true;
+    public Sha1DigestOf(final Input input) {
+        super(input, "SHA-1");
     }
 
     /**
-     * Ask if the {@link Reader} is closed.
-     * @return True if closed, false otherwise
+     * Ctor.
+     * @param input The input
+     * @param max Buffer size
      */
-    public boolean isClosed() {
-        return this.closed;
+    public Sha1DigestOf(final Input input, final int max) {
+        // @checkstyle MagicNumber (1 line)
+        super(input, max, "SHA-1");
     }
 }

--- a/src/main/java/org/cactoos/bytes/Sha256DigestOf.java
+++ b/src/main/java/org/cactoos/bytes/Sha256DigestOf.java
@@ -21,25 +21,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.cactoos.io;
+package org.cactoos.bytes;
 
 import org.cactoos.Input;
 
 /**
- * SHA-1 checksum calculation of {@link Input}.
+ * SHA-256 checksum calculation of {@link Input}.
  *
  * <p>There is no thread-safety guarantee.
  *
  * @since 0.29
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class Sha1DigestOf extends DigestEnvelope {
+public final class Sha256DigestOf extends DigestEnvelope {
     /**
      * Ctor.
      * @param input The input
      */
-    public Sha1DigestOf(final Input input) {
-        super(input, "SHA-1");
+    public Sha256DigestOf(final Input input) {
+        super(input, "SHA-256");
     }
 
     /**
@@ -47,8 +47,8 @@ public final class Sha1DigestOf extends DigestEnvelope {
      * @param input The input
      * @param max Buffer size
      */
-    public Sha1DigestOf(final Input input, final int max) {
+    public Sha256DigestOf(final Input input, final int max) {
         // @checkstyle MagicNumber (1 line)
-        super(input, max, "SHA-1");
+        super(input, max, "SHA-256");
     }
 }

--- a/src/main/java/org/cactoos/bytes/UncheckedBytes.java
+++ b/src/main/java/org/cactoos/bytes/UncheckedBytes.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.cactoos.io;
+package org.cactoos.bytes;
 
 import org.cactoos.Bytes;
 import org.cactoos.Func;

--- a/src/main/java/org/cactoos/io/InputOf.java
+++ b/src/main/java/org/cactoos/io/InputOf.java
@@ -36,6 +36,7 @@ import org.cactoos.Bytes;
 import org.cactoos.Input;
 import org.cactoos.Scalar;
 import org.cactoos.Text;
+import org.cactoos.bytes.BytesOf;
 import org.cactoos.scalar.IoChecked;
 import org.cactoos.scalar.Unchecked;
 

--- a/src/main/java/org/cactoos/io/ResourceOf.java
+++ b/src/main/java/org/cactoos/io/ResourceOf.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import org.cactoos.Func;
 import org.cactoos.Input;
 import org.cactoos.Text;
+import org.cactoos.bytes.BytesOf;
 import org.cactoos.func.IoCheckedFunc;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.TextOf;

--- a/src/main/java/org/cactoos/io/Zip.java
+++ b/src/main/java/org/cactoos/io/Zip.java
@@ -33,6 +33,7 @@ import java.nio.file.Path;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import org.cactoos.Input;
+import org.cactoos.bytes.BytesOf;
 
 /**
  * Zip files and directory.

--- a/src/main/java/org/cactoos/iterable/IterableOfBytes.java
+++ b/src/main/java/org/cactoos/iterable/IterableOfBytes.java
@@ -25,7 +25,7 @@ package org.cactoos.iterable;
 
 import org.cactoos.Bytes;
 import org.cactoos.Text;
-import org.cactoos.io.BytesOf;
+import org.cactoos.bytes.BytesOf;
 import org.cactoos.iterator.IteratorOfBytes;
 
 /**

--- a/src/main/java/org/cactoos/iterator/IteratorOfBytes.java
+++ b/src/main/java/org/cactoos/iterator/IteratorOfBytes.java
@@ -28,8 +28,8 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.cactoos.Bytes;
 import org.cactoos.Text;
-import org.cactoos.io.BytesOf;
-import org.cactoos.io.UncheckedBytes;
+import org.cactoos.bytes.BytesOf;
+import org.cactoos.bytes.UncheckedBytes;
 
 /**
  * Iterator that returns a set of bytes.

--- a/src/main/java/org/cactoos/text/Base64Decoded.java
+++ b/src/main/java/org/cactoos/text/Base64Decoded.java
@@ -26,7 +26,7 @@ package org.cactoos.text;
 
 import org.cactoos.Text;
 import org.cactoos.bytes.Base64Bytes;
-import org.cactoos.io.BytesOf;
+import org.cactoos.bytes.BytesOf;
 
 /**
  * Decodes the origin text using the Base64 encoding scheme.

--- a/src/main/java/org/cactoos/text/Base64Encoded.java
+++ b/src/main/java/org/cactoos/text/Base64Encoded.java
@@ -26,7 +26,7 @@ package org.cactoos.text;
 
 import org.cactoos.Text;
 import org.cactoos.bytes.BytesBase64;
-import org.cactoos.io.BytesOf;
+import org.cactoos.bytes.BytesOf;
 
 /**
  * Encodes the origin text using the Base64 encoding scheme.

--- a/src/main/java/org/cactoos/text/TextOf.java
+++ b/src/main/java/org/cactoos/text/TextOf.java
@@ -46,7 +46,7 @@ import org.cactoos.Bytes;
 import org.cactoos.Input;
 import org.cactoos.Scalar;
 import org.cactoos.Text;
-import org.cactoos.io.BytesOf;
+import org.cactoos.bytes.BytesOf;
 import org.cactoos.io.InputOf;
 import org.cactoos.iterable.Mapped;
 import org.cactoos.scalar.And;

--- a/src/test/java/org/cactoos/bytes/Base64BytesTest.java
+++ b/src/test/java/org/cactoos/bytes/Base64BytesTest.java
@@ -25,7 +25,6 @@
 package org.cactoos.bytes;
 
 import java.util.Base64;
-import org.cactoos.io.BytesOf;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;

--- a/src/test/java/org/cactoos/bytes/BytesBase64Test.java
+++ b/src/test/java/org/cactoos/bytes/BytesBase64Test.java
@@ -25,7 +25,6 @@
 package org.cactoos.bytes;
 
 import java.util.Base64;
-import org.cactoos.io.BytesOf;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;

--- a/src/test/java/org/cactoos/bytes/BytesOfTest.java
+++ b/src/test/java/org/cactoos/bytes/BytesOfTest.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.cactoos.io;
+package org.cactoos.bytes;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -30,13 +30,16 @@ import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.cactoos.Text;
+import org.cactoos.io.InputOf;
+import org.cactoos.io.Sticky;
 import org.cactoos.iterable.Endless;
 import org.cactoos.iterable.HeadOf;
+import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.IterableOfBytes;
 import org.cactoos.iterator.IteratorOfBytes;
 import org.cactoos.text.Joined;
 import org.cactoos.text.TextOf;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.AllOf;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
@@ -76,6 +79,7 @@ final class BytesOfTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void readsInputIntoBytes() throws Exception {
         new Assertion<>(
             "must read bytes from Input",
@@ -84,9 +88,11 @@ final class BytesOfTest {
                     new InputOf("Hello, друг!")
                 )
             ),
-            Matchers.allOf(
-                new StartsWith("Hello, "),
-                new EndsWith("друг!")
+            new AllOf<>(
+                new IterableOf<>(
+                    new StartsWith("Hello, "),
+                    new EndsWith("друг!")
+                )
             )
         ).affirm();
     }
@@ -113,6 +119,7 @@ final class BytesOfTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void readsInputIntoBytesWithSmallBuffer() throws Exception {
         new Assertion<>(
             "must read bytes from Input with a small reading buffer",
@@ -122,9 +129,11 @@ final class BytesOfTest {
                     2
                 )
             ),
-            Matchers.allOf(
-                new StartsWith("Hello,"),
-                new EndsWith("товарищ!")
+            new AllOf<>(
+                new IterableOf<>(
+                    new StartsWith("Hello,"),
+                    new EndsWith("товарищ!")
+                )
             )
         ).affirm();
     }
@@ -214,7 +223,7 @@ final class BytesOfTest {
                 new Joined(
                     System.lineSeparator(),
                     "java.io.IOException: It doesn't work at all",
-                    "\tat org.cactoos.io.BytesOfTest"
+                    "\tat org.cactoos.bytes.BytesOfTest"
                 )
             )
         ).affirm();
@@ -229,7 +238,7 @@ final class BytesOfTest {
                     new IOException("").getStackTrace()
                 )
             ),
-            new TextHasString("org.cactoos.io.BytesOfTest")
+            new TextHasString("org.cactoos.bytes.BytesOfTest")
         ).affirm();
     }
 

--- a/src/test/java/org/cactoos/bytes/CheckedBytesTest.java
+++ b/src/test/java/org/cactoos/bytes/CheckedBytesTest.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.cactoos.io;
+package org.cactoos.bytes;
 
 import java.io.IOException;
 import org.hamcrest.core.IsNull;

--- a/src/test/java/org/cactoos/bytes/EmptyClosableReader.java
+++ b/src/test/java/org/cactoos/bytes/EmptyClosableReader.java
@@ -21,27 +21,46 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.cactoos.io;
+package org.cactoos.bytes;
 
-import org.cactoos.Bytes;
+import java.io.IOException;
+import java.io.Reader;
+import org.cactoos.io.ReaderOf;
 
 /**
- * Bytes with no data.
+ * Empty Closable Reader
  *
- * <p>There is no thread-safety guarantee.
+ * <p>Empty {@link Reader} that can tell you if it was explicitly closed by
+ * calling {@link Reader#close()} method.</p>
  *
- * @since 0.2
+ * <p>This class is for internal use only. Use {@link ReaderOf} instead</p>
+ *
+ * <p>There is no thread-safety guarantee.</p>
+ *
+ * @since 0.29
  */
-public final class EmptyBytes implements Bytes {
-
+final class EmptyClosableReader extends Reader {
     /**
-     * Empty array of bytes.
+     * Closed reader.
      */
-    private static final byte[] EMPTY = {};
+    private boolean closed;
 
     @Override
-    public byte[] asBytes() {
-        return EmptyBytes.EMPTY;
+    public int read(final char[] cbuf, final int off, final int len)
+        throws IOException {
+        return -1;
     }
 
+    @Override
+    public void close() throws IOException {
+        this.closed = true;
+    }
+
+    /**
+     * Ask if the {@link Reader} is closed.
+     * @return True if closed, false otherwise
+     */
+    public boolean isClosed() {
+        return this.closed;
+    }
 }

--- a/src/test/java/org/cactoos/bytes/HexOfTest.java
+++ b/src/test/java/org/cactoos/bytes/HexOfTest.java
@@ -26,7 +26,6 @@ package org.cactoos.bytes;
 
 import java.io.IOException;
 import java.util.Arrays;
-import org.cactoos.io.BytesOf;
 import org.cactoos.text.TextOf;
 import org.junit.Test;
 import org.llorllale.cactoos.matchers.Assertion;

--- a/src/test/java/org/cactoos/bytes/InputAsBytesTest.java
+++ b/src/test/java/org/cactoos/bytes/InputAsBytesTest.java
@@ -21,10 +21,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.cactoos.io;
+package org.cactoos.bytes;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import org.cactoos.io.InputOf;
+import org.cactoos.io.SlowInputStream;
 import org.cactoos.iterable.Endless;
 import org.cactoos.iterable.HeadOf;
 import org.cactoos.iterable.IterableOf;

--- a/src/test/java/org/cactoos/bytes/Md5DigestOfTest.java
+++ b/src/test/java/org/cactoos/bytes/Md5DigestOfTest.java
@@ -21,8 +21,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.cactoos.io;
+package org.cactoos.bytes;
 
+import org.cactoos.io.InputOf;
+import org.cactoos.io.ResourceOf;
+import org.cactoos.io.Sticky;
 import org.cactoos.text.HexOf;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;

--- a/src/test/java/org/cactoos/bytes/ReaderAsBytesTest.java
+++ b/src/test/java/org/cactoos/bytes/ReaderAsBytesTest.java
@@ -21,43 +21,53 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.cactoos.io;
+package org.cactoos.bytes;
 
-import java.io.IOException;
-import org.cactoos.Text;
+import java.io.StringReader;
 import org.cactoos.text.TextOf;
-import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.IsTrue;
+import org.llorllale.cactoos.matchers.TextIs;
 
 /**
- * Test case for {@link UncheckedBytes}.
+ * Test case for {@link ReaderAsBytes}.
  *
- * @since 0.3
+ * @since 0.12
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-public final class UncheckedBytesTest {
+public final class ReaderAsBytesTest {
+    /**
+     * Temporary files and folders generator.
+     */
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
 
-    @Test(expected = RuntimeException.class)
-    public void rethrowsCheckedToUncheckedException() {
-        new UncheckedBytes(
-            () -> {
-                throw new IOException("intended");
-            }
-        ).asBytes();
+    @Test
+    public void readsString() throws Exception {
+        final String source = "hello, друг!";
+        new Assertion<>(
+            "Must read string through a reader",
+            new TextOf(
+                new ReaderAsBytes(
+                    new StringReader(source)
+                )
+            ),
+            new TextIs(source)
+        ).affirm();
     }
 
     @Test
-    public void worksNormallyWhenNoExceptionIsThrown() throws Exception {
-        final Text source = new TextOf("hello, cactoos!");
+    public void readsAndClosesReader() throws Exception {
+        final EmptyClosableReader reader = new EmptyClosableReader();
+        new ReaderAsBytes(reader).asBytes();
         new Assertion<>(
-            "Must works normally when no exception is thrown",
-            new UncheckedBytes(
-                new BytesOf(source)
-            ).asBytes(),
-            Matchers.equalTo(
-                new BytesOf(source).asBytes()
-            )
+            "Must close the reader after reading it",
+            reader.isClosed(),
+            new IsTrue()
         ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/bytes/Sha1DigestOfTest.java
+++ b/src/test/java/org/cactoos/bytes/Sha1DigestOfTest.java
@@ -21,8 +21,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.cactoos.io;
+package org.cactoos.bytes;
 
+import org.cactoos.io.InputOf;
+import org.cactoos.io.ResourceOf;
+import org.cactoos.io.Sticky;
 import org.cactoos.text.HexOf;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;

--- a/src/test/java/org/cactoos/bytes/Sha256DigestOfTest.java
+++ b/src/test/java/org/cactoos/bytes/Sha256DigestOfTest.java
@@ -21,8 +21,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.cactoos.io;
+package org.cactoos.bytes;
 
+import org.cactoos.io.InputOf;
+import org.cactoos.io.ResourceOf;
+import org.cactoos.io.Sticky;
 import org.cactoos.text.HexOf;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;

--- a/src/test/java/org/cactoos/bytes/UncheckedBytesTest.java
+++ b/src/test/java/org/cactoos/bytes/UncheckedBytesTest.java
@@ -21,53 +21,41 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.cactoos.io;
+package org.cactoos.bytes;
 
-import java.io.StringReader;
+import java.io.IOException;
+import org.cactoos.Text;
 import org.cactoos.text.TextOf;
-import org.junit.Rule;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import org.llorllale.cactoos.matchers.Assertion;
-import org.llorllale.cactoos.matchers.IsTrue;
-import org.llorllale.cactoos.matchers.TextIs;
 
 /**
- * Test case for {@link ReaderAsBytes}.
+ * Test case for {@link UncheckedBytes}.
  *
- * @since 0.12
+ * @since 0.3
  * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-public final class ReaderAsBytesTest {
-    /**
-     * Temporary files and folders generator.
-     */
-    @Rule
-    public final TemporaryFolder folder = new TemporaryFolder();
+public final class UncheckedBytesTest {
 
-    @Test
-    public void readsString() throws Exception {
-        final String source = "hello, друг!";
-        new Assertion<>(
-            "Must read string through a reader",
-            new TextOf(
-                new ReaderAsBytes(
-                    new StringReader(source)
-                )
-            ),
-            new TextIs(source)
-        ).affirm();
+    @Test(expected = RuntimeException.class)
+    public void rethrowsCheckedToUncheckedException() {
+        new UncheckedBytes(
+            () -> {
+                throw new IOException("intended");
+            }
+        ).asBytes();
     }
 
     @Test
-    public void readsAndClosesReader() throws Exception {
-        final EmptyClosableReader reader = new EmptyClosableReader();
-        new ReaderAsBytes(reader).asBytes();
+    public void worksNormallyWhenNoExceptionIsThrown() throws Exception {
+        final Text source = new TextOf("hello, cactoos!");
         new Assertion<>(
-            "Must close the reader after reading it",
-            reader.isClosed(),
-            new IsTrue()
+            "Must works normally when no exception is thrown",
+            new UncheckedBytes(
+                new BytesOf(source)
+            ).asBytes(),
+            new IsEqual<>(new BytesOf(source).asBytes())
         ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/io/InputOfTest.java
+++ b/src/test/java/org/cactoos/io/InputOfTest.java
@@ -39,6 +39,7 @@ import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
+import org.cactoos.bytes.BytesOf;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.text.TextOf;
 import org.hamcrest.core.AllOf;
@@ -310,7 +311,7 @@ public final class InputOfTest {
         new Assertion<>(
             "must read encoded string through a reader",
             new TextOf(
-                new InputAsBytes(
+                new BytesOf(
                     new InputOf(
                         new StringReader(source),
                         StandardCharsets.UTF_8
@@ -326,7 +327,7 @@ public final class InputOfTest {
         final byte[] bytes = new byte[] {(byte) 0xCA, (byte) 0xFE};
         new Assertion<>(
             "must read array of bytes",
-            new InputAsBytes(
+            new BytesOf(
                 new SyncInput(new InputOf(bytes))
             ).asBytes(),
             new IsEqual<>(bytes)

--- a/src/test/java/org/cactoos/io/InputStreamOfTest.java
+++ b/src/test/java/org/cactoos/io/InputStreamOfTest.java
@@ -29,6 +29,7 @@ import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.cactoos.bytes.BytesOf;
 import org.cactoos.scalar.LengthOf;
 import org.cactoos.text.TextOf;
 import org.hamcrest.Matchers;

--- a/src/test/java/org/cactoos/io/LoggingOutputTest.java
+++ b/src/test/java/org/cactoos/io/LoggingOutputTest.java
@@ -28,6 +28,7 @@ import java.io.OutputStream;
 import java.nio.file.Path;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.cactoos.bytes.BytesOf;
 import org.cactoos.scalar.LengthOf;
 import org.hamcrest.Matchers;
 import org.junit.Rule;

--- a/src/test/java/org/cactoos/io/ReaderOfTest.java
+++ b/src/test/java/org/cactoos/io/ReaderOfTest.java
@@ -26,6 +26,7 @@ package org.cactoos.io;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import org.cactoos.bytes.BytesOf;
 import org.cactoos.text.TextOf;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/org/cactoos/io/ResourceOfTest.java
+++ b/src/test/java/org/cactoos/io/ResourceOfTest.java
@@ -26,6 +26,7 @@ package org.cactoos.io;
 import java.io.IOException;
 import java.util.Arrays;
 import org.cactoos.Text;
+import org.cactoos.bytes.BytesOf;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.TextOf;
 import org.hamcrest.Matchers;

--- a/src/test/java/org/cactoos/io/SlowInputStream.java
+++ b/src/test/java/org/cactoos/io/SlowInputStream.java
@@ -32,7 +32,7 @@ import java.io.InputStream;
  *
  * @since 0.12
  */
-final class SlowInputStream extends InputStream {
+public final class SlowInputStream extends InputStream {
 
     /**
      * Original stream.
@@ -43,7 +43,7 @@ final class SlowInputStream extends InputStream {
      * Ctor.
      * @param size The size of the array to encapsulate
      */
-    SlowInputStream(final int size) {
+    public SlowInputStream(final int size) {
         this(new ByteArrayInputStream(new byte[size]));
     }
 

--- a/src/test/java/org/cactoos/io/SlowInputStreamTest.java
+++ b/src/test/java/org/cactoos/io/SlowInputStreamTest.java
@@ -23,6 +23,7 @@
  */
 package org.cactoos.io;
 
+import org.cactoos.bytes.BytesOf;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;

--- a/src/test/java/org/cactoos/io/StickyTest.java
+++ b/src/test/java/org/cactoos/io/StickyTest.java
@@ -25,6 +25,7 @@ package org.cactoos.io;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import org.cactoos.bytes.BytesOf;
 import org.cactoos.func.Repeated;
 import org.cactoos.scalar.LengthOf;
 import org.cactoos.text.TextOf;

--- a/src/test/java/org/cactoos/io/TailOfTest.java
+++ b/src/test/java/org/cactoos/io/TailOfTest.java
@@ -25,6 +25,7 @@ package org.cactoos.io;
 
 import java.util.Arrays;
 import java.util.Random;
+import org.cactoos.bytes.BytesOf;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.llorllale.cactoos.matchers.Assertion;

--- a/src/test/java/org/cactoos/io/TeeInputFromBytesTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputFromBytesTest.java
@@ -25,6 +25,7 @@ package org.cactoos.io;
 
 import java.io.File;
 import java.io.IOException;
+import org.cactoos.bytes.BytesOf;
 import org.cactoos.scalar.LengthOf;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/org/cactoos/text/HexOfTest.java
+++ b/src/test/java/org/cactoos/text/HexOfTest.java
@@ -24,7 +24,7 @@
 package org.cactoos.text;
 
 import java.io.IOException;
-import org.cactoos.io.BytesOf;
+import org.cactoos.bytes.BytesOf;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.TextHasString;

--- a/src/test/java/org/cactoos/text/TextOfTest.java
+++ b/src/test/java/org/cactoos/text/TextOfTest.java
@@ -39,7 +39,7 @@ import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.Locale;
 import java.util.TimeZone;
-import org.cactoos.io.BytesOf;
+import org.cactoos.bytes.BytesOf;
 import org.cactoos.io.InputOf;
 import org.cactoos.iterator.IteratorOfChars;
 import org.hamcrest.Matchers;


### PR DESCRIPTION
#1199
- Move Bytes classes from io to bytes package;
- Fix some errors of compilation in unit tests classes (there was some inner classes of io package that was required by some Bytes classes moved)
- Fix error about using static method Matchers.allOf in BytesOfTest
