### PR TITLE
Use `IsText` for testing `Text` objects

### DIFF
--- a/src/main/java/org/cactoos/io/ResourceOf.java
+++ b/src/main/java/org/cactoos/io/ResourceOf.java
@@ -159,7 +159,7 @@ public final class ResourceOf implements Input {
                 throw new IOException(
                     new FormattedText(
                         "The resource \"%s\" was not found in %s",
-                        input.asString(),
+                        input,
                         ldr
                     ).asString()
                 );
@@ -174,7 +174,7 @@ public final class ResourceOf implements Input {
      * @param fbk Fallback
      */
     public ResourceOf(final Text res, final Text fbk) {
-        this(res, input -> new InputOf(new BytesOf(fbk.asString())));
+        this(res, input -> new InputOf(fbk));
     }
 
     /**

--- a/src/main/java/org/cactoos/io/TempFile.java
+++ b/src/main/java/org/cactoos/io/TempFile.java
@@ -86,6 +86,23 @@ public final class TempFile implements Scalar<Path>, Closeable {
 
     /**
      * Ctor.
+     * <p>
+     * The temporary file will be created inside the filesystem's
+     * temporary folder (system property: {@code java.io.tmpdir}).
+     * @param prefix The temp filename's prefix
+     * @param suffix The temp filename's suffix
+     * @since 1.0
+     */
+    public TempFile(final Text prefix, final Text suffix) {
+        this(
+            () -> Paths.get(System.getProperty("java.io.tmpdir")),
+            prefix,
+            suffix
+        );
+    }
+
+    /**
+     * Ctor.
      * @param dir The directory in which to create the temp file
      * @param prefix The temp filename's prefix
      * @param suffix The temp filename's suffix

--- a/src/main/java/org/cactoos/text/SuffixOf.java
+++ b/src/main/java/org/cactoos/text/SuffixOf.java
@@ -24,7 +24,6 @@
 package org.cactoos.text;
 
 import org.cactoos.Text;
-import org.cactoos.scalar.LengthOf;
 import org.cactoos.scalar.ScalarOf;
 import org.cactoos.scalar.Ternary;
 

--- a/src/test/java/org/cactoos/TextTest.java
+++ b/src/test/java/org/cactoos/TextTest.java
@@ -27,7 +27,7 @@ import org.cactoos.text.NoNulls;
 import org.cactoos.text.TextOf;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
-import org.llorllale.cactoos.matchers.HasString;
+import org.llorllale.cactoos.matchers.IsText;
 import org.llorllale.cactoos.matchers.Throws;
 
 /**
@@ -69,7 +69,7 @@ final class TextTest {
             new NoNulls(
                 new TextOf(message)
             ),
-            new HasString(message)
+            new IsText(message)
         ).affirm();
     }
 

--- a/src/test/java/org/cactoos/io/GzipInputTest.java
+++ b/src/test/java/org/cactoos/io/GzipInputTest.java
@@ -32,9 +32,9 @@ import java.io.Writer;
 import java.util.zip.GZIPOutputStream;
 import org.cactoos.scalar.LengthOf;
 import org.cactoos.text.TextOf;
-import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.IsText;
 
 /**
  * Test case for {@link org.cactoos.io.GzipInput}.
@@ -62,8 +62,8 @@ public final class GzipInputTest {
             "Can't read from a gzip input",
             new TextOf(
                 new GzipInput(new InputOf(bytes))
-            ).asString(),
-            new IsEqual<>(content)
+            ),
+            new IsText(content)
         ).affirm();
     }
 

--- a/src/test/java/org/cactoos/io/InputOfTest.java
+++ b/src/test/java/org/cactoos/io/InputOfTest.java
@@ -43,6 +43,7 @@ import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.EndsWith;
 import org.llorllale.cactoos.matchers.HasContent;
 import org.llorllale.cactoos.matchers.HasString;
+import org.llorllale.cactoos.matchers.IsText;
 import org.llorllale.cactoos.matchers.IsTrue;
 import org.llorllale.cactoos.matchers.MatchesRegex;
 import org.llorllale.cactoos.matchers.Satisfies;
@@ -272,8 +273,8 @@ final class InputOfTest {
                 new InputOf(
                     new StringReader(source)
                 )
-            ).asString(),
-            new IsEqual<>(source)
+            ),
+            new IsText(source)
         ).affirm();
     }
 
@@ -289,8 +290,8 @@ final class InputOfTest {
                         StandardCharsets.UTF_8
                     )
                 )
-            ).asString(),
-            new IsEqual<>(source)
+            ),
+            new IsText(source)
         ).affirm();
     }
 

--- a/src/test/java/org/cactoos/io/InputStreamOfTest.java
+++ b/src/test/java/org/cactoos/io/InputStreamOfTest.java
@@ -32,12 +32,12 @@ import java.nio.file.Path;
 import org.cactoos.bytes.BytesOf;
 import org.cactoos.scalar.LengthOf;
 import org.cactoos.text.TextOf;
-import org.hamcrest.core.IsEqual;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasContent;
+import org.llorllale.cactoos.matchers.IsText;
 import org.llorllale.cactoos.matchers.Satisfies;
 
 /**
@@ -107,8 +107,8 @@ public final class InputStreamOfTest {
         ).value();
         new Assertion<>(
             "Must read from file",
-            new TextOf(new InputStreamOf(file)).asString(),
-            new IsEqual<>(content)
+            new TextOf(new InputStreamOf(file)),
+            new IsText(content)
         ).affirm();
     }
 
@@ -117,8 +117,8 @@ public final class InputStreamOfTest {
         final String content = "Bytes content";
         new Assertion<>(
             "Must read from bytes",
-            new TextOf(new InputStreamOf(new BytesOf(content))).asString(),
-            new IsEqual<>(content)
+            new TextOf(new InputStreamOf(new BytesOf(content))),
+            new IsText(content)
         ).affirm();
     }
 
@@ -128,8 +128,8 @@ public final class InputStreamOfTest {
         final byte[] bytes = new BytesOf(content).asBytes();
         new Assertion<>(
             "Must read from byte array",
-            new TextOf(new InputStreamOf(bytes)).asString(),
-            new IsEqual<>(content)
+            new TextOf(new InputStreamOf(bytes)),
+            new IsText(content)
         ).affirm();
     }
 
@@ -138,8 +138,8 @@ public final class InputStreamOfTest {
         final String content = "Text content";
         new Assertion<>(
             "Must read from text",
-            new TextOf(new InputStreamOf(new TextOf(content))).asString(),
-            new IsEqual<>(content)
+            new TextOf(new InputStreamOf(new TextOf(content))),
+            new IsText(content)
         ).affirm();
     }
 
@@ -152,8 +152,8 @@ public final class InputStreamOfTest {
         ).value();
         new Assertion<>(
             "Must read from URI",
-            new TextOf(new InputStreamOf(file.toURI())).asString(),
-            new IsEqual<>(content)
+            new TextOf(new InputStreamOf(file.toURI())),
+            new IsText(content)
         ).affirm();
     }
 
@@ -166,8 +166,8 @@ public final class InputStreamOfTest {
         ).value();
         new Assertion<>(
             "Must read from URL",
-            new TextOf(new InputStreamOf(file.toURI().toURL())).asString(),
-            new IsEqual<>(content)
+            new TextOf(new InputStreamOf(file.toURI().toURL())),
+            new IsText(content)
         ).affirm();
     }
 
@@ -183,8 +183,8 @@ public final class InputStreamOfTest {
                     StandardCharsets.UTF_8.name(),
                     max
                 )
-            ).asString(),
-            new IsEqual<>(content)
+            ),
+            new IsText(content)
         ).affirm();
     }
 
@@ -199,8 +199,8 @@ public final class InputStreamOfTest {
                     StandardCharsets.UTF_8,
                     1
                 )
-            ).asString(),
-            new IsEqual<>(content)
+            ),
+            new IsText(content)
         ).affirm();
     }
 
@@ -214,8 +214,8 @@ public final class InputStreamOfTest {
                     new StringReader(content),
                     StandardCharsets.UTF_8.name()
                 )
-            ).asString(),
-            new IsEqual<>(content)
+            ),
+            new IsText(content)
         ).affirm();
     }
 
@@ -233,8 +233,8 @@ public final class InputStreamOfTest {
                     new TextOf(file),
                     StandardCharsets.UTF_8.name()
                 )
-            ).asString(),
-            new IsEqual<>(content)
+            ),
+            new IsText(content)
         ).affirm();
     }
 
@@ -248,8 +248,8 @@ public final class InputStreamOfTest {
                     content,
                     StandardCharsets.UTF_8.name()
                 )
-            ).asString(),
-            new IsEqual<>(content)
+            ),
+            new IsText(content)
         ).affirm();
     }
 
@@ -263,8 +263,8 @@ public final class InputStreamOfTest {
                     content,
                     StandardCharsets.UTF_8
                 )
-            ).asString(),
-            new IsEqual<>(content)
+            ),
+            new IsText(content)
         ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/io/InputStreamOfTest.java
+++ b/src/test/java/org/cactoos/io/InputStreamOfTest.java
@@ -113,7 +113,7 @@ public final class InputStreamOfTest {
     }
 
     @Test
-    public void readsBytes() throws Exception {
+    public void readsBytes() {
         final String content = "Bytes content";
         new Assertion<>(
             "Must read from bytes",
@@ -134,7 +134,7 @@ public final class InputStreamOfTest {
     }
 
     @Test
-    public void readsText() throws Exception {
+    public void readsText() {
         final String content = "Text content";
         new Assertion<>(
             "Must read from text",
@@ -172,7 +172,7 @@ public final class InputStreamOfTest {
     }
 
     @Test
-    public void readsFromReaderWithMax() throws Exception {
+    public void readsFromReaderWithMax() {
         final String content = "Reading with charset name and buffer size";
         final int max = 3;
         new Assertion<>(
@@ -189,7 +189,7 @@ public final class InputStreamOfTest {
     }
 
     @Test
-    public void readsFromReaderWithCharsetWithMax() throws Exception {
+    public void readsFromReaderWithCharsetWithMax() {
         final String content = "Reading with charset and buffer size";
         new Assertion<>(
             "Must read from reader with charset and buffer size",
@@ -205,7 +205,7 @@ public final class InputStreamOfTest {
     }
 
     @Test
-    public void readsFromReaderWithCharset() throws Exception {
+    public void readsFromReaderWithCharset() {
         final String content = "Content for reading with charset";
         new Assertion<>(
             "Must read from reader with charset name",
@@ -239,7 +239,7 @@ public final class InputStreamOfTest {
     }
 
     @Test
-    public void readsFromCharSequenceWithCharsetName() throws Exception {
+    public void readsFromCharSequenceWithCharsetName() {
         final String content = "Simple content";
         new Assertion<>(
             "Must read from char sequence with charset name",
@@ -254,7 +254,7 @@ public final class InputStreamOfTest {
     }
 
     @Test
-    public void readsFromCharSequenceWithCharset() throws Exception {
+    public void readsFromCharSequenceWithCharset() {
         final String content = "Another simple content";
         new Assertion<>(
             "Must read from char sequence with charset",

--- a/src/test/java/org/cactoos/io/TempFileTest.java
+++ b/src/test/java/org/cactoos/io/TempFileTest.java
@@ -26,6 +26,7 @@ package org.cactoos.io;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import org.cactoos.Text;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.TextOf;
 import org.hamcrest.core.AllOf;
@@ -87,11 +88,11 @@ final class TempFileTest {
 
     @Test
     void createFileWithPrefix() throws Exception {
-        final String prefix = new FormattedText(
+        final Text prefix = new FormattedText(
             "randomPrefix%s",
             System.currentTimeMillis()
-        ).asString();
-        try (TempFile file = new TempFile(prefix, "")) {
+        );
+        try (TempFile file = new TempFile(prefix, new TextOf(""))) {
             new Assertion<>(
                 "File must be created with the given prefix",
                 new TextOf(file.value().getFileName().toString()),
@@ -102,10 +103,10 @@ final class TempFileTest {
 
     @Test
     void createFileWithSuffix() throws Exception {
-        final String suffix = new FormattedText(
+        final Text suffix = new FormattedText(
             "randomSuffix%s", System.currentTimeMillis()
-        ).asString();
-        try (TempFile file = new TempFile("", suffix)) {
+        );
+        try (TempFile file = new TempFile(new TextOf(""), suffix)) {
             new Assertion<>(
                 "File must be created with the given suffix",
                 new TextOf(file.value().getFileName().toString()),

--- a/src/test/java/org/cactoos/iterable/MappedTest.java
+++ b/src/test/java/org/cactoos/iterable/MappedTest.java
@@ -31,6 +31,7 @@ import org.hamcrest.collection.IsEmptyIterable;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.IsText;
 
 /**
  * Test case for {@link Mapped}.
@@ -50,8 +51,8 @@ final class MappedTest {
                 new IterableOf<>(
                     "hello", "world", "друг"
                 )
-            ).iterator().next().asString(),
-            new IsEqual<>("HELLO")
+            ).iterator().next(),
+            new IsText("HELLO")
         ).affirm();
     }
 

--- a/src/test/java/org/cactoos/text/TextEnvelopeTest.java
+++ b/src/test/java/org/cactoos/text/TextEnvelopeTest.java
@@ -26,9 +26,9 @@ package org.cactoos.text;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import org.cactoos.Scalar;
-import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.IsText;
 
 /**
  * Tests for {@link TextEnvelope}.
@@ -38,15 +38,14 @@ final class TextEnvelopeTest {
     /**
      * Test for {@link TextEnvelope#asString()} method. Must assert that
      * the envelope asString value is equal to its string value.
-     * @throws Exception Throws from asString.
      */
     @Test
-    void testAsString() throws Exception {
+    void testAsString() {
         final String text = "asString";
         new Assertion<>(
             "Envelope value does not match String value",
-            new TextEnvelopeDummy(text).asString(),
-            new IsEqual<>(text)
+            new TextEnvelopeDummy(text),
+            new IsText(text)
         ).affirm();
     }
 

--- a/src/test/java/org/cactoos/text/TextOfTest.java
+++ b/src/test/java/org/cactoos/text/TextOfTest.java
@@ -28,16 +28,18 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
-import org.cactoos.bytes.BytesOf;
 import org.cactoos.io.InputOf;
 import org.cactoos.iterator.IteratorOfChars;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.AllOf;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNot;
+import org.hamcrest.core.IsNull;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.EndsWith;
 import org.llorllale.cactoos.matchers.HasString;
 import org.llorllale.cactoos.matchers.IsText;
+import org.llorllale.cactoos.matchers.StartsWith;
 
 /**
  * Test case for {@link TextOf}.
@@ -48,11 +50,11 @@ import org.llorllale.cactoos.matchers.IsText;
  * @checkstyle MagicNumberCheck (1000 lines)
  * @checkstyle StringLiteralsConcatenationCheck (1000 lines)
  */
-@SuppressWarnings({"PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals"})
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals", "unchecked"})
 final class TextOfTest {
 
     @Test
-    void readsInputIntoText() throws Exception {
+    void readsInputIntoText() {
         new Assertion<>(
             "Can't read text from Input",
             new Synced(
@@ -60,40 +62,40 @@ final class TextOfTest {
                     new InputOf("привет, друг!"),
                     StandardCharsets.UTF_8
                 )
-            ).asString(),
-            Matchers.allOf(
-                Matchers.startsWith("привет, "),
-                Matchers.endsWith("друг!")
+            ),
+            new AllOf<>(
+                new StartsWith("привет, "),
+                new EndsWith("друг!")
             )
         ).affirm();
     }
 
     @Test
-    void readsInputIntoTextWithDefaultCharset() throws Exception {
+    void readsInputIntoTextWithDefaultCharset() {
         new Assertion<>(
             "Can't read text from Input with default charset",
             new TextOf(
                 new InputOf("Hello, друг! with default charset")
-            ).asString(),
-            Matchers.allOf(
-                Matchers.startsWith("Hello, "),
-                Matchers.endsWith("друг! with default charset")
+            ),
+            new AllOf<>(
+                new StartsWith("Hello, "),
+                new EndsWith("друг! with default charset")
             )
         ).affirm();
     }
 
     @Test
-    void readsInputIntoTextWithSmallBuffer() throws Exception {
+    void readsInputIntoTextWithSmallBuffer() {
         new Assertion<>(
             "Can't read text with a small reading buffer",
             new TextOf(
                 new InputOf("Hi, товарищ! with small buffer"),
                 2,
                 StandardCharsets.UTF_8
-            ).asString(),
-            Matchers.allOf(
-                Matchers.startsWith("Hi,"),
-                Matchers.endsWith("товарищ! with small buffer")
+            ),
+            new AllOf<>(
+                new StartsWith("Hi,"),
+                new EndsWith("товарищ! with small buffer")
             )
         ).affirm();
     }
@@ -103,119 +105,106 @@ final class TextOfTest {
         final String text = "Hi there! with small buffer";
         new Assertion<>(
             "Can't read text from Reader with a small reading buffer",
-            new TextOf(text),
-            new IsText(
-                new TextOf(
-                    new StringReader(text), 2, StandardCharsets.UTF_8
-                )
-            )
+            new TextOf(
+                new StringReader(text), 2, StandardCharsets.UTF_8
+            ),
+            new IsText(text)
         ).affirm();
     }
 
     @Test
-    void readsInputIntoTextWithSmallBufferAndDefaultCharset()
-        throws Exception {
+    void readsInputIntoTextWithSmallBufferAndDefaultCharset() {
         new Assertion<>(
             "Can't read text with a small reading buffer and default charset",
             new TextOf(
                 new InputOf("Hello, товарищ! with default charset"),
                 2
-            ).asString(),
-            Matchers.allOf(
-                Matchers.startsWith("Hello,"),
-                Matchers.endsWith("товарищ! with default charset")
+            ),
+            new AllOf<>(
+                new StartsWith("Hello,"),
+                new EndsWith("товарищ! with default charset")
             )
         ).affirm();
     }
 
     @Test
-    void readsFromReader() throws Exception {
+    void readsFromReader() {
         final String source = "hello, друг!";
         new Assertion<>(
             "Can't read string through a reader",
             new TextOf(
                 new StringReader(source),
                 StandardCharsets.UTF_8
-            ).asString(),
-            Matchers.equalTo(
-                new String(
-                    new BytesOf(source).asBytes(),
-                    StandardCharsets.UTF_8
-                )
-            )
+            ),
+            new IsText(source)
         ).affirm();
     }
 
     @Test
-    void readsFromReaderWithDefaultEncoding() throws Exception {
+    void readsFromReaderWithDefaultEncoding() {
         final String source = "hello, друг! with default encoding";
         new Assertion<>(
             "Can't read string with default encoding through a reader",
-            new TextOf(new StringReader(source)).asString(),
-            Matchers.equalTo(
-                new String(
-                    new BytesOf(source).asBytes(),
-                    StandardCharsets.UTF_8
-                )
-            )
+            new TextOf(new StringReader(source)),
+            new IsText(source)
         ).affirm();
     }
 
     @Test
-    void readsEncodedArrayOfCharsIntoText() throws Exception {
+    void readsEncodedArrayOfCharsIntoText() {
         new Assertion<>(
             "Can't read array of encoded chars into text.",
             new TextOf(
                 'O', ' ', 'q', 'u', 'e', ' ', 's', 'e', 'r', 'a',
                 ' ', 'q', 'u', 'e', ' ', 's', 'e', 'r', 'a'
-            ).asString(),
-            Matchers.allOf(
-                Matchers.startsWith("O que sera"),
-                Matchers.endsWith(" que sera")
+            ),
+            new AllOf<>(
+                new StartsWith("O que sera"),
+                new EndsWith(" que sera")
             )
         ).affirm();
     }
 
     @Test
-    void readsAnArrayOfBytes() throws Exception {
-        final byte[] bytes = new byte[] {(byte) 0xCA, (byte) 0xFE};
+    void readsAnArrayOfBytes() {
+        final byte[] bytes = new byte[]{(byte) 0xCA, (byte) 0xFE};
         new Assertion<>(
             "Can't read array of bytes",
             new TextOf(
                 bytes
-            ).asString(),
-            Matchers.equalTo(new String(bytes, StandardCharsets.UTF_8))
+            ),
+            new IsText(new String(bytes, StandardCharsets.UTF_8))
         ).affirm();
     }
 
     @Test
-    void readsStringBuilder() throws Exception {
+    void readsStringBuilder() {
         final String starts = "Name it, ";
         final String ends = "then it exists!";
         new Assertion<>(
             "Can't process a string builder",
             new TextOf(
                 new StringBuilder(starts).append(ends)
-            ).asString(),
-            Matchers.allOf(
-                Matchers.startsWith(starts),
-                Matchers.endsWith(ends)
+            ),
+            new AllOf<>(
+                new StartsWith(starts),
+                new EndsWith(ends)
             )
         ).affirm();
     }
 
     @Test
-    void readsStringBuffer() throws Exception {
+    void readsStringBuffer() {
         final String starts = "In our daily life, ";
         final String ends = "we can smile!";
         new Assertion<>(
             "Can't process a string builder hahahaha",
             new TextOf(
                 new StringBuffer(starts).append(ends)
-            ).asString(),
-            Matchers.allOf(
-                Matchers.startsWith(starts),
-                Matchers.endsWith(ends)
+            ),
+            new AllOf<>(
+                new StartsWith(starts),
+                new EndsWith(ends)
             )
         ).affirm();
     }
@@ -247,8 +236,8 @@ final class TextOfTest {
         );
         new Assertion<>(
             "Can't read inputStream",
-            new TextOf(stream).asString(),
-            Matchers.equalTo(
+            new TextOf(stream),
+            new IsText(
                 new String(content.getBytes(), StandardCharsets.UTF_8)
             )
         ).affirm();
@@ -262,8 +251,8 @@ final class TextOfTest {
         );
         new Assertion<>(
             "Can't read multiline inputStream",
-            new TextOf(stream).asString(),
-            Matchers.equalTo(content)
+            new TextOf(stream),
+            new IsText(content)
         ).affirm();
     }
 
@@ -275,8 +264,8 @@ final class TextOfTest {
         );
         new Assertion<>(
             "Can't read multiline inputStream with carriage return",
-            new TextOf(stream).asString(),
-            Matchers.equalTo(content)
+            new TextOf(stream),
+            new IsText(content)
         ).affirm();
     }
 
@@ -289,8 +278,8 @@ final class TextOfTest {
         stream.close();
         new Assertion<>(
             "Can't read closed input stream",
-            new TextOf(stream).asString(),
-            Matchers.equalTo(content)
+            new TextOf(stream),
+            new IsText(content)
         ).affirm();
     }
 
@@ -302,8 +291,8 @@ final class TextOfTest {
         );
         new Assertion<>(
             "Can't read empty input stream",
-            new TextOf(stream).asString(),
-            Matchers.equalTo(content)
+            new TextOf(stream),
+            new IsText(content)
         ).affirm();
     }
 
@@ -319,13 +308,13 @@ final class TextOfTest {
     }
 
     @Test
-    void readsIteratorToText() throws Exception {
+    void readsIteratorToText() {
         new Assertion<>(
             "Can't read Iterator to Text",
             new TextOf(
                 new IteratorOfChars("qwer")
-            ).asString(),
-            new IsEqual<>("qwer")
+            ),
+            new IsText("qwer")
         ).affirm();
     }
 
@@ -385,9 +374,8 @@ final class TextOfTest {
     void testDoesNotEqualsFalse() {
         new Assertion<>(
             "Must not equals null",
-            new TextOf("is not equals to not Text object")
-                .equals(null),
-            new IsEqual<>(false)
+            new TextOf("is not equals to not Text object"),
+            new IsNot<>(new IsNull<>())
         ).affirm();
     }
 


### PR DESCRIPTION
- Avoid calling `asString`
Releated to https://github.com/llorllale/cactoos-matchers/issues/199