### PR TITLE
(#1434) Replace calls to Matchers with their OO counterparts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@ The MIT License (MIT)
                 <signaturesFile>./src/test/resources/forbidden-apis.txt</signaturesFile>
               </signaturesFiles>
               <!--
-               @todo #1223:30min In the continuation of #588, all the calls
+               @todo #1434:30min In the continuation of #588, all the calls
                 to Matchers should be replaced with their OO counterparts.
                 This todo should be updated with a new one until everything is
                 done. The newly covered classes should be added to the include
@@ -270,6 +270,7 @@ The MIT License (MIT)
                 <include>org/cactoos/collection/*.class</include>
                 <include>org/cactoos/experimental/*.class</include>
                 <include>org/cactoos/func/*.class</include>
+                <include>org/cactoos/io/*.class</include>
               </includes>
             </configuration>
             <executions>

--- a/src/test/java/org/cactoos/io/DeadOutputTest.java
+++ b/src/test/java/org/cactoos/io/DeadOutputTest.java
@@ -23,7 +23,7 @@
  */
 package org.cactoos.io;
 
-import org.hamcrest.Matchers;
+import org.hamcrest.core.StringEndsWith;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasContent;
@@ -45,7 +45,7 @@ final class DeadOutputTest {
                 new InputOf("How are you, мой друг?"),
                 new DeadOutput()
             ),
-            new HasContent(Matchers.endsWith("друг?"))
+            new HasContent(new StringEndsWith("друг?"))
         ).affirm();
     }
 

--- a/src/test/java/org/cactoos/io/InputStreamOfTest.java
+++ b/src/test/java/org/cactoos/io/InputStreamOfTest.java
@@ -32,13 +32,13 @@ import java.nio.file.Path;
 import org.cactoos.bytes.BytesOf;
 import org.cactoos.scalar.LengthOf;
 import org.cactoos.text.TextOf;
-import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasContent;
+import org.llorllale.cactoos.matchers.Verifies;
 
 /**
  * Test case for {@link InputStreamOf}.
@@ -94,7 +94,7 @@ public final class InputStreamOfTest {
         new Assertion<>(
             "Must show that data is available",
             new InputStreamOf(content).available(),
-            Matchers.greaterThan(0)
+            new Verifies<>(x -> x > 0)
         ).affirm();
     }
 

--- a/src/test/java/org/cactoos/io/LSInputOfTest.java
+++ b/src/test/java/org/cactoos/io/LSInputOfTest.java
@@ -23,7 +23,8 @@
  */
 package org.cactoos.io;
 
-import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.StringContains;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 
@@ -43,7 +44,7 @@ final class LSInputOfTest {
             new LSInputOf(
                 new InputOf("hello, world!")
             ).getStringData(),
-            Matchers.endsWith("world!")
+            new StringContains("world!")
         ).affirm();
     }
 
@@ -57,7 +58,7 @@ final class LSInputOfTest {
                     new SlowInputStream(size)
                 )
             ).getStringData().length(),
-            Matchers.equalTo(size)
+            new IsEqual<>(size)
         ).affirm();
     }
 
@@ -71,7 +72,7 @@ final class LSInputOfTest {
                     new SlowInputStream(size)
                 )
             ).getStringData().length(),
-            Matchers.equalTo(size)
+            new IsEqual<>(size)
         ).affirm();
     }
 

--- a/src/test/java/org/cactoos/io/LoggingInputTest.java
+++ b/src/test/java/org/cactoos/io/LoggingInputTest.java
@@ -61,7 +61,7 @@ final class LoggingInputTest {
             )
         ).value();
         new Assertion<>(
-            "Can't log zero byte read from dead input",
+            "Must log zero byte read from dead input",
             new TextOf(logger.toString()),
             new HasString("Read 0 byte(s) from dead input in")
         ).affirm();
@@ -78,7 +78,7 @@ final class LoggingInputTest {
             )
         ).value();
         new Assertion<>(
-            "Can't log one byte read from memory",
+            "Must log one byte read from memory",
             new TextOf(logger.toString()),
             new HasString("Read 1 byte(s) from memory in")
         ).affirm();
@@ -95,7 +95,7 @@ final class LoggingInputTest {
             )
         ).value();
         new Assertion<>(
-            "Can't log 22 bytes read from memory",
+            "Must log 22 bytes read from memory",
             new TextOf(logger.toString()),
             new HasString("Read 22 byte(s) from memory in")
         ).affirm();
@@ -113,7 +113,7 @@ final class LoggingInputTest {
             )
         ).value();
         new Assertion<>(
-            "Can't log 74536 bytes read from text file",
+            "Must log 74536 bytes read from text file",
             new TextOf(logger.toString()),
             new AllOf<>(
                 new IsNot<Text>(
@@ -137,7 +137,7 @@ final class LoggingInputTest {
             )
         ).value();
         new Assertion<>(
-            "Can't log all read and close operations from text file",
+            "Must log all read and close operations from text file",
             new TextOf(logger.toString()),
             new AllOf<>(
                 new HasString("Read 16384 byte(s) from text file"),
@@ -160,7 +160,7 @@ final class LoggingInputTest {
         // @checkstyle MagicNumber (1 line)
         ).stream().skip(100);
         new Assertion<>(
-            "Can't log skip from text file",
+            "Must log skip from text file",
             new TextOf(logger.toString()),
             new HasString("Skipped 100 byte(s) from text file.")
         ).affirm();
@@ -175,7 +175,7 @@ final class LoggingInputTest {
             logger
         ).stream().available();
         new Assertion<>(
-            "Can't log avaliable byte(s) from text file",
+            "Must log avaliable byte(s) from text file",
             new TextOf(logger.toString()),
             new HasString(
                 "There is(are) 74536 byte(s) available from text file"
@@ -196,7 +196,7 @@ final class LoggingInputTest {
         input.mark(150);
         input.reset();
         new Assertion<>(
-            "Can't log mark and reset from text file",
+            "Must log mark and reset from text file",
             new TextOf(logger.toString()),
             new AllOf<>(
                 new HasString("Marked position 150 from text file"),
@@ -214,7 +214,7 @@ final class LoggingInputTest {
             logger
         ).stream().markSupported();
         new Assertion<>(
-            "Can't log mark and reset are not supported from text file",
+            "Must log mark and reset are not supported from text file",
             new TextOf(logger.toString()),
             new HasString(
                 "Mark and reset are supported from text file"

--- a/src/test/java/org/cactoos/io/LoggingInputTest.java
+++ b/src/test/java/org/cactoos/io/LoggingInputTest.java
@@ -26,10 +26,14 @@ package org.cactoos.io;
 import java.io.InputStream;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.cactoos.Text;
 import org.cactoos.scalar.LengthOf;
-import org.hamcrest.Matchers;
+import org.cactoos.text.TextOf;
+import org.hamcrest.core.AllOf;
+import org.hamcrest.core.IsNot;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.HasString;
 
 /**
  * Test case for {@link LoggingInput}.
@@ -58,8 +62,8 @@ final class LoggingInputTest {
         ).value();
         new Assertion<>(
             "Can't log zero byte read from dead input",
-            logger.toString(),
-            Matchers.containsString("Read 0 byte(s) from dead input in")
+            new TextOf(logger.toString()),
+            new HasString("Read 0 byte(s) from dead input in")
         ).affirm();
     }
 
@@ -75,8 +79,8 @@ final class LoggingInputTest {
         ).value();
         new Assertion<>(
             "Can't log one byte read from memory",
-            logger.toString(),
-            Matchers.containsString("Read 1 byte(s) from memory in")
+            new TextOf(logger.toString()),
+            new HasString("Read 1 byte(s) from memory in")
         ).affirm();
     }
 
@@ -92,12 +96,13 @@ final class LoggingInputTest {
         ).value();
         new Assertion<>(
             "Can't log 22 bytes read from memory",
-            logger.toString(),
-            Matchers.containsString("Read 22 byte(s) from memory in")
+            new TextOf(logger.toString()),
+            new HasString("Read 22 byte(s) from memory in")
         ).affirm();
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void logReadFromLargeTextFile() throws Exception {
         final Logger logger = new FakeLogger();
         new LengthOf(
@@ -109,18 +114,19 @@ final class LoggingInputTest {
         ).value();
         new Assertion<>(
             "Can't log 74536 bytes read from text file",
-            logger.toString(),
-            Matchers.allOf(
-                Matchers.not(
-                    Matchers.containsString("Read 16384 byte(s) from text file")
+            new TextOf(logger.toString()),
+            new AllOf<>(
+                new IsNot<Text>(
+                    new HasString("Read 16384 byte(s) from text file")
                 ),
-                Matchers.containsString("Read 74536 byte(s) from text file in"),
-                Matchers.containsString("Closed input stream from text file")
+                new HasString("Read 74536 byte(s) from text file in"),
+                new HasString("Closed input stream from text file")
             )
         ).affirm();
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void logAllFromLargeTextFile() throws Exception {
         final Logger logger = new FakeLogger(Level.WARNING);
         new LengthOf(
@@ -132,14 +138,14 @@ final class LoggingInputTest {
         ).value();
         new Assertion<>(
             "Can't log all read and close operations from text file",
-            logger.toString(),
-            Matchers.allOf(
-                Matchers.containsString("Read 16384 byte(s) from text file"),
-                Matchers.containsString("Read 32768 byte(s) from text file"),
-                Matchers.containsString("Read 49152 byte(s) from text file"),
-                Matchers.containsString("Read 65536 byte(s) from text file"),
-                Matchers.containsString("Read 74536 byte(s) from text file"),
-                Matchers.containsString("Closed input stream from text file")
+            new TextOf(logger.toString()),
+            new AllOf<>(
+                new HasString("Read 16384 byte(s) from text file"),
+                new HasString("Read 32768 byte(s) from text file"),
+                new HasString("Read 49152 byte(s) from text file"),
+                new HasString("Read 65536 byte(s) from text file"),
+                new HasString("Read 74536 byte(s) from text file"),
+                new HasString("Closed input stream from text file")
             )
         ).affirm();
     }
@@ -155,8 +161,8 @@ final class LoggingInputTest {
         ).stream().skip(100);
         new Assertion<>(
             "Can't log skip from text file",
-            logger.toString(),
-            Matchers.containsString("Skipped 100 byte(s) from text file.")
+            new TextOf(logger.toString()),
+            new HasString("Skipped 100 byte(s) from text file.")
         ).affirm();
     }
 
@@ -170,14 +176,15 @@ final class LoggingInputTest {
         ).stream().available();
         new Assertion<>(
             "Can't log avaliable byte(s) from text file",
-            logger.toString(),
-            Matchers.containsString(
+            new TextOf(logger.toString()),
+            new HasString(
                 "There is(are) 74536 byte(s) available from text file"
             )
         ).affirm();
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void logResetFromLargeTextFile() throws Exception {
         final Logger logger = new FakeLogger();
         final InputStream input = new LoggingInput(
@@ -190,10 +197,10 @@ final class LoggingInputTest {
         input.reset();
         new Assertion<>(
             "Can't log mark and reset from text file",
-            logger.toString(),
-            Matchers.allOf(
-                Matchers.containsString("Marked position 150 from text file"),
-                Matchers.containsString("Reset input stream from text file")
+            new TextOf(logger.toString()),
+            new AllOf<>(
+                new HasString("Marked position 150 from text file"),
+                new HasString("Reset input stream from text file")
             )
         ).affirm();
     }
@@ -208,8 +215,8 @@ final class LoggingInputTest {
         ).stream().markSupported();
         new Assertion<>(
             "Can't log mark and reset are not supported from text file",
-            logger.toString(),
-            Matchers.containsString(
+            new TextOf(logger.toString()),
+            new HasString(
                 "Mark and reset are supported from text file"
             )
         ).affirm();
@@ -230,8 +237,8 @@ final class LoggingInputTest {
             ).value();
             new Assertion<>(
                 "",
-                handler.toString(),
-                Matchers.containsString("Read 8 byte(s)")
+                new TextOf(handler.toString()),
+                new HasString("Read 8 byte(s)")
             ).affirm();
         } finally {
             logger.removeHandler(handler);

--- a/src/test/java/org/cactoos/io/LoggingOutputTest.java
+++ b/src/test/java/org/cactoos/io/LoggingOutputTest.java
@@ -72,7 +72,7 @@ public final class LoggingOutputTest {
             )
         ).value();
         new Assertion<>(
-            "Can't log zero byte written to memory",
+            "Must log write zero byte written to memory",
             logger.toString(),
             new StringContains("Written 0 byte(s) to memory in ")
         ).affirm();
@@ -91,7 +91,7 @@ public final class LoggingOutputTest {
             out.write(new BytesOf("a").asBytes());
         }
         new Assertion<>(
-            "Can't log one byte written to memory",
+            "Must log one byte written to memory",
             logger.toString(),
             new StringContains("Written 1 byte(s) to memory in")
         ).affirm();
@@ -110,7 +110,7 @@ public final class LoggingOutputTest {
             out.write(new BytesOf("Hello, товарищ!").asBytes());
         }
         new Assertion<>(
-            "Can't log 22 bytes written to memory",
+            "Must log 22 bytes written to memory",
             logger.toString(),
             new StringContains("Written 22 byte(s) to memory in")
         ).affirm();
@@ -136,7 +136,7 @@ public final class LoggingOutputTest {
             ).value();
         }
         new Assertion<>(
-            "Can't log write and close operations to text file",
+            "Must log write and close operations to text file",
             logger.toString(),
             new AllOf<>(
                 new IsNot<String>(
@@ -170,7 +170,7 @@ public final class LoggingOutputTest {
             ).value();
         }
         new Assertion<>(
-            "Can't log all write and close operations to text file",
+            "Must log all write and close operations to text file",
             logger.toString(),
             new AllOf<>(
                 new StringContains("Written 16384 byte(s) to text file"),

--- a/src/test/java/org/cactoos/io/LoggingOutputTest.java
+++ b/src/test/java/org/cactoos/io/LoggingOutputTest.java
@@ -30,7 +30,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.cactoos.bytes.BytesOf;
 import org.cactoos.scalar.LengthOf;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.AllOf;
+import org.hamcrest.core.IsNot;
+import org.hamcrest.core.StringContains;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -72,7 +74,7 @@ public final class LoggingOutputTest {
         new Assertion<>(
             "Can't log zero byte written to memory",
             logger.toString(),
-            Matchers.containsString("Written 0 byte(s) to memory in ")
+            new StringContains("Written 0 byte(s) to memory in ")
         ).affirm();
     }
 
@@ -91,7 +93,7 @@ public final class LoggingOutputTest {
         new Assertion<>(
             "Can't log one byte written to memory",
             logger.toString(),
-            Matchers.containsString("Written 1 byte(s) to memory in")
+            new StringContains("Written 1 byte(s) to memory in")
         ).affirm();
     }
 
@@ -110,11 +112,12 @@ public final class LoggingOutputTest {
         new Assertion<>(
             "Can't log 22 bytes written to memory",
             logger.toString(),
-            Matchers.containsString("Written 22 byte(s) to memory in")
+            new StringContains("Written 22 byte(s) to memory in")
         ).affirm();
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void logWriteToLargeTextFile() throws Exception {
         final Logger logger = new FakeLogger();
         final Path temp = this.folder.newFolder("ccts-1").toPath();
@@ -135,19 +138,20 @@ public final class LoggingOutputTest {
         new Assertion<>(
             "Can't log write and close operations to text file",
             logger.toString(),
-            Matchers.allOf(
-                Matchers.not(
-                    Matchers.containsString(
+            new AllOf<>(
+                new IsNot<String>(
+                    new StringContains(
                         "Written 16384 byte(s) to text file"
                     )
                 ),
-                Matchers.containsString("Written 74536 byte(s) to text file"),
-                Matchers.containsString("Closed output stream from text file")
+                new StringContains("Written 74536 byte(s) to text file"),
+                new StringContains("Closed output stream from text file")
             )
         ).affirm();
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void logAllWriteToLargeTextFile() throws Exception {
         final Logger logger = new FakeLogger(Level.WARNING);
         final Path temp = this.folder.newFolder("ccts-2").toPath();
@@ -168,13 +172,13 @@ public final class LoggingOutputTest {
         new Assertion<>(
             "Can't log all write and close operations to text file",
             logger.toString(),
-            Matchers.allOf(
-                Matchers.containsString("Written 16384 byte(s) to text file"),
-                Matchers.containsString("Written 32768 byte(s) to text file"),
-                Matchers.containsString("Written 49152 byte(s) to text file"),
-                Matchers.containsString("Written 65536 byte(s) to text file"),
-                Matchers.containsString("Written 74536 byte(s) to text file"),
-                Matchers.containsString("Closed output stream from text file")
+            new AllOf<>(
+                new StringContains("Written 16384 byte(s) to text file"),
+                new StringContains("Written 32768 byte(s) to text file"),
+                new StringContains("Written 49152 byte(s) to text file"),
+                new StringContains("Written 65536 byte(s) to text file"),
+                new StringContains("Written 74536 byte(s) to text file"),
+                new StringContains("Closed output stream from text file")
             )
         ).affirm();
     }

--- a/src/test/java/org/cactoos/io/ResourceOfTest.java
+++ b/src/test/java/org/cactoos/io/ResourceOfTest.java
@@ -29,16 +29,18 @@ import org.cactoos.Text;
 import org.cactoos.bytes.BytesOf;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.TextOf;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.EndsWith;
+import org.llorllale.cactoos.matchers.StartsWith;
 
 /**
  * Test case for {@link ResourceOf}.
  *
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class ResourceOfTest {
 
@@ -56,7 +58,7 @@ public final class ResourceOfTest {
                 0,
                 4
             ),
-            Matchers.equalTo(
+            new IsEqual<>(
                 new byte[]{
                     // @checkstyle MagicNumber (1 line)
                     (byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE,
@@ -94,8 +96,8 @@ public final class ResourceOfTest {
                         "the replacement"
                     )
                 )
-            ).asString(),
-            Matchers.endsWith("replacement")
+            ),
+            new EndsWith("replacement")
         ).affirm();
     }
 
@@ -116,8 +118,8 @@ public final class ResourceOfTest {
                 new ResourceOf(
                     new TextOf("org/cactoos/small-text.txt")
                 )
-            ).asString(),
-            Matchers.endsWith("ex ea commodo")
+            ),
+            new EndsWith("ex ea commodo")
         ).affirm();
     }
 
@@ -130,8 +132,8 @@ public final class ResourceOfTest {
                     new FormattedText("%s/absent.txt", "baz"),
                     new TextOf("another replacement")
                 )
-            ).asString(),
-            Matchers.startsWith("another")
+            ),
+            new StartsWith("another")
         ).affirm();
     }
 

--- a/src/test/java/org/cactoos/io/TailOfTest.java
+++ b/src/test/java/org/cactoos/io/TailOfTest.java
@@ -26,7 +26,7 @@ package org.cactoos.io;
 import java.util.Arrays;
 import java.util.Random;
 import org.cactoos.bytes.BytesOf;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 
@@ -49,7 +49,7 @@ public final class TailOfTest {
                     size - 1
                 )
             ).asBytes(),
-            Matchers.equalTo(Arrays.copyOfRange(bytes, 1, bytes.length))
+            new IsEqual<>(Arrays.copyOfRange(bytes, 1, bytes.length))
         ).affirm();
     }
 
@@ -65,7 +65,7 @@ public final class TailOfTest {
                     size
                 )
             ).asBytes(),
-            Matchers.equalTo(bytes)
+            new IsEqual<>(bytes)
         ).affirm();
     }
 
@@ -82,7 +82,7 @@ public final class TailOfTest {
                     size
                 )
             ).asBytes(),
-            Matchers.equalTo(bytes)
+            new IsEqual<>(bytes)
         ).affirm();
     }
 
@@ -98,7 +98,7 @@ public final class TailOfTest {
                     size + 1
                 )
             ).asBytes(),
-            Matchers.equalTo(bytes)
+            new IsEqual<>(bytes)
         ).affirm();
     }
 
@@ -115,7 +115,7 @@ public final class TailOfTest {
                     size - 1
                 )
             ).asBytes(),
-            Matchers.equalTo(
+            new IsEqual<>(
                 Arrays.copyOfRange(bytes, 1, bytes.length)
             )
         ).affirm();

--- a/src/test/java/org/cactoos/io/TeeInputStreamTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputStreamTest.java
@@ -30,7 +30,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.cactoos.scalar.LengthOf;
 import org.cactoos.text.TextOf;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.AllOf;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
@@ -44,6 +44,7 @@ import org.llorllale.cactoos.matchers.Assertion;
 final class TeeInputStreamTest {
 
     @Test
+    @SuppressWarnings("unchecked")
     void copiesContentByteByByte() throws Exception {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final String content = "Hello, товарищ!";
@@ -58,9 +59,9 @@ final class TeeInputStreamTest {
                     )
                 )
             ).asString(),
-            Matchers.allOf(
-                Matchers.equalTo(content),
-                Matchers.equalTo(
+            new AllOf<>(
+                new IsEqual<String>(content),
+                new IsEqual<String>(
                     new String(baos.toByteArray(), StandardCharsets.UTF_8)
                 )
             )

--- a/src/test/java/org/cactoos/io/TeeOutputStreamTest.java
+++ b/src/test/java/org/cactoos/io/TeeOutputStreamTest.java
@@ -27,7 +27,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import org.cactoos.text.TextOf;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.AllOf;
+import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 
@@ -40,6 +41,7 @@ import org.llorllale.cactoos.matchers.Assertion;
 final class TeeOutputStreamTest {
 
     @Test
+    @SuppressWarnings("unchecked")
     void copiesContentByteByByte() throws Exception {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final ByteArrayOutputStream copy = new ByteArrayOutputStream();
@@ -56,12 +58,12 @@ final class TeeOutputStreamTest {
                     )
                 )
             ).asString(),
-            Matchers.allOf(
-                Matchers.equalTo(content),
-                Matchers.equalTo(
+            new AllOf<>(
+                new IsEqual<String>(content),
+                new IsEqual<String>(
                     new String(baos.toByteArray(), StandardCharsets.UTF_8)
                 ),
-                Matchers.equalTo(
+                new IsEqual<String>(
                     new String(copy.toByteArray(), StandardCharsets.UTF_8)
                 )
             )

--- a/src/test/java/org/cactoos/io/TempFileTest.java
+++ b/src/test/java/org/cactoos/io/TempFileTest.java
@@ -28,7 +28,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.TextOf;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.AllOf;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
@@ -56,17 +56,18 @@ final class TempFileTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void createFileInCustomPath() throws Exception {
         final Path custom = Paths.get(System.getProperty("user.home"));
         try (TempFile file = new TempFile(() -> custom, "", "")) {
             new Assertion<>(
                 "Must create a temp file at a custom path",
                 file,
-                Matchers.allOf(
-                    new Verifies<>(
+                new AllOf<>(
+                    new Verifies<TempFile>(
                         tmp -> Files.exists(tmp.value())
                     ),
-                    new Verifies<>(
+                    new Verifies<TempFile>(
                         tmp -> tmp.value().getParent().equals(custom)
                     )
                 )


### PR DESCRIPTION
For #1434 :

- Replace calls to `Matchers` for test package `com.cactoos.io`