### PR TITLE
(#1411) Actually use latest hamcrest 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,12 +131,12 @@ The MIT License (MIT)
       <artifactId>junit</artifactId>
       <version>4.13</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>1.3</version>
-      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
   <build>

--- a/src/test/java/org/cactoos/bytes/BytesOfTest.java
+++ b/src/test/java/org/cactoos/bytes/BytesOfTest.java
@@ -34,7 +34,6 @@ import org.cactoos.io.InputOf;
 import org.cactoos.io.Sticky;
 import org.cactoos.iterable.Endless;
 import org.cactoos.iterable.HeadOf;
-import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.IterableOfBytes;
 import org.cactoos.iterator.IteratorOfBytes;
 import org.cactoos.text.Concatenated;
@@ -89,10 +88,8 @@ final class BytesOfTest {
                 )
             ),
             new AllOf<>(
-                new IterableOf<>(
-                    new StartsWith("Hello, "),
-                    new EndsWith("друг!")
-                )
+                new StartsWith("Hello, "),
+                new EndsWith("друг!")
             )
         ).affirm();
     }
@@ -130,10 +127,8 @@ final class BytesOfTest {
                 )
             ),
             new AllOf<>(
-                new IterableOf<>(
-                    new StartsWith("Hello,"),
-                    new EndsWith("товарищ!")
-                )
+                new StartsWith("Hello,"),
+                new EndsWith("товарищ!")
             )
         ).affirm();
     }

--- a/src/test/java/org/cactoos/bytes/InputAsBytesTest.java
+++ b/src/test/java/org/cactoos/bytes/InputAsBytesTest.java
@@ -29,7 +29,6 @@ import org.cactoos.io.InputOf;
 import org.cactoos.io.SlowInputStream;
 import org.cactoos.iterable.Endless;
 import org.cactoos.iterable.HeadOf;
-import org.cactoos.iterable.IterableOf;
 import org.cactoos.text.TextOf;
 import org.hamcrest.core.AllOf;
 import org.hamcrest.core.IsEqual;
@@ -98,10 +97,8 @@ final class InputAsBytesTest {
                 StandardCharsets.UTF_8
             ),
             new AllOf<>(
-                new IterableOf<>(
-                    new StartsWith("Hello, "),
-                    new EndsWith("друг!")
-                )
+                new StartsWith("Hello, "),
+                new EndsWith("друг!")
             )
         ).affirm();
     }
@@ -122,10 +119,8 @@ final class InputAsBytesTest {
                 StandardCharsets.UTF_8
             ),
             new AllOf<>(
-                new IterableOf<>(
-                    new StartsWith("Hello,"),
-                    new EndsWith("товарищ!")
-                )
+                new StartsWith("Hello,"),
+                new EndsWith("товарищ!")
             )
         ).affirm();
     }

--- a/src/test/java/org/cactoos/collection/BehavesAsCollection.java
+++ b/src/test/java/org/cactoos/collection/BehavesAsCollection.java
@@ -29,10 +29,10 @@ import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.collection.IsCollectionWithSize;
 import org.hamcrest.collection.IsEmptyCollection;
-import org.hamcrest.core.IsCollectionContaining;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNot;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.HasValues;
 import org.llorllale.cactoos.matchers.Verifies;
 
 /**
@@ -65,11 +65,7 @@ public final class BehavesAsCollection<E> extends
         new Assertion<>(
             "Must contain item",
             col,
-            new IsCollectionContaining<>(
-                new IsEqual<>(
-                    this.sample
-                )
-            )
+            new HasValues<>(this.sample)
         ).affirm();
         new Assertion<>(
             "Must not be empty",
@@ -90,18 +86,14 @@ public final class BehavesAsCollection<E> extends
             new ListOf<>(
                 (E[]) col.toArray()
             ),
-            new IsCollectionContaining<>(
-                new IsEqual<>(this.sample)
-            )
+            new HasValues<>(this.sample)
         ).affirm();
         final E[] array = (E[]) new Object[col.size()];
         col.toArray(array);
         new Assertion<>(
             "Array from collection must contain item",
             new ListOf<>(array),
-            new IsCollectionContaining<>(
-                new IsEqual<>(this.sample)
-            )
+            new HasValues<>(this.sample)
         ).affirm();
         new Assertion<>(
             "Must contain list with the item",

--- a/src/test/java/org/cactoos/io/InputOfTest.java
+++ b/src/test/java/org/cactoos/io/InputOfTest.java
@@ -40,7 +40,6 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 import org.cactoos.bytes.BytesOf;
-import org.cactoos.iterable.IterableOf;
 import org.cactoos.text.TextOf;
 import org.hamcrest.core.AllOf;
 import org.hamcrest.core.IsEqual;
@@ -180,10 +179,8 @@ final class InputOfTest {
                 StandardCharsets.UTF_8
             ),
             new AllOf<>(
-                new IterableOf<>(
-                    new StartsWith("Hello, "),
-                    new EndsWith("друг!")
-                )
+                new StartsWith("Hello, "),
+                new EndsWith("друг!")
             )
         ).affirm();
     }
@@ -203,10 +200,8 @@ final class InputOfTest {
                 )
             ),
             new AllOf<>(
-                new IterableOf<>(
-                    new StartsWith(starts),
-                    new EndsWith(ends)
-                )
+                new StartsWith(starts),
+                new EndsWith(ends)
             )
         ).affirm();
     }
@@ -226,10 +221,8 @@ final class InputOfTest {
                 )
             ),
             new AllOf<>(
-                new IterableOf<>(
-                    new StartsWith(starts),
-                    new EndsWith(ends)
-                )
+                new StartsWith(starts),
+                new EndsWith(ends)
             )
         ).affirm();
     }
@@ -247,10 +240,8 @@ final class InputOfTest {
                 )
             ),
             new AllOf<>(
-                new IterableOf<>(
-                    new StartsWith("Hold "),
-                    new EndsWith("infinity")
-                )
+                new StartsWith("Hold "),
+                new EndsWith("infinity")
             )
         ).affirm();
     }
@@ -272,10 +263,8 @@ final class InputOfTest {
                 StandardCharsets.UTF_8
             ),
             new AllOf<>(
-                new IterableOf<>(
-                    new StartsWith("O que sera"),
-                    new EndsWith(" que sera")
-                )
+                new StartsWith("O que sera"),
+                new EndsWith(" que sera")
             )
         ).affirm();
     }

--- a/src/test/java/org/cactoos/map/BehavesAsMap.java
+++ b/src/test/java/org/cactoos/map/BehavesAsMap.java
@@ -25,11 +25,10 @@ package org.cactoos.map;
 
 import java.util.Map;
 import org.hamcrest.Description;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.TypeSafeMatcher;
-import org.hamcrest.collection.IsMapContaining;
-import org.hamcrest.core.IsCollectionContaining;
-import org.hamcrest.core.IsEqual;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.HasEntry;
+import org.llorllale.cactoos.matchers.HasValues;
 
 /**
  * Matcher for collection.
@@ -62,25 +61,23 @@ public final class BehavesAsMap<K, V> extends TypeSafeMatcher<Map<K, V>>  {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public boolean matchesSafely(final Map<K, V> map) {
-        MatcherAssert.assertThat(
-            "Doesn't contain the key",
+        new Assertion<>(
+            "Must contain the key/value entry",
             map,
-            new IsMapContaining<>(
-                new IsEqual<>(this.key),
-                new IsEqual<>(this.value)
-            )
-        );
-        MatcherAssert.assertThat(
-            "Doesn't contain the key in #keySet()",
+            new HasEntry<>(this.key, this.value)
+        ).affirm();
+        new Assertion<>(
+            "Must contain the key in #keySet()",
             map.keySet(),
-            new IsCollectionContaining<>(new IsEqual<>(this.key))
-        );
-        MatcherAssert.assertThat(
-            "Doesn't contain the value in #values()",
+            new HasValues<>(this.key)
+        ).affirm();
+        new Assertion<>(
+            "Must contain the value in #values()",
             map.values(),
-            new IsCollectionContaining<>(new IsEqual<>(this.value))
-        );
+            new HasValues<>(this.value)
+        ).affirm();
         return true;
     }
 

--- a/src/test/java/org/cactoos/map/MapOfTest.java
+++ b/src/test/java/org/cactoos/map/MapOfTest.java
@@ -29,7 +29,6 @@ import org.cactoos.Scalar;
 import org.cactoos.func.FuncOf;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.scalar.Constant;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.collection.IsMapContaining;
 import org.hamcrest.core.AllOf;
 import org.hamcrest.core.IsAnything;
@@ -37,6 +36,7 @@ import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.StringStartsWith;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.HasEntry;
 
 /**
  * Test case for {@link MapOf}.
@@ -49,8 +49,8 @@ final class MapOfTest {
 
     @Test
     void behavesAsMap() {
-        MatcherAssert.assertThat(
-            "Can't behave as a map",
+        new Assertion<>(
+            "Must behave as a map",
             new NoNulls<>(
                 new MapOf<Integer, Integer>(
                     new MapEntry<>(0, -1),
@@ -58,13 +58,13 @@ final class MapOfTest {
                 )
             ),
             new BehavesAsMap<>(1, 1)
-        );
+        ).affirm();
     }
 
     @Test
     void convertsIterableToMap() {
-        MatcherAssert.assertThat(
-            "Can't convert iterable to map",
+        new Assertion<>(
+            "Must convert iterable to map",
             new MapOf<Integer, String>(
                 new MapEntry<>(0, "hello, "),
                 new MapEntry<>(1, "world!")
@@ -73,13 +73,13 @@ final class MapOfTest {
                 new IsEqual<>(0),
                 new StringStartsWith("hello")
             )
-        );
+        ).affirm();
     }
 
     @Test
     void createsMapWithFunctions() {
-        MatcherAssert.assertThat(
-            "Can't create a map with functions as values",
+        new Assertion<>(
+            "Must create a map with functions as values",
             new MapOf<Integer, Scalar<Boolean>>(
                 new MapEntry<>(0, () -> true),
                 new MapEntry<>(
@@ -90,25 +90,25 @@ final class MapOfTest {
                 )
             ),
             new IsMapContaining<>(new IsEqual<>(0), new IsAnything<>())
-        );
+        ).affirm();
     }
 
     @Test
     void integersToString() {
-        MatcherAssert.assertThat(
-            "Can't convert map of integers to string",
+        new Assertion<>(
+            "Must convert map of integers to string",
             new MapOf<Integer, Integer>(
                 new MapEntry<>(-1, 0),
                 new MapEntry<>(1, 2)
             ).toString(),
             new IsEqual<>("{-1=0, 1=2}")
-        );
+        ).affirm();
     }
 
     @Test
     void mapsToString() {
-        MatcherAssert.assertThat(
-            "Can't convert map op maps to string",
+        new Assertion<>(
+            "Must convert map op maps to string",
             new MapOf<Integer, Map<String, String>>(
                 new MapEntry<Integer, Map<String, String>>(
                     -1,
@@ -126,36 +126,34 @@ final class MapOfTest {
                 )
             ).toString(),
             new IsEqual<>("{-1={4=7, first=second}, 1={green=red, 2.7=3.1}}")
-        );
+        ).affirm();
     }
 
     @Test
     void emptyToString() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't convert empty map to string",
             new MapOf<Integer, Map<String, String>>().toString(),
             new IsEqual<>("{}")
-        );
+        ).affirm();
     }
 
     @Test
     @SuppressWarnings("unchecked")
     void createsMapFromMapAndMapEntries() {
-        MatcherAssert.assertThat(
-            "Can't create a map from map and map entries",
-            new MapOf<Integer, Integer>(
-                new MapOf<Integer, Integer>(
+        new Assertion<MapOf<Integer, Integer>>(
+            "Must create a map from map and map entries",
+            new MapOf<>(
+                new MapOf<>(
                     new MapEntry<Integer, Integer>(0, 0)
                 ),
                 new MapEntry<Integer, Integer>(1, 1)
             ),
             new AllOf<>(
-                new IterableOf<>(
-                    new IsMapContaining<>(new IsEqual<>(0), new IsEqual<>(0)),
-                    new IsMapContaining<>(new IsEqual<>(1), new IsEqual<>(1))
-                )
+                new HasEntry<>(0,  0),
+                new HasEntry<>(1,  1)
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -167,15 +165,15 @@ final class MapOfTest {
                 new FuncOf<Integer, Integer>(new Constant<>(0)),
                 new IterableOf<Integer>(0)
             ),
-            new IsMapContaining<>(new IsEqual<>(0), new IsEqual<>(0))
+            new HasEntry<>(0, 0)
         ).affirm();
     }
 
     @Test
     @SuppressWarnings("unchecked")
     void createsMapFromMapFunctionsAndIterable() {
-        new Assertion<>(
-            "Can't create a map from map, functions and iterable.",
+        new Assertion<MapOf<Integer, Integer>>(
+            "Must create a map from map, functions and iterable.",
             new MapOf<Integer, Integer>(
                 new FuncOf<Integer, Integer>(new Constant<>(0)),
                 new FuncOf<Integer, Integer>(new Constant<>(0)),
@@ -185,10 +183,8 @@ final class MapOfTest {
                 new IterableOf<>(0)
             ),
             new AllOf<>(
-                new IterableOf<>(
-                    new IsMapContaining<>(new IsEqual<>(0), new IsEqual<>(0)),
-                    new IsMapContaining<>(new IsEqual<>(1), new IsEqual<>(1))
-                )
+                new HasEntry<>(0,  0),
+                new HasEntry<>(1,  1)
             )
         ).affirm();
     }

--- a/src/test/java/org/cactoos/map/NoNullsTest.java
+++ b/src/test/java/org/cactoos/map/NoNullsTest.java
@@ -24,14 +24,16 @@
 package org.cactoos.map;
 
 import java.util.HashMap;
-import org.cactoos.iterable.IterableOf;
+import java.util.Map;
+import java.util.Set;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.collection.IsMapContaining;
 import org.hamcrest.core.AllOf;
 import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsIterableContaining;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.IsEntry;
 import org.llorllale.cactoos.matchers.Throws;
 
 /**
@@ -347,8 +349,8 @@ public final class NoNullsTest {
     @Test
     @SuppressWarnings("unchecked")
     public void entrySet() {
-        MatcherAssert.assertThat(
-            "Can't call #entrySet()",
+        new Assertion<Set<Map.Entry<Integer, Integer>>>(
+            "Must call #entrySet()",
             new NoNulls<Integer, Integer>(
                 new HashMap<Integer, Integer>() {
                     {
@@ -356,14 +358,12 @@ public final class NoNullsTest {
                         put(0, 0);
                     }
                 }
-            ),
+            ).entrySet(),
             new AllOf<>(
-                new IterableOf<>(
-                    new IsMapContaining<>(new IsEqual<>(1), new IsEqual<>(1)),
-                    new IsMapContaining<>(new IsEqual<>(0), new IsEqual<>(0))
-                )
+                new IsIterableContaining<>(new IsEntry<>(1, 1)),
+                new IsIterableContaining<>(new IsEntry<>(0, 0))
             )
-        );
+        ).affirm();
     }
 
     @Test

--- a/src/test/java/org/cactoos/map/RemoveDeletesValues.java
+++ b/src/test/java/org/cactoos/map/RemoveDeletesValues.java
@@ -25,12 +25,12 @@ package org.cactoos.map;
 
 import java.util.Map;
 import org.hamcrest.Description;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.collection.IsMapContaining;
-import org.hamcrest.core.IsCollectionContaining;
 import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsIterableContaining;
 import org.hamcrest.core.IsNot;
+import org.llorllale.cactoos.matchers.Assertion;
 
 /**
  * Check a remove method.
@@ -66,8 +66,8 @@ public final class RemoveDeletesValues<K, V> extends
     @Override
     public boolean matchesSafely(final Map<K, V> map) {
         map.remove(this.key);
-        MatcherAssert.assertThat(
-            "Contains the key/value after remove",
+        new Assertion<>(
+            "Must not the key/value after remove",
             map,
             new IsNot<>(
                 new IsMapContaining<>(
@@ -75,21 +75,21 @@ public final class RemoveDeletesValues<K, V> extends
                     new IsEqual<>(this.value)
                 )
             )
-        );
-        MatcherAssert.assertThat(
-            "Contains the key in #keySet() after remove",
+        ).affirm();
+        new Assertion<>(
+            "Must not the key in #keySet() after remove",
             map.keySet(),
             new IsNot<>(
-                new IsCollectionContaining<>(new IsEqual<>(this.key))
+                new IsIterableContaining<>(new IsEqual<>(this.key))
             )
-        );
-        MatcherAssert.assertThat(
-            "Contains the value in #values() after remove",
+        ).affirm();
+        new Assertion<>(
+            "Must not the value in #values() after remove",
             map.values(),
             new IsNot<>(
-                new IsCollectionContaining<>(new IsEqual<>(this.value))
+                new IsIterableContaining<>(new IsEqual<>(this.value))
             )
-        );
+        ).affirm();
         return true;
     }
 

--- a/src/test/java/org/cactoos/scalar/TernaryTest.java
+++ b/src/test/java/org/cactoos/scalar/TernaryTest.java
@@ -24,13 +24,14 @@
 package org.cactoos.scalar;
 
 import java.util.concurrent.atomic.AtomicInteger;
-import org.cactoos.iterable.IterableOf;
+import org.cactoos.Scalar;
+import org.cactoos.Text;
 import org.cactoos.text.FormattedText;
-import org.cactoos.text.TextOf;
 import org.hamcrest.core.AllOf;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasValue;
+import org.llorllale.cactoos.matchers.IsText;
 
 /**
  * Test case for {@link Ternary}.
@@ -124,7 +125,7 @@ final class TernaryTest {
     @Test
     @SuppressWarnings("unchecked")
     void inputScalarValueConserved() throws Exception {
-        new Assertion<>(
+        new Assertion<Scalar<Text>>(
             "Must conserve the same scalar value for each whole evaluation",
             new Ternary<>(
                 new ScalarOf<>(new AtomicInteger(0)::incrementAndGet),
@@ -133,11 +134,9 @@ final class TernaryTest {
                 i -> new FormattedText("else: %d", i)
             ),
             new AllOf<>(
-                new IterableOf<>(
-                    new HasValue<>(new TextOf("1 equals 1")),
-                    new HasValue<>(new TextOf("else: 2")),
-                    new HasValue<>(new TextOf("else: 3"))
-                )
+                new HasValue<>(new IsText("1 equals 1")),
+                new HasValue<>(new IsText("else: 2")),
+                new HasValue<>(new IsText("else: 3"))
             )
         ).affirm();
     }

--- a/src/test/java/org/cactoos/set/SetOfTest.java
+++ b/src/test/java/org/cactoos/set/SetOfTest.java
@@ -23,77 +23,68 @@
  */
 package org.cactoos.set;
 
+import org.cactoos.Text;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.Joined;
 import org.cactoos.text.TextOf;
-import org.hamcrest.Matcher;
 import org.hamcrest.core.AllOf;
-import org.hamcrest.core.IsCollectionContaining;
-import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasSize;
+import org.llorllale.cactoos.matchers.HasValues;
 
 /**
  * Test case for {@link SetOf}.
  * @since 0.49.2
  * @checkstyle MagicNumber (500 line)
- * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class SetOfTest {
 
     @Test
+    @SuppressWarnings("unchecked")
     void behaveAsSetWithOriginalDuplicationsInTheTail() {
-        new Assertion<>(
+        new Assertion<SetOf<Integer>>(
             "Must keep unique integer numbers",
             new SetOf<>(1, 2, 2),
             new AllOf<>(
-                new IterableOf<Matcher<? super SetOf<Integer>>>(
-                    new HasSize(2),
-                    new IsCollectionContaining<>(new IsEqual<>(1)),
-                    new IsCollectionContaining<>(new IsEqual<>(2))
-                )
+                new HasSize(2),
+                new HasValues<>(1, 2)
             )
         ).affirm();
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void behaveAsSetWithOriginalDuplicationsInTheHead() {
-        new Assertion<>(
+        new Assertion<SetOf<Integer>>(
             "Must keep unique integer numbers",
             new SetOf<>(1, 1, 2, 3),
             new AllOf<>(
-                new IterableOf<Matcher<? super SetOf<Integer>>>(
-                    new HasSize(3),
-                    new IsCollectionContaining<>(new IsEqual<>(1)),
-                    new IsCollectionContaining<>(new IsEqual<>(2)),
-                    new IsCollectionContaining<>(new IsEqual<>(3))
-                )
+                new HasSize(3),
+                new HasValues<>(1, 2, 3)
             )
         ).affirm();
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void behaveAsSetWithOriginalDuplicationsInTheMiddle() {
-        new Assertion<>(
+        new Assertion<SetOf<Integer>>(
             "Must keep unique integer numbers",
             new SetOf<>(1, 2, 2, 3),
             new AllOf<>(
-                new IterableOf<Matcher<? super SetOf<Integer>>>(
-                    new HasSize(3),
-                    new IsCollectionContaining<>(new IsEqual<>(1)),
-                    new IsCollectionContaining<>(new IsEqual<>(2)),
-                    new IsCollectionContaining<>(new IsEqual<>(3))
-                )
+                new HasSize(3),
+                new HasValues<>(1, 2, 3)
             )
         ).affirm();
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void behaveAsSetMergedCollectionsOfLiteralsWithDuplicates() {
-        new Assertion<>(
+        new Assertion<SetOf<String>>(
             "Must keep unique string literals",
             new SetOf<String>(
                 new Joined<String>(
@@ -102,53 +93,42 @@ final class SetOfTest {
                 )
             ),
             new AllOf<>(
-                new IterableOf<Matcher<? super SetOf<String>>>(
-                    new HasSize(5),
-                    new IsCollectionContaining<>(new IsEqual<>("aa")),
-                    new IsCollectionContaining<>(new IsEqual<>("bb")),
-                    new IsCollectionContaining<>(new IsEqual<>("cc")),
-                    new IsCollectionContaining<>(new IsEqual<>("dd")),
-                    new IsCollectionContaining<>(new IsEqual<>("ff"))
-                )
+                new HasSize(5),
+                new HasValues<>("aa", "bb", "cc", "dd", "ff")
             )
         ).affirm();
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void behaveAsSetWithOriginalDuplicationsOfCharsInTheMiddle() {
-        new Assertion<>(
+        new Assertion<SetOf<Character>>(
             "Must keep unique characters",
             new SetOf<>('a', 'b', 'b', 'c', 'a', 'b', 'd'),
             new AllOf<>(
-                new IterableOf<Matcher<? super SetOf<Character>>>(
-                    new HasSize(4),
-                    new IsCollectionContaining<>(new IsEqual<>('a')),
-                    new IsCollectionContaining<>(new IsEqual<>('b')),
-                    new IsCollectionContaining<>(new IsEqual<>('c')),
-                    new IsCollectionContaining<>(new IsEqual<>('d'))
-                )
+                new HasSize(4),
+                new HasValues<>('a', 'b', 'c', 'd')
             )
         ).affirm();
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void behaveAsSetWithOriginalDuplicationsOfDoublesInTheMiddle() {
-        new Assertion<>(
+        new Assertion<SetOf<Double>>(
             "Must keep unique double numbers",
             new SetOf<>(1.5d, 2.4d, 1.5d, 2.4d, 2.4d, 1.5d),
             new AllOf<>(
-                new IterableOf<Matcher<? super SetOf<Double>>>(
-                    new HasSize(2),
-                    new IsCollectionContaining<>(new IsEqual<>(1.5d)),
-                    new IsCollectionContaining<>(new IsEqual<>(2.4d))
-                )
+                new HasSize(2),
+                new HasValues<>(1.5d, 2.4d)
             )
         ).affirm();
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void behaveAsSetWithOriginalDuplicationsOfTextsInTheMiddle() {
-        new Assertion<>(
+        new Assertion<SetOf<Text>>(
             "Must keep unique TextOf objects",
             new SetOf<>(
                 new TextOf("12345"),
@@ -157,17 +137,11 @@ final class SetOfTest {
                 new TextOf("00000")
             ),
             new AllOf<>(
-                new IterableOf<Matcher<? super SetOf<TextOf>>>(
-                    new HasSize(3),
-                    new IsCollectionContaining<>(
-                        new IsEqual<>(new TextOf("12345"))
-                    ),
-                    new IsCollectionContaining<>(
-                        new IsEqual<>(new TextOf("67890"))
-                    ),
-                    new IsCollectionContaining<>(
-                        new IsEqual<>(new TextOf("00000"))
-                    )
+                new HasSize(3),
+                new HasValues<>(
+                    new TextOf("12345"),
+                    new TextOf("67890"),
+                    new TextOf("00000")
                 )
             )
         ).affirm();

--- a/src/test/java/org/cactoos/text/AbbreviatedTest.java
+++ b/src/test/java/org/cactoos/text/AbbreviatedTest.java
@@ -25,7 +25,6 @@ package org.cactoos.text;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import org.cactoos.Text;
-import org.cactoos.iterable.IterableOf;
 import org.hamcrest.core.AllOf;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
@@ -146,13 +145,11 @@ final class AbbreviatedTest {
                 15
             ),
             new AllOf<>(
-                new IterableOf<>(
-                    new IsText(
-                        "The quick br..."
-                    ),
-                    new IsText(
-                        "The lazy bla..."
-                    )
+                new IsText(
+                    "The quick br..."
+                ),
+                new IsText(
+                    "The lazy bla..."
                 )
             )
         ).affirm();


### PR DESCRIPTION
This was missing from #1411 to actually use hamcrest 2.2 instead of the old one from junit dependencies