### PR TITLE
(#1453) Migrate test to JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@ The MIT License (MIT)
       </exclusions>
     </dependency>
     <!--
-     @todo #1416:30min Migrate the rest of tests to JUnit 5 Junit 4 Rule
+     @todo #1453:30min Continue migration of tests to JUnit 5. Junit 4 Rule
       should be replaced with a Jupiter counterpart. `@Text(expected=..)`
       with `Throws`. After that remove this dependencies.
     -->

--- a/src/test/java/org/cactoos/BytesTest.java
+++ b/src/test/java/org/cactoos/BytesTest.java
@@ -24,7 +24,9 @@
 package org.cactoos;
 
 import org.cactoos.bytes.NoNulls;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link NoNulls}.
@@ -33,14 +35,20 @@ import org.junit.Test;
  */
 public final class BytesTest {
 
-    @Test(expected = IllegalArgumentException.class)
     public void failForNullArgument() throws Exception {
-        new NoNulls(null).asBytes();
+        new Assertion<>(
+            "Must fail for null argument.",
+            () -> new NoNulls(null).asBytes(),
+            new Throws<>(IllegalArgumentException.class)
+        ).affirm();
     }
 
-    @Test(expected = IllegalStateException.class)
     public void failForNullResult() throws Exception {
-        new NoNulls(() -> null).asBytes();
+        new Assertion<>(
+            "Must fail for null result.",
+            () -> new NoNulls(() -> null).asBytes(),
+            new Throws<>(IllegalStateException.class)
+        ).affirm();
     }
 
     @Test

--- a/src/test/java/org/cactoos/bytes/HexOfTest.java
+++ b/src/test/java/org/cactoos/bytes/HexOfTest.java
@@ -68,19 +68,27 @@ public final class HexOfTest {
         ).affirm();
     }
 
+    @Test
     public void invalidHexLength() throws Exception {
         new Assertion<>(
             "Must invalid hex length",
             () -> new HexOf(new TextOf("ABF")).asBytes(),
-            new Throws<>(IOException.class)
+            new Throws<>(
+                "Length of hexadecimal text is odd",
+                IOException.class
+            )
         ).affirm();
     }
 
+    @Test
     public void invalidHex() throws Exception {
         new Assertion<>(
             "Must invalid hex",
             () -> new HexOf(new TextOf("ABG!")).asBytes(),
-            new Throws<>(IOException.class)
+            new Throws<>(
+                "Unexpected character 'G'",
+                IOException.class
+            )
         ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/bytes/HexOfTest.java
+++ b/src/test/java/org/cactoos/bytes/HexOfTest.java
@@ -27,8 +27,9 @@ package org.cactoos.bytes;
 import java.io.IOException;
 import org.cactoos.text.TextOf;
 import org.hamcrest.core.IsEqual;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 import org.llorllale.cactoos.matchers.Verifies;
 
 /**
@@ -37,6 +38,7 @@ import org.llorllale.cactoos.matchers.Verifies;
  * @since 0.29
  * @checkstyle MagicNumberCheck (500 line)
  * @checkstyle JavadocMethodCheck (500 line)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class HexOfTest {
 
@@ -66,13 +68,19 @@ public final class HexOfTest {
         ).affirm();
     }
 
-    @Test(expected = IOException.class)
     public void invalidHexLength() throws Exception {
-        new HexOf(new TextOf("ABF")).asBytes();
+        new Assertion<>(
+            "Must invalid hex length",
+            () -> new HexOf(new TextOf("ABF")).asBytes(),
+            new Throws<>(IOException.class)
+        ).affirm();
     }
 
-    @Test(expected = IOException.class)
     public void invalidHex() throws Exception {
-        new HexOf(new TextOf("ABG!")).asBytes();
+        new Assertion<>(
+            "Must invalid hex",
+            () -> new HexOf(new TextOf("ABG!")).asBytes(),
+            new Throws<>(IOException.class)
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/bytes/ReaderAsBytesTest.java
+++ b/src/test/java/org/cactoos/bytes/ReaderAsBytesTest.java
@@ -26,7 +26,7 @@ package org.cactoos.bytes;
 import java.io.StringReader;
 import org.cactoos.text.TextOf;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.IsText;

--- a/src/test/java/org/cactoos/bytes/UncheckedBytesTest.java
+++ b/src/test/java/org/cactoos/bytes/UncheckedBytesTest.java
@@ -27,8 +27,9 @@ import java.io.IOException;
 import org.cactoos.Text;
 import org.cactoos.text.TextOf;
 import org.hamcrest.core.IsEqual;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link UncheckedBytes}.
@@ -38,13 +39,17 @@ import org.llorllale.cactoos.matchers.Assertion;
  */
 public final class UncheckedBytesTest {
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void rethrowsCheckedToUncheckedException() {
-        new UncheckedBytes(
-            () -> {
-                throw new IOException("intended");
-            }
-        ).asBytes();
+        new Assertion<>(
+            "Must rethrow checked to unchecked exception",
+            () -> new UncheckedBytes(
+                () -> {
+                    throw new IOException("intended");
+                }
+            ).asBytes(),
+            new Throws<>(RuntimeException.class)
+        ).affirm();
     }
 
     @Test


### PR DESCRIPTION
For #1453. Migrate tests to JUnit 5 for test packages :

- `org.cactoos`
- `org.cactoos.bytes`
- `org.cactoos.collection`
- `org.cactoos.experimental`