### PR TITLE
(#1560) Delegate `TextOf(Iterator)` to `TextOf(Iterable)`

### DIFF
--- a/src/main/java/org/cactoos/iterable/IterableOf.java
+++ b/src/main/java/org/cactoos/iterable/IterableOf.java
@@ -33,7 +33,7 @@ import org.cactoos.scalar.Or;
 import org.cactoos.scalar.ScalarWithFallback;
 import org.cactoos.scalar.SumOfInt;
 import org.cactoos.scalar.Unchecked;
-import org.cactoos.text.TextOf;
+import org.cactoos.text.Joined;
 import org.cactoos.text.UncheckedText;
 
 /**
@@ -134,6 +134,14 @@ public final class IterableOf<X> implements Iterable<X> {
 
     @Override
     public String toString() {
-        return new UncheckedText(new TextOf(this)).asString();
+        return new UncheckedText(
+            new Joined(
+                ", ",
+                new Mapped<>(
+                    Object::toString,
+                    this
+                )
+            )
+        ).asString();
     }
 }

--- a/src/main/java/org/cactoos/map/MapEnvelope.java
+++ b/src/main/java/org/cactoos/map/MapEnvelope.java
@@ -26,7 +26,9 @@ package org.cactoos.map;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
-import org.cactoos.text.TextOf;
+import org.cactoos.iterable.Mapped;
+import org.cactoos.text.Concatenated;
+import org.cactoos.text.Joined;
 
 /**
  * Map envelope.
@@ -124,7 +126,14 @@ public abstract class MapEnvelope<X, Y> implements Map<X, Y> {
     public final String toString() {
         return new StringBuilder()
             .append('{')
-            .append(new TextOf(this.entrySet()).toString())
+            .append(
+                new Concatenated(
+                    new Joined(
+                        ", ",
+                        new Mapped<>(Object::toString, this.entrySet())
+                    )
+                )
+            )
             .append('}')
             .toString();
     }

--- a/src/main/java/org/cactoos/map/MapEnvelope.java
+++ b/src/main/java/org/cactoos/map/MapEnvelope.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import org.cactoos.iterable.Mapped;
 import org.cactoos.text.Concatenated;
 import org.cactoos.text.Joined;
+import org.cactoos.text.TextOf;
 
 /**
  * Map envelope.
@@ -124,18 +125,14 @@ public abstract class MapEnvelope<X, Y> implements Map<X, Y> {
 
     @Override
     public final String toString() {
-        return new StringBuilder()
-            .append('{')
-            .append(
-                new Concatenated(
-                    new Joined(
-                        ", ",
-                        new Mapped<>(Object::toString, this.entrySet())
-                    )
-                )
-            )
-            .append('}')
-            .toString();
+        return new Concatenated(
+            new TextOf("{"),
+            new Joined(
+                ", ",
+                new Mapped<>(Object::toString, this.entrySet())
+            ),
+            new TextOf("}")
+        ).toString();
     }
 
     @Override

--- a/src/main/java/org/cactoos/text/TextOf.java
+++ b/src/main/java/org/cactoos/text/TextOf.java
@@ -318,6 +318,9 @@ public final class TextOf extends TextEnvelope {
      * Ctor.
      *
      * @param iterable The iterable to convert to string
+     * @todo #1560:30min/DEV We want {@link Concatenated} to have
+     *  an extra constructor that accepts {@code Iterable<CharSequence>}
+     *  to avoid creating of {@link Joined} with empty delimiter.
      */
     public TextOf(final Iterable<Character> iterable) {
         super(

--- a/src/main/java/org/cactoos/text/TextOf.java
+++ b/src/main/java/org/cactoos/text/TextOf.java
@@ -39,6 +39,7 @@ import org.cactoos.Scalar;
 import org.cactoos.Text;
 import org.cactoos.bytes.BytesOf;
 import org.cactoos.io.InputOf;
+import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.Mapped;
 
 /**
@@ -319,7 +320,15 @@ public final class TextOf extends TextEnvelope {
      * @param iterable The iterable to convert to string
      */
     public TextOf(final Iterable<Character> iterable) {
-        this(iterable.iterator());
+        super(
+            new Joined(
+                "",
+                new Mapped<>(
+                    Object::toString,
+                    iterable
+                )
+            )
+        );
     }
 
     /**
@@ -328,15 +337,7 @@ public final class TextOf extends TextEnvelope {
      * @param iterator The iterable to convert to string
      */
     public TextOf(final Iterator<Character> iterator) {
-        this(
-            new TextOfScalar(
-                () -> {
-                    final StringBuilder buf = new StringBuilder();
-                    iterator.forEachRemaining(buf::append);
-                    return buf.toString();
-                }
-            )
-        );
+        this(new IterableOf<>(iterator));
     }
 
     /**

--- a/src/main/java/org/cactoos/text/TextOf.java
+++ b/src/main/java/org/cactoos/text/TextOf.java
@@ -324,16 +324,8 @@ public final class TextOf extends TextEnvelope {
      *  modify other parts of cactoos that relied on this in order to preserve their behaviour
      *  by using {@link Joined} and {@link Concatenated}.
      */
-    public TextOf(final Iterable<?> iterable) {
-        super(
-            new Joined(
-                ", ",
-                new Mapped<>(
-                    Object::toString,
-                    iterable
-                )
-            )
-        );
+    public TextOf(final Iterable<Character> iterable) {
+        this(iterable.iterator());
     }
 
     /**

--- a/src/main/java/org/cactoos/text/TextOf.java
+++ b/src/main/java/org/cactoos/text/TextOf.java
@@ -317,30 +317,26 @@ public final class TextOf extends TextEnvelope {
     /**
      * Ctor.
      *
-     * @param iterable The iterable to convert to string
-     * @todo #1560:30min/DEV We want {@link Concatenated} to have
-     *  an extra constructor that accepts {@code Iterable<CharSequence>}
-     *  to avoid creating of {@link Joined} with empty delimiter.
+     * @param iterator The iterable to convert to string
      */
-    public TextOf(final Iterable<Character> iterable) {
-        super(
-            new Joined(
-                "",
-                new Mapped<>(
-                    Object::toString,
-                    iterable
-                )
-            )
-        );
+    public TextOf(final Iterator<Character> iterator) {
+        this(new IterableOf<>(iterator));
     }
 
     /**
      * Ctor.
      *
-     * @param iterator The iterable to convert to string
+     * @param iterable The iterable to convert to string
      */
-    public TextOf(final Iterator<Character> iterator) {
-        this(new IterableOf<>(iterator));
+    public TextOf(final Iterable<Character> iterable) {
+        super(
+            new Concatenated(
+                new Mapped<>(
+                    TextOf::new,
+                    iterable
+                )
+            )
+        );
     }
 
     /**

--- a/src/main/java/org/cactoos/text/TextOf.java
+++ b/src/main/java/org/cactoos/text/TextOf.java
@@ -317,12 +317,6 @@ public final class TextOf extends TextEnvelope {
      * Ctor.
      *
      * @param iterable The iterable to convert to string
-     * @todo #1461:30min We want constructors with {@code Iterable<?>} and
-     *  {@code Iterator<Character>} to have same behaviour (simply concatenate list of strings).
-     *  To do that, we should change {@code Iterable<?>} to {@code Iterable<Character>}
-     *  and delegate the {@link Iterator} one to the {@link Iterable} one. After that, we need to
-     *  modify other parts of cactoos that relied on this in order to preserve their behaviour
-     *  by using {@link Joined} and {@link Concatenated}.
      */
     public TextOf(final Iterable<Character> iterable) {
         this(iterable.iterator());

--- a/src/test/java/org/cactoos/map/MapEnvelopeTest.java
+++ b/src/test/java/org/cactoos/map/MapEnvelopeTest.java
@@ -301,6 +301,18 @@ public final class MapEnvelopeTest {
         ).affirm();
     }
 
+    @Test
+    public void testToString() {
+        new Assertion<>(
+            "Must be a readable representation",
+            new MapOf<String, Integer>(
+                new MapEntry<>("k1", 10),
+                new MapEntry<>("k2", -2)
+            ).toString(),
+            new IsEqual<>("{k1=10, k2=-2}")
+        ).affirm();
+    }
+
     /**
      * Class derived from MapEnvelope to use in some tests.
      * @param <K> - key type

--- a/src/test/java/org/cactoos/map/MapEnvelopeTest.java
+++ b/src/test/java/org/cactoos/map/MapEnvelopeTest.java
@@ -301,18 +301,6 @@ public final class MapEnvelopeTest {
         ).affirm();
     }
 
-    @Test
-    public void testToString() {
-        new Assertion<>(
-            "Must be a readable representation",
-            new MapOf<String, Integer>(
-                new MapEntry<>("k1", 10),
-                new MapEntry<>("k2", -2)
-            ).toString(),
-            new IsEqual<>("{k1=10, k2=-2}")
-        ).affirm();
-    }
-
     /**
      * Class derived from MapEnvelope to use in some tests.
      * @param <K> - key type

--- a/src/test/java/org/cactoos/text/TextOfTest.java
+++ b/src/test/java/org/cactoos/text/TextOfTest.java
@@ -323,7 +323,7 @@ final class TextOfTest {
     @Test
     void readsIterableToText() {
         new Assertion<>(
-            "Can't read Iterable to Text",
+            "Must read Iterable to Text",
             new TextOf(
                 new IterableOfChars("hello")
             ),

--- a/src/test/java/org/cactoos/text/TextOfTest.java
+++ b/src/test/java/org/cactoos/text/TextOfTest.java
@@ -29,7 +29,6 @@ import java.io.InputStream;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import org.cactoos.io.InputOf;
-import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.IterableOfChars;
 import org.cactoos.iterator.IteratorOfChars;
 import org.hamcrest.core.AllOf;

--- a/src/test/java/org/cactoos/text/TextOfTest.java
+++ b/src/test/java/org/cactoos/text/TextOfTest.java
@@ -30,6 +30,8 @@ import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import org.cactoos.bytes.BytesOf;
 import org.cactoos.io.InputOf;
+import org.cactoos.iterable.IterableOf;
+import org.cactoos.iterable.IterableOfChars;
 import org.cactoos.iterator.IteratorOfChars;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
@@ -315,6 +317,17 @@ final class TextOfTest {
                 new IOException("").getStackTrace()
             ),
             new HasString("org.cactoos.text.TextOfTest")
+        ).affirm();
+    }
+
+    @Test
+    void readsIterableToText() throws Exception {
+        new Assertion<>(
+            "Can't read Iterable to Text",
+            new TextOf(
+                new IterableOfChars("hello")
+            ).asString(),
+            new IsEqual<>("hello")
         ).affirm();
     }
 

--- a/src/test/java/org/cactoos/text/TextOfTest.java
+++ b/src/test/java/org/cactoos/text/TextOfTest.java
@@ -321,13 +321,13 @@ final class TextOfTest {
     }
 
     @Test
-    void readsIterableToText() throws Exception {
+    void readsIterableToText() {
         new Assertion<>(
             "Can't read Iterable to Text",
             new TextOf(
                 new IterableOfChars("hello")
-            ).asString(),
-            new IsEqual<>("hello")
+            ),
+            new IsText("hello")
         ).affirm();
     }
 


### PR DESCRIPTION
For #1560:

- Constructor `TextOf(Iterator)` now delegates to `TextOf(Iterable)`
- Constructor `TextOf` parameter is typed as `Iterable<Character>` instead of `Iterable<?>`
- Add extra test for `TextOf(Iterable)`
- Replace usages of `TextOf(Iterable<?>)` with `Joined` and `Concatenated`
