### PR TITLE
(#1531) Bump cactoos-matchers to 0.24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ The MIT License (MIT)
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>parent</artifactId>
-    <version>0.50.5</version>
+    <version>0.51.1</version>
   </parent>
   <groupId>org.cactoos</groupId>
   <artifactId>cactoos</artifactId>
@@ -91,7 +91,7 @@ The MIT License (MIT)
     <dependency>
       <groupId>org.llorllale</groupId>
       <artifactId>cactoos-matchers</artifactId>
-      <version>0.23</version>
+      <version>0.24</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -169,7 +169,6 @@ The MIT License (MIT)
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.6</version>
         <configuration>
           <output>file</output>
           <outputDirectory>${project.build.directory}/coverage</outputDirectory>

--- a/src/main/java/org/cactoos/io/TempFolder.java
+++ b/src/main/java/org/cactoos/io/TempFolder.java
@@ -37,6 +37,7 @@ import org.cactoos.proc.ForEach;
 import org.cactoos.proc.IoCheckedProc;
 import org.cactoos.scalar.IoChecked;
 import org.cactoos.scalar.Sticky;
+import org.cactoos.text.Concatenated;
 import org.cactoos.text.Joined;
 import org.cactoos.text.Randomized;
 import org.cactoos.text.TextOf;
@@ -64,8 +65,7 @@ public final class TempFolder implements Scalar<Path>, Closeable {
      */
     public TempFolder() {
         this(
-            new Joined(
-                new TextOf(""),
+            new Concatenated(
                 new TextOf("tmp"),
                 new Randomized(
                     // @checkstyle MagicNumber (1 line)

--- a/src/main/java/org/cactoos/text/Capitalized.java
+++ b/src/main/java/org/cactoos/text/Capitalized.java
@@ -57,8 +57,7 @@ public final class Capitalized extends TextEnvelope {
                     new ScalarOf<>(() -> new Sticky(text)),
                     new org.cactoos.func.Flattened<>(IsBlank::new),
                     t -> t,
-                    t -> new Joined(
-                        "",
+                    t -> new Concatenated(
                         new TextOf(
                             Character.toChars(
                                 Character.toTitleCase(

--- a/src/main/java/org/cactoos/text/PaddedStart.java
+++ b/src/main/java/org/cactoos/text/PaddedStart.java
@@ -46,8 +46,7 @@ public final class PaddedStart extends TextEnvelope {
             new Flattened(
                 () -> {
                     final String original = text.asString();
-                    return new Joined(
-                        new TextOf(""),
+                    return new Concatenated(
                         new Repeated(
                             new TextOf(symbol), length - original.length()
                         ),

--- a/src/test/java/org/cactoos/bytes/BytesOfTest.java
+++ b/src/test/java/org/cactoos/bytes/BytesOfTest.java
@@ -37,6 +37,7 @@ import org.cactoos.iterable.HeadOf;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.IterableOfBytes;
 import org.cactoos.iterator.IteratorOfBytes;
+import org.cactoos.text.Concatenated;
 import org.cactoos.text.Joined;
 import org.cactoos.text.TextOf;
 import org.hamcrest.core.AllOf;
@@ -66,10 +67,9 @@ final class BytesOfTest {
             "must read large content from in-memory Input",
             new BytesOf(
                 new InputOf(
-                    new Joined(
-                        "",
+                    new Concatenated(
                         new HeadOf<>(
-                            multiplier, new Endless<>(body)
+                            multiplier, new Endless<>(new TextOf(body))
                         )
                     )
                 )

--- a/src/test/java/org/cactoos/bytes/HexOfTest.java
+++ b/src/test/java/org/cactoos/bytes/HexOfTest.java
@@ -25,11 +25,11 @@
 package org.cactoos.bytes;
 
 import java.io.IOException;
-import java.util.Arrays;
 import org.cactoos.text.TextOf;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 import org.llorllale.cactoos.matchers.Assertion;
-import org.llorllale.cactoos.matchers.MatcherOf;
+import org.llorllale.cactoos.matchers.Verifies;
 
 /**
  * Test case for {@link HexOf}.
@@ -45,7 +45,7 @@ public final class HexOfTest {
         new Assertion<>(
             "Must represent an empty hexadecimal text",
             new HexOf(new TextOf("")).asBytes(),
-            new MatcherOf<>(array -> array.length == 0)
+            new Verifies<>(array -> array.length == 0)
         ).affirm();
     }
 
@@ -62,9 +62,7 @@ public final class HexOfTest {
                     new BytesOf(bytes)
                 )
             ).asBytes(),
-            new MatcherOf<>(
-                (byte[] array) -> Arrays.equals(bytes, array)
-            )
+            new IsEqual<>(bytes)
         ).affirm();
     }
 

--- a/src/test/java/org/cactoos/collection/BehavesAsCollection.java
+++ b/src/test/java/org/cactoos/collection/BehavesAsCollection.java
@@ -33,7 +33,7 @@ import org.hamcrest.core.IsCollectionContaining;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNot;
 import org.llorllale.cactoos.matchers.Assertion;
-import org.llorllale.cactoos.matchers.MatcherOf;
+import org.llorllale.cactoos.matchers.Verifies;
 
 /**
  * Matcher for collection.
@@ -82,7 +82,7 @@ public final class BehavesAsCollection<E> extends
             "Size must be more than 0",
             col,
             new IsCollectionWithSize<>(
-                new MatcherOf<>(s -> s > 0)
+                new Verifies<>(s -> s > 0)
             )
         ).affirm();
         new Assertion<>(

--- a/src/test/java/org/cactoos/collection/ImmutableTest.java
+++ b/src/test/java/org/cactoos/collection/ImmutableTest.java
@@ -28,7 +28,6 @@ import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasValues;
-import org.llorllale.cactoos.matchers.MatcherOf;
 import org.llorllale.cactoos.matchers.Throws;
 
 /**
@@ -123,9 +122,7 @@ public class ImmutableTest {
                 new ListOf<>(1, 2)
             ).add(3),
             new Throws<>(
-                new MatcherOf<>(
-                    (String msg) -> msg.equals("#add(): the collection is read-only")
-                ),
+                "#add(): the collection is read-only",
                 UnsupportedOperationException.class
             )
         ).affirm();
@@ -139,9 +136,7 @@ public class ImmutableTest {
                 new ListOf<>(1, 2)
             ).remove(1),
             new Throws<>(
-                new MatcherOf<>(
-                    (String msg) -> msg.equals("#remove(): the collection is read-only")
-                ),
+                "#remove(): the collection is read-only",
                 UnsupportedOperationException.class
             )
         ).affirm();
@@ -169,9 +164,7 @@ public class ImmutableTest {
                 new ListOf<>(1, 2)
             ).addAll(new ListOf<>(3, 4)),
             new Throws<>(
-                new MatcherOf<>(
-                    (String msg) -> msg.equals("#addAll(): the collection is read-only")
-                ),
+                "#addAll(): the collection is read-only",
                 UnsupportedOperationException.class
             )
         ).affirm();
@@ -185,9 +178,7 @@ public class ImmutableTest {
                 new ListOf<>(1, 2, 3)
             ).removeAll(new ListOf<>(2, 3)),
             new Throws<>(
-                new MatcherOf<>(
-                    (String msg) -> msg.equals("#removeAll(): the collection is read-only")
-                ),
+                "#removeAll(): the collection is read-only",
                 UnsupportedOperationException.class
             )
         ).affirm();
@@ -201,9 +192,7 @@ public class ImmutableTest {
                 new ListOf<>(1, 2, 3)
             ).retainAll(new ListOf<>(1)),
             new Throws<>(
-                new MatcherOf<>(
-                    (String msg) -> msg.equals("#retainAll(): the collection is read-only")
-                ),
+                "#retainAll(): the collection is read-only",
                 UnsupportedOperationException.class
             )
         ).affirm();
@@ -220,9 +209,7 @@ public class ImmutableTest {
                 return new Object();
             },
             new Throws<>(
-                new MatcherOf<>(
-                    (String msg) -> msg.equals("#clear(): the collection is read-only")
-                ),
+                "#clear(): the collection is read-only",
                 UnsupportedOperationException.class
             )
         ).affirm();

--- a/src/test/java/org/cactoos/func/AsyncTest.java
+++ b/src/test/java/org/cactoos/func/AsyncTest.java
@@ -31,20 +31,19 @@ import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.IsApplicable;
-import org.llorllale.cactoos.matchers.MatcherOf;
+import org.llorllale.cactoos.matchers.Verifies;
 
 /**
  * Test case for {@link Async}.
  *
  * @since 0.10
- * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 final class AsyncTest {
     @Test
     void runsInBackground() {
         new Assertion<>(
-            "Can't run in the background",
+            "Must run in the background",
             new Async<>(
                 input -> {
                     TimeUnit.DAYS.sleep(1L);
@@ -53,7 +52,7 @@ final class AsyncTest {
             ),
             new IsApplicable<>(
                 true,
-                new MatcherOf<>(
+                new Verifies<>(
                     future -> !future.isDone()
                 )
             )
@@ -63,7 +62,7 @@ final class AsyncTest {
     @Test
     void runsAsProcInBackground() {
         new Assertion<>(
-            "Can't run proc in the background",
+            "Must run proc in the background",
             input -> {
                 final CountDownLatch latch = new CountDownLatch(1);
                 new Async<>(
@@ -82,16 +81,14 @@ final class AsyncTest {
     void runsInBackgroundWithoutFuture() {
         final CountDownLatch latch = new CountDownLatch(1);
         new Assertion<>(
-            "Can't run in the background without us touching the Future",
+            "Must run in the background without us touching the Future",
             new Async<>(
                 new FuncOf<>(input -> latch.countDown(), true)
             ),
             new IsApplicable<>(
                 true,
-                new MatcherOf<>(
-                    future -> {
-                        return latch.await(1L, TimeUnit.SECONDS);
-                    }
+                new Verifies<>(
+                    future -> latch.await(1L, TimeUnit.SECONDS)
                 )
             )
         ).affirm();
@@ -103,7 +100,7 @@ final class AsyncTest {
         final ThreadFactory factory = r -> new Thread(r, name);
         final CountDownLatch latch = new CountDownLatch(1);
         new Assertion<>(
-            "Can't run in the background with specific thread factory",
+            "Must run in the background with specific thread factory",
             new Async<>(
                 new FuncOf<>(
                     input -> {
@@ -120,7 +117,7 @@ final class AsyncTest {
             ),
             new IsApplicable<>(
                 name,
-                new MatcherOf<>(
+                new Verifies<>(
                     future -> {
                         future.get();
                         return latch.getCount() == 0;
@@ -136,7 +133,7 @@ final class AsyncTest {
         final ThreadFactory factory = r -> new Thread(r, name);
         final CountDownLatch latch = new CountDownLatch(1);
         new Assertion<>(
-            "Can't run in the background with specific thread executor",
+            "Must run in the background with specific thread executor",
             new Async<>(
                 new FuncOf<>(
                     input -> {
@@ -153,7 +150,7 @@ final class AsyncTest {
             ),
             new IsApplicable<>(
                 name,
-                new MatcherOf<>(
+                new Verifies<>(
                     future -> {
                         future.get();
                         return latch.getCount() == 0;

--- a/src/test/java/org/cactoos/func/BiFuncOfTest.java
+++ b/src/test/java/org/cactoos/func/BiFuncOfTest.java
@@ -30,7 +30,7 @@ import org.cactoos.scalar.Constant;
 import org.hamcrest.core.IsSame;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
-import org.llorllale.cactoos.matchers.MatcherOf;
+import org.llorllale.cactoos.matchers.Verifies;
 
 /**
  * Test case for {@link BiFuncOf}.
@@ -48,7 +48,7 @@ final class BiFuncOfTest {
             new BiFuncOf<>(
                 new FuncOf<>(input -> input)
             ),
-            new MatcherOf<>(
+            new Verifies<>(
                 func -> {
                     final Object first = new Object();
                     final Object res = func.apply(first, "discarded");
@@ -72,7 +72,7 @@ final class BiFuncOfTest {
                 ),
                 result
             ),
-            new MatcherOf<>(
+            new Verifies<>(
                 func -> {
                     final Object first = new Object();
                     final Object res = func.apply(first, "discarded");
@@ -97,7 +97,7 @@ final class BiFuncOfTest {
         new Assertion<>(
             "Must convert lambda into bi-function",
             new BiFuncOf<>((first, second) -> new Object[] {first, second}),
-            new MatcherOf<BiFunc<Object, Object, Object[]>>(
+            new Verifies<BiFunc<Object, Object, Object[]>>(
                 func -> {
                     final Object first = new Object();
                     final Object second = new Object();

--- a/src/test/java/org/cactoos/func/FuncOfTest.java
+++ b/src/test/java/org/cactoos/func/FuncOfTest.java
@@ -28,7 +28,7 @@ import org.cactoos.proc.ProcOf;
 import org.cactoos.scalar.Constant;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
-import org.llorllale.cactoos.matchers.MatcherOf;
+import org.llorllale.cactoos.matchers.Verifies;
 
 /**
  * Test case for {@link FuncOf}.
@@ -50,7 +50,7 @@ final class FuncOfTest {
                 ),
                 result
             ),
-            new MatcherOf<>(
+            new Verifies<>(
                 func -> {
                     final Object input = new Object();
                     final Object res = func.apply(input);
@@ -66,7 +66,7 @@ final class FuncOfTest {
         new Assertion<>(
             "Must convert Scalar into Func",
             new FuncOf<>(new Constant<>(result)),
-            new MatcherOf<>(
+            new Verifies<>(
                 func -> {
                     final Object res = func.apply("discarded");
                     return res.equals(result);
@@ -80,7 +80,7 @@ final class FuncOfTest {
         new Assertion<>(
             "Must convert Lambda into Func",
             new FuncOf<>(input -> input),
-            new MatcherOf<>(
+            new Verifies<>(
                 func -> {
                     final Object input = new Object();
                     final Object res = func.apply(input);

--- a/src/test/java/org/cactoos/io/AppendToTest.java
+++ b/src/test/java/org/cactoos/io/AppendToTest.java
@@ -26,7 +26,7 @@ package org.cactoos.io;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.NoSuchFileException;
-import org.cactoos.text.Joined;
+import org.cactoos.text.Concatenated;
 import org.cactoos.text.Randomized;
 import org.junit.Rule;
 import org.junit.Test;
@@ -83,7 +83,7 @@ public final class AppendToTest {
         new Assertion<>(
             "Does not contain expected text",
             new InputOf(source),
-            new HasContent(new Joined("", first, second))
+            new HasContent(new Concatenated(first, second))
         ).affirm();
     }
 
@@ -105,7 +105,7 @@ public final class AppendToTest {
         new Assertion<>(
             "Can't find expected unicode text content",
             new InputOf(source),
-            new HasContent(new Joined("", first, second))
+            new HasContent(new Concatenated(first, second))
         ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/io/InputOfTest.java
+++ b/src/test/java/org/cactoos/io/InputOfTest.java
@@ -44,16 +44,16 @@ import org.cactoos.iterable.IterableOf;
 import org.cactoos.text.TextOf;
 import org.hamcrest.core.AllOf;
 import org.hamcrest.core.IsEqual;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.EndsWith;
 import org.llorllale.cactoos.matchers.HasContent;
 import org.llorllale.cactoos.matchers.HasString;
-import org.llorllale.cactoos.matchers.MatcherOf;
+import org.llorllale.cactoos.matchers.IsTrue;
 import org.llorllale.cactoos.matchers.MatchesRegex;
 import org.llorllale.cactoos.matchers.StartsWith;
+import org.llorllale.cactoos.matchers.Verifies;
 import org.takes.http.FtRemote;
 import org.takes.tk.TkHtml;
 
@@ -61,20 +61,13 @@ import org.takes.tk.TkHtml;
  * Test case for {@link InputOf}.
  *
  * @since 0.1
- * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle ClassFanOutComplexityCheck (500 lines)
  */
 @SuppressWarnings({ "PMD.TooManyMethods", "PMD.ExcessiveImports", "unchecked" })
-public final class InputOfTest {
-    /**
-     * Temporary files and folders generator.
-     */
-    @Rule
-    public final TemporaryFolder folder = new TemporaryFolder();
-
+final class InputOfTest {
     @Test
-    public void readsAlternativeInputForFileCase() {
+    void readsAlternativeInputForFileCase() {
         new Assertion<>(
             "must read alternative source from file not found",
             new TextOf(
@@ -90,9 +83,8 @@ public final class InputOfTest {
     }
 
     @Test
-    public void readsSimpleFileContent() throws IOException {
-        final Path temp = this.folder.newFile("cactoos-1.txt-1")
-            .toPath();
+    void readsSimpleFileContent(final @TempDir Path folder) throws IOException {
+        final Path temp = folder.resolve("cactoos-1.txt-1");
         final String content = "Hello, товарищ!";
         Files.write(temp, content.getBytes(StandardCharsets.UTF_8));
         new Assertion<>(
@@ -103,39 +95,36 @@ public final class InputOfTest {
     }
 
     @Test
-    public void closesInputStream() throws Exception {
+    void closesInputStream() throws Exception {
         final AtomicBoolean closed = new AtomicBoolean();
         final InputStream input = new ByteArrayInputStream(
             "how are you?".getBytes()
         );
-        new Assertion<>(
-            "must close InputStream correctly",
-            new TextOf(
-                new InputOf(
-                    new InputStream() {
-                        @Override
-                        public int read() throws IOException {
-                            return input.read();
-                        }
-
-                        @Override
-                        public void close() throws IOException {
-                            input.close();
-                            closed.set(true);
-                        }
+        new TextOf(
+            new InputOf(
+                new InputStream() {
+                    @Override
+                    public int read() throws IOException {
+                        return input.read();
                     }
-                )
-            ).asString(),
-            new MatcherOf<>(
-                text -> {
-                    return closed.get();
+
+                    @Override
+                    public void close() throws IOException {
+                        input.close();
+                        closed.set(true);
+                    }
                 }
             )
+        ).asString();
+        new Assertion<>(
+            "must close InputStream correctly",
+            closed.get(),
+            new IsTrue()
         ).affirm();
     }
 
     @Test
-    public void readsFileContent() throws Exception {
+    void readsFileContent() throws Exception {
         new Assertion<>(
             "must read bytes from a file-system URL",
             new BytesOf(
@@ -144,13 +133,13 @@ public final class InputOfTest {
                         "/org/cactoos/io/InputOf.class"
                     )
                 )
-            ).asBytes().length,
-            new MatcherOf<>(len -> len > 0)
+            ).asBytes(),
+            new Verifies<>(arr -> arr.length > 0)
         ).affirm();
     }
 
     @Test
-    public void readsRealUrl() throws IOException {
+    void readsRealUrl() throws IOException {
         new FtRemote(new TkHtml("<html>How are you?</html>")).exec(
             home -> new Assertion<>(
                 "must fetch bytes from the URL",
@@ -163,7 +152,7 @@ public final class InputOfTest {
     }
 
     @Test
-    public void readsStringUrl() throws IOException {
+    void readsStringUrl() throws IOException {
         new Assertion<>(
             "must fetch bytes from the HTTPS URL",
             new TextOf(
@@ -181,7 +170,7 @@ public final class InputOfTest {
     }
 
     @Test
-    public void readsStringIntoBytes() throws Exception {
+    void readsStringIntoBytes() throws Exception {
         new Assertion<>(
             "must read bytes from Input",
             new TextOf(
@@ -200,7 +189,7 @@ public final class InputOfTest {
     }
 
     @Test
-    public void readsStringBuilder() throws Exception {
+    void readsStringBuilder() throws Exception {
         final String starts = "Name it, ";
         final String ends = "then it exists!";
         new Assertion<>(
@@ -223,7 +212,7 @@ public final class InputOfTest {
     }
 
     @Test
-    public void readsStringBuffer() throws Exception {
+    void readsStringBuffer() throws Exception {
         final String starts = "The future ";
         final String ends = "is now!";
         new Assertion<>(
@@ -246,7 +235,7 @@ public final class InputOfTest {
     }
 
     @Test
-    public void readsArrayOfChars() throws Exception {
+    void readsArrayOfChars() throws Exception {
         new Assertion<>(
             "must read array of chars.",
             new TextOf(
@@ -267,7 +256,7 @@ public final class InputOfTest {
     }
 
     @Test
-    public void readsEncodedArrayOfChars() throws Exception {
+    void readsEncodedArrayOfChars() throws Exception {
         new Assertion<>(
             "must read array of encoded chars.",
             new TextOf(
@@ -292,7 +281,7 @@ public final class InputOfTest {
     }
 
     @Test
-    public void readsStringFromReader() throws Exception {
+    void readsStringFromReader() throws Exception {
         final String source = "hello, source!";
         new Assertion<>(
             "must read string through a reader",
@@ -306,7 +295,7 @@ public final class InputOfTest {
     }
 
     @Test
-    public void readsEncodedStringFromReader() throws Exception {
+    void readsEncodedStringFromReader() throws Exception {
         final String source = "hello, друг!";
         new Assertion<>(
             "must read encoded string through a reader",
@@ -323,7 +312,7 @@ public final class InputOfTest {
     }
 
     @Test
-    public void readsAnArrayOfBytes() throws Exception {
+    void readsAnArrayOfBytes() throws Exception {
         final byte[] bytes = new byte[] {(byte) 0xCA, (byte) 0xFE};
         new Assertion<>(
             "must read array of bytes",
@@ -335,18 +324,18 @@ public final class InputOfTest {
     }
 
     @Test
-    public void makesDataAvailable() throws Exception {
+    void makesDataAvailable() throws Exception {
         final String content = "Hello,חבר!";
         new Assertion<>(
             "must show that data is available",
-            new InputOf(content).stream().available(),
-            new MatcherOf<>(avl -> avl > 0)
+            new InputOf(content).stream(),
+            new Verifies<>(s -> s.available() > 0)
         ).affirm();
     }
 
     @Test
     // @checkstyle MethodBodyCommentsCheck (50 lines)
-    public void readsSecureUrlContent() throws Exception {
+    void readsSecureUrlContent() throws Exception {
         final TrustManager[] managers = {
             new X509TrustManager() {
                 @Override
@@ -380,8 +369,8 @@ public final class InputOfTest {
                         "https://www.yegor256.com/robots.txt"
                     )
                 )
-            ).asBytes().length,
-            new MatcherOf<>(len -> len > 0)
+            ).asBytes(),
+            new Verifies<>(arr -> arr.length > 0)
         ).affirm();
     }
 

--- a/src/test/java/org/cactoos/io/StickyTest.java
+++ b/src/test/java/org/cactoos/io/StickyTest.java
@@ -33,12 +33,11 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.EndsWith;
-import org.llorllale.cactoos.matchers.MatcherOf;
+import org.llorllale.cactoos.matchers.Verifies;
 
 /**
  * Test case for {@link Sticky}.
  * @since 0.6
- * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 final class StickyTest {
@@ -46,13 +45,13 @@ final class StickyTest {
     @Test
     void readsFileContent() {
         new Assertion<>(
-            "Can't read bytes from a file",
+            "Must read bytes from a file",
             new Sticky(
                 new ResourceOf(
                     "org/cactoos/large-text.txt"
                 )
             ),
-            new MatcherOf<>(
+            new Verifies<>(
                 new Repeated<>(
                     input -> new BytesOf(
                         new TeeInput(input, new DeadOutput())
@@ -67,7 +66,7 @@ final class StickyTest {
     @Test
     void readsRealUrl() throws MalformedURLException {
         new Assertion<>(
-            "Can't fetch text page from the URL",
+            "Must fetch text page from the URL",
             new TextOf(
                 new Sticky(
                     new InputOf(
@@ -86,7 +85,7 @@ final class StickyTest {
     void readsFileContentSlowlyAndCountsLength() {
         final long size = 100_000L;
         new Assertion<>(
-            "Can't read bytes from a large source slowly and count length",
+            "Must read bytes from a large source slowly and count length",
             new LengthOf(
                 new Sticky(
                     new SlowInput(size)
@@ -100,7 +99,7 @@ final class StickyTest {
     void readsFileContentSlowly() throws Exception {
         final int size = 130_000;
         new Assertion<>(
-            "Can't read bytes from a large source slowly",
+            "Must read bytes from a large source slowly",
             new BytesOf(
                 new Sticky(
                     new SlowInput(size)

--- a/src/test/java/org/cactoos/io/TempFileTest.java
+++ b/src/test/java/org/cactoos/io/TempFileTest.java
@@ -33,14 +33,13 @@ import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.EndsWith;
-import org.llorllale.cactoos.matchers.MatcherOf;
 import org.llorllale.cactoos.matchers.StartsWith;
+import org.llorllale.cactoos.matchers.Verifies;
 
 /**
  * Unit tests for {@link TempFile}.
  *
  * @since 1.0
- * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 final class TempFileTest {
@@ -64,15 +63,11 @@ final class TempFileTest {
                 "Must create a temp file at a custom path",
                 file,
                 Matchers.allOf(
-                    new MatcherOf<>(
-                        tmp -> {
-                            return Files.exists(tmp.value());
-                        }
+                    new Verifies<>(
+                        tmp -> Files.exists(tmp.value())
                     ),
-                    new MatcherOf<>(
-                        tmp -> {
-                            return tmp.value().getParent().equals(custom);
-                        }
+                    new Verifies<>(
+                        tmp -> tmp.value().getParent().equals(custom)
                     )
                 )
             ).affirm();

--- a/src/test/java/org/cactoos/iterable/JoinedTest.java
+++ b/src/test/java/org/cactoos/iterable/JoinedTest.java
@@ -51,7 +51,7 @@ final class JoinedTest {
     void joinsMappedIterables() {
         new Assertion<>(
             "Must concatenate mapped iterables together",
-            new Joined<>(
+            new Joined<String>(
                 new Mapped<>(
                     IterableOf::new,
                     new IterableOf<>("x", "y")

--- a/src/test/java/org/cactoos/iterator/NoNullsTest.java
+++ b/src/test/java/org/cactoos/iterator/NoNullsTest.java
@@ -25,14 +25,13 @@ package org.cactoos.iterator;
 
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
-import org.llorllale.cactoos.matchers.MatcherOf;
 import org.llorllale.cactoos.matchers.Throws;
+import org.llorllale.cactoos.matchers.Verifies;
 
 /**
  * Test cases for {@link NoNulls}.
  *
  * <p>There is no thread-safety guarantee.
- * @checkstyle JavadocMethodCheck (500 lines)
  * @since 0.35
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
@@ -46,7 +45,7 @@ final class NoNullsTest {
                 new IteratorOf<>(new String[]{null})
             ).next(),
             new Throws<>(
-                new MatcherOf<>(
+                new Verifies<>(
                     (String msg) -> msg.matches("^Item #0 of .*? is NULL")
                 ),
                 IllegalStateException.class
@@ -65,7 +64,7 @@ final class NoNullsTest {
                 )
             ).next(),
             new Throws<>(
-                new MatcherOf<>(
+                new Verifies<>(
                     (String msg) -> msg.matches("^Item #2 of .*? is NULL")
                 ),
                 IllegalStateException.class

--- a/src/test/java/org/cactoos/list/BehavesAsList.java
+++ b/src/test/java/org/cactoos/list/BehavesAsList.java
@@ -31,13 +31,12 @@ import org.hamcrest.core.IsNot;
 import org.hamcrest.core.IsNull;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.IsTrue;
-import org.llorllale.cactoos.matchers.MatcherOf;
+import org.llorllale.cactoos.matchers.Verifies;
 
 /**
  * Matcher for collection.
  * @param <E> Type of source item
  * @since 0.23
- * @checkstyle JavadocMethodCheck (500 lines)
  */
 public final class BehavesAsList<E> extends TypeSafeMatcher<List<E>>  {
 
@@ -65,12 +64,12 @@ public final class BehavesAsList<E> extends TypeSafeMatcher<List<E>>  {
         new Assertion<>(
             "must have an index for the sample item",
             list.indexOf(this.sample),
-            new MatcherOf<>(i -> i >= 0)
+            new Verifies<>(i -> i >= 0)
         ).affirm();
         new Assertion<>(
             "must have a last index for the sample item",
             list.lastIndexOf(this.sample),
-            new MatcherOf<>(i -> i >= 0)
+            new Verifies<>(i -> i >= 0)
         ).affirm();
         new Assertion<>(
             "must have at least one element in list iterator",

--- a/src/test/java/org/cactoos/list/ImmutableTest.java
+++ b/src/test/java/org/cactoos/list/ImmutableTest.java
@@ -32,7 +32,6 @@ import org.hamcrest.core.IsNot;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasValues;
-import org.llorllale.cactoos.matchers.MatcherOf;
 import org.llorllale.cactoos.matchers.Throws;
 
 /**
@@ -43,7 +42,7 @@ import org.llorllale.cactoos.matchers.Throws;
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings({"PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals"})
-public class ImmutableTest {
+class ImmutableTest {
 
     @Test
     void innerListIsDecorated() {
@@ -232,9 +231,7 @@ public class ImmutableTest {
                 new ListOf<>(1, 2)
             ).add(3),
             new Throws<>(
-                new MatcherOf<>(
-                    (String msg) -> msg.equals("#add(T): the list is read-only")
-                ),
+                "#add(T): the list is read-only",
                 UnsupportedOperationException.class
             )
         ).affirm();
@@ -248,9 +245,7 @@ public class ImmutableTest {
                 new ListOf<>("1", "2")
             ).remove("1"),
             new Throws<>(
-                new MatcherOf<>(
-                    (String msg) -> msg.equals("#remove(Object): the list is read-only")
-                ),
+                "#remove(Object): the list is read-only",
                 UnsupportedOperationException.class
             )
         ).affirm();
@@ -279,9 +274,7 @@ public class ImmutableTest {
                 new ListOf<>(1, 2)
             ).addAll(new ListOf<>(3, 4)),
             new Throws<>(
-                new MatcherOf<>(
-                    (String msg) -> msg.equals("#addAll(Collection): the list is read-only")
-                ),
+                "#addAll(Collection): the list is read-only",
                 UnsupportedOperationException.class
             )
         ).affirm();
@@ -295,9 +288,7 @@ public class ImmutableTest {
                 new ListOf<>(1, 2)
             ).addAll(2, new ListOf<>(3, 4)),
             new Throws<>(
-                new MatcherOf<>(
-                    (String msg) -> msg.equals("#addAll(int, Collection): the list is read-only")
-                ),
+                "#addAll(int, Collection): the list is read-only",
                 UnsupportedOperationException.class
             )
         ).affirm();
@@ -311,9 +302,7 @@ public class ImmutableTest {
                 new ListOf<>(1, 2, 3)
             ).removeAll(new ListOf<>(1, 3)),
             new Throws<>(
-                new MatcherOf<>(
-                    (String msg) -> msg.equals("#removeAll(): the list is read-only")
-                ),
+                "#removeAll(): the list is read-only",
                 UnsupportedOperationException.class
             )
         ).affirm();
@@ -327,9 +316,7 @@ public class ImmutableTest {
                 new ListOf<>(1, 2, 3)
             ).retainAll(new ListOf<>(1, 3)),
             new Throws<>(
-                new MatcherOf<>(
-                    (String msg) -> msg.equals("#retainAll(): the list is read-only")
-                ),
+                "#retainAll(): the list is read-only",
                 UnsupportedOperationException.class
             )
         ).affirm();
@@ -346,9 +333,7 @@ public class ImmutableTest {
                 return new Object();
             },
             new Throws<>(
-                new MatcherOf<>(
-                    (String msg) -> msg.equals("#clear(): the list is read-only")
-                ),
+                "#clear(): the list is read-only",
                 UnsupportedOperationException.class
             )
         ).affirm();
@@ -375,9 +360,7 @@ public class ImmutableTest {
                 new ListOf<>("a", "b")
             ).set(3, "c"),
             new Throws<>(
-                new MatcherOf<>(
-                    (String msg) -> msg.equals("#set(): the list is read-only")
-                ),
+                "#set(): the list is read-only",
                 UnsupportedOperationException.class
             )
         ).affirm();
@@ -394,9 +377,7 @@ public class ImmutableTest {
                 return new Object();
             },
             new Throws<>(
-                new MatcherOf<>(
-                    (String msg) -> msg.equals("#add(int, T): the list is read-only")
-                ),
+                "#add(int, T): the list is read-only",
                 UnsupportedOperationException.class
             )
         ).affirm();
@@ -410,9 +391,7 @@ public class ImmutableTest {
                 new ListOf<>("a", "b")
             ).remove(2),
             new Throws<>(
-                new MatcherOf<>(
-                    (String msg) -> msg.equals("#remove(int): the list is read-only")
-                ),
+                "#remove(int): the list is read-only",
                 UnsupportedOperationException.class
             )
         ).affirm();
@@ -487,9 +466,7 @@ public class ImmutableTest {
                 new ListOf<>("a", "b", "c")
             ).subList(0, 2).add("d"),
             new Throws<>(
-                new MatcherOf<>(
-                    (String msg) -> msg.equals("#add(T): the list is read-only")
-                ),
+                "#add(T): the list is read-only",
                 UnsupportedOperationException.class
             )
         ).affirm();
@@ -576,11 +553,7 @@ public class ImmutableTest {
                 return new Object();
             },
             new Throws<>(
-                new MatcherOf<>(
-                    (String msg) -> msg.equals(
-                        "List Iterator is read-only and doesn't allow rewriting items"
-                    )
-                ),
+                "List Iterator is read-only and doesn't allow rewriting items",
                 UnsupportedOperationException.class
             )
         ).affirm();

--- a/src/test/java/org/cactoos/proc/BiProcOfTest.java
+++ b/src/test/java/org/cactoos/proc/BiProcOfTest.java
@@ -28,7 +28,7 @@ import org.cactoos.func.BiFuncOf;
 import org.cactoos.func.FuncOf;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
-import org.llorllale.cactoos.matchers.MatcherOf;
+import org.llorllale.cactoos.matchers.Verifies;
 
 /**
  * Test case for {@link BiProcOf}.
@@ -50,7 +50,7 @@ final class BiProcOfTest {
                     }
                 )
             ),
-            new MatcherOf<>(
+            new Verifies<>(
                 proc -> {
                     final Object first = new Object();
                     final Object second = new Object();
@@ -74,7 +74,7 @@ final class BiProcOfTest {
                     }
                 )
             ),
-            new MatcherOf<>(
+            new Verifies<>(
                 proc -> {
                     final Object first = new Object();
                     final Object second = new Object();
@@ -97,7 +97,7 @@ final class BiProcOfTest {
                     }
                 )
             ),
-            new MatcherOf<>(
+            new Verifies<>(
                 proc -> {
                     final Object first = new Object();
                     final Object second = new Object();
@@ -120,7 +120,7 @@ final class BiProcOfTest {
                     }
                 )
             ),
-            new MatcherOf<>(
+            new Verifies<>(
                 proc -> {
                     final Object first = new Object();
                     final Object second = new Object();

--- a/src/test/java/org/cactoos/proc/ForEachInThreadsTest.java
+++ b/src/test/java/org/cactoos/proc/ForEachInThreadsTest.java
@@ -27,9 +27,9 @@ import java.util.List;
 import org.cactoos.list.ListOf;
 import org.cactoos.list.Synced;
 import org.hamcrest.collection.IsIterableContainingInAnyOrder;
+import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
-import org.llorllale.cactoos.matchers.MatcherOf;
 
 /**
  * Test case for {@link ForEachInThreads}.
@@ -60,19 +60,8 @@ public class ForEachInThreadsTest {
             list,
             new IsIterableContainingInAnyOrder<>(
                 new ListOf<>(
-                    new MatcherOf<>(
-                        value -> {
-                            return value.equals(
-                                1
-                            );
-                        }
-                    ), new MatcherOf<>(
-                        value -> {
-                            return value.equals(
-                                2
-                            );
-                        }
-                    )
+                    new IsEqual<>(1),
+                    new IsEqual<>(2)
                 )
             )
         ).affirm();

--- a/src/test/java/org/cactoos/proc/ProcOfTest.java
+++ b/src/test/java/org/cactoos/proc/ProcOfTest.java
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.cactoos.func.FuncOf;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
-import org.llorllale.cactoos.matchers.MatcherOf;
+import org.llorllale.cactoos.matchers.Verifies;
 
 /**
  * Test case for {@link ProcOf}.
@@ -48,7 +48,7 @@ final class ProcOfTest {
                     }
                 )
             ),
-            new MatcherOf<>(
+            new Verifies<>(
                 proc -> {
                     final Object input = new Object();
                     proc.exec(input);
@@ -68,7 +68,7 @@ final class ProcOfTest {
                     done.set(input);
                 }
             ),
-            new MatcherOf<>(
+            new Verifies<>(
                 proc -> {
                     final Object input = new Object();
                     proc.exec(input);

--- a/src/test/java/org/cactoos/proc/RunnableOfTest.java
+++ b/src/test/java/org/cactoos/proc/RunnableOfTest.java
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.cactoos.scalar.ScalarOf;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
-import org.llorllale.cactoos.matchers.MatcherOf;
+import org.llorllale.cactoos.matchers.Verifies;
 
 /**
  * Test case for {@link RunnableOf}.
@@ -50,7 +50,7 @@ final class RunnableOfTest {
                 ),
                 obj
             ),
-            new MatcherOf<>(
+            new Verifies<>(
                 runnable -> {
                     runnable.run();
                     return done.get().equals(obj);
@@ -73,7 +73,7 @@ final class RunnableOfTest {
                     }
                 )
             ),
-            new MatcherOf<>(
+            new Verifies<>(
                 runnable -> {
                     runnable.run();
                     return done.get().equals(obj);
@@ -93,7 +93,7 @@ final class RunnableOfTest {
                     done.set(obj);
                 }
             ),
-            new MatcherOf<Runnable>(
+            new Verifies<>(
                 runnable -> {
                     runnable.run();
                     return done.get().equals(obj);

--- a/src/test/java/org/cactoos/scalar/AndInThreadsTest.java
+++ b/src/test/java/org/cactoos/scalar/AndInThreadsTest.java
@@ -33,22 +33,20 @@ import org.cactoos.iterable.Mapped;
 import org.cactoos.list.ListOf;
 import org.cactoos.list.Synced;
 import org.cactoos.proc.ProcNoNulls;
-import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsIterableContainingInAnyOrder;
+import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasValue;
-import org.llorllale.cactoos.matchers.MatcherOf;
 
 /**
  * Test case for {@link AndInThreads}.
  * @since 0.25
- * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-@SuppressWarnings({"PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals"})
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals", "unchecked"})
 final class AndInThreadsTest {
 
     @Test
@@ -117,18 +115,10 @@ final class AndInThreadsTest {
         new Assertion<>(
             "Iterable must contain elements in any order",
             list,
-            new IsIterableContainingInAnyOrder<String>(
-                new ListOf<Matcher<? super String>>(
-                    new MatcherOf<>(
-                        text -> {
-                            return "hello".equals(text);
-                        }
-                    ),
-                    new MatcherOf<>(
-                        text -> {
-                            return "world".equals(text);
-                        }
-                    )
+            new IsIterableContainingInAnyOrder<>(
+                new ListOf<>(
+                    new IsEqual<>("hello"),
+                    new IsEqual<>("world")
                 )
             )
         ).affirm();
@@ -169,18 +159,10 @@ final class AndInThreadsTest {
         ).value();
         MatcherAssert.assertThat(
             list,
-            new IsIterableContainingInAnyOrder<Integer>(
-                new ListOf<Matcher<? super Integer>>(
-                    new MatcherOf<>(
-                        value -> {
-                            return value.equals(1);
-                        }
-                    ),
-                    new MatcherOf<>(
-                        value -> {
-                            return value.equals(2);
-                        }
-                    )
+            new IsIterableContainingInAnyOrder<>(
+                new ListOf<>(
+                    new IsEqual<>(1),
+                    new IsEqual<>(2)
                 )
             )
         );
@@ -197,18 +179,10 @@ final class AndInThreadsTest {
         ).value();
         MatcherAssert.assertThat(
             list,
-            new IsIterableContainingInAnyOrder<Integer>(
-                new ListOf<Matcher<? super Integer>>(
-                    new MatcherOf<>(
-                        value -> {
-                            return value.equals(1);
-                        }
-                    ),
-                    new MatcherOf<>(
-                        value -> {
-                            return value.equals(2);
-                        }
-                    )
+            new IsIterableContainingInAnyOrder<>(
+                new ListOf<>(
+                    new IsEqual<>(1),
+                    new IsEqual<>(2)
                 )
             )
         );

--- a/src/test/java/org/cactoos/scalar/AndWithIndexTest.java
+++ b/src/test/java/org/cactoos/scalar/AndWithIndexTest.java
@@ -28,17 +28,15 @@ import java.util.List;
 import org.cactoos.func.BiFuncOf;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.proc.BiProcOf;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.HasSize;
 import org.llorllale.cactoos.matchers.HasValue;
-import org.llorllale.cactoos.matchers.MatcherOf;
 
 /**
  * Test case for {@link AndWithIndex}.
  *
  * @since 0.8
- * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
@@ -56,14 +54,12 @@ final class AndWithIndexTest {
                 ),
                 "hello", "world"
             ),
-            new HasValue<>(
-                Matchers.allOf(
-                    Matchers.equalTo(true),
-                    new MatcherOf<>(
-                        value -> list.size() == 2
-                    )
-                )
-            )
+            new HasValue<>(true)
+        ).affirm();
+        new Assertion<>(
+            "Must have populated the list",
+            list,
+            new HasSize(2)
         ).affirm();
     }
 
@@ -80,14 +76,12 @@ final class AndWithIndexTest {
                 ),
                 new IterableOf<>("hello", "world")
             ),
-            new HasValue<>(
-                Matchers.allOf(
-                    Matchers.equalTo(true),
-                    new MatcherOf<>(
-                        value -> list.size() == 2
-                    )
-                )
-            )
+            new HasValue<>(true)
+        ).affirm();
+        new Assertion<>(
+            "Must have populated the list",
+            list,
+            new HasSize(2)
         ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/scalar/PropertiesOfTest.java
+++ b/src/test/java/org/cactoos/scalar/PropertiesOfTest.java
@@ -23,22 +23,21 @@
  */
 package org.cactoos.scalar;
 
-import java.util.Properties;
 import org.cactoos.io.InputOf;
 import org.cactoos.map.MapEntry;
 import org.cactoos.map.MapOf;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.HasProperty;
 import org.llorllale.cactoos.matchers.HasValue;
-import org.llorllale.cactoos.matchers.MatcherOf;
 
 /**
  * Test case for {@link PropertiesOf}.
  *
  * @since 0.7
- * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class PropertiesOfTest {
 
     @Test
@@ -49,13 +48,7 @@ final class PropertiesOfTest {
                 "foo=Hello, world!\nbar=works fine?\n"
             ),
             new HasValue<>(
-                new MatcherOf<Properties>(
-                    props -> {
-                        return "Hello, world!".equals(
-                            props.getProperty("foo")
-                        );
-                    }
-                )
+                new HasProperty("foo", "Hello, world!")
             )
         ).affirm();
     }
@@ -68,13 +61,7 @@ final class PropertiesOfTest {
                 new InputOf("greet=Hello, inner world!\nask=works fine?\n")
             ),
             new HasValue<>(
-                new MatcherOf<Properties>(
-                    props -> {
-                        return "Hello, inner world!".equals(
-                            props.getProperty("greet")
-                        );
-                    }
-                )
+                new HasProperty("greet", "Hello, inner world!")
             )
         ).affirm();
     }
@@ -90,11 +77,7 @@ final class PropertiesOfTest {
                 )
             ),
             new HasValue<>(
-                new MatcherOf<Properties>(
-                    props -> {
-                        return props.getProperty("0").endsWith(", world");
-                    }
-                )
+                new HasProperty("0", "hello, world")
             )
         ).affirm();
     }
@@ -108,11 +91,7 @@ final class PropertiesOfTest {
                 new MapEntry<>(1, "How are you?")
             ),
             new HasValue<>(
-                new MatcherOf<Properties>(
-                    props -> {
-                        return props.getProperty("0").endsWith(" world");
-                    }
-                )
+                new HasProperty("0", "hello world")
             )
         ).affirm();
     }

--- a/src/test/java/org/cactoos/scalar/ScalarOfTest.java
+++ b/src/test/java/org/cactoos/scalar/ScalarOfTest.java
@@ -30,7 +30,7 @@ import org.cactoos.proc.RunnableOf;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasValue;
-import org.llorllale.cactoos.matchers.MatcherOf;
+import org.llorllale.cactoos.matchers.Verifies;
 
 /**
  * Test case for {@link ScalarOf}.
@@ -65,7 +65,7 @@ final class ScalarOfTest {
                 ),
                 obj
             ),
-            new MatcherOf<>(
+            new Verifies<>(
                 scalar -> {
                     final Object res = scalar.value();
                     return res.equals(obj) && done.get().equals(result);
@@ -100,7 +100,7 @@ final class ScalarOfTest {
                 ipt,
                 result
             ),
-            new MatcherOf<>(
+            new Verifies<>(
                 scalar -> {
                     final Object res = scalar.value();
                     return res.equals(result) && done.get().equals(ipt);

--- a/src/test/java/org/cactoos/text/TextOfTest.java
+++ b/src/test/java/org/cactoos/text/TextOfTest.java
@@ -604,7 +604,7 @@ final class TextOfTest {
             "Must match another text representing the same value",
             new TextOf("isequaltoanothertext"),
             new IsEqual<>(
-                new Joined("", "is", "equal", "to", "another", "text")
+                new Concatenated("is", "equal", "to", "another", "text")
             )
         ).affirm();
     }

--- a/src/test/java/org/cactoos/text/UncheckedTextTest.java
+++ b/src/test/java/org/cactoos/text/UncheckedTextTest.java
@@ -90,7 +90,7 @@ final class UncheckedTextTest {
                 new TextOf("abcdefghijkl")
             ),
             new IsEqual<>(
-                new Joined("", "ab", "cde", "fghi", "j", "kl")
+                new Concatenated("ab", "cde", "fghi", "j", "kl")
             )
         ).affirm();
     }


### PR DESCRIPTION
Bump cactoos-matchers to latest version, use `Verifies` instead of `MatcherOf` and replace `Joined` by `Concatenated` when possible.