### PR TITLE
(#1572) Covariance for `func.FuncWithFallback`

### DIFF
--- a/src/main/java/org/cactoos/func/FuncWithFallback.java
+++ b/src/main/java/org/cactoos/func/FuncWithFallback.java
@@ -100,7 +100,7 @@ public final class FuncWithFallback<X, Y> implements Func<X, Y> {
     /**
      * The fallbacks.
      */
-    private final Iterable<Fallback<Y>> fallbacks;
+    private final Iterable<Fallback<? extends Y>> fallbacks;
 
     /**
      * Ctor.
@@ -108,7 +108,7 @@ public final class FuncWithFallback<X, Y> implements Func<X, Y> {
      * @param fbks The fallbacks
      */
     @SafeVarargs
-    public FuncWithFallback(final Func<X, Y> fnc, final Fallback<Y>... fbks) {
+    public FuncWithFallback(final Func<X, Y> fnc, final Fallback<? extends Y>... fbks) {
         this(fnc, new IterableOf<>(fbks));
     }
 
@@ -118,7 +118,7 @@ public final class FuncWithFallback<X, Y> implements Func<X, Y> {
      * @param fbks The fallbacks
      */
     public FuncWithFallback(
-        final Func<X, Y> fnc, final Iterable<Fallback<Y>> fbks
+        final Func<X, Y> fnc, final Iterable<Fallback<? extends Y>> fbks
     ) {
         this.func = fnc;
         this.fallbacks = fbks;

--- a/src/main/java/org/cactoos/func/FuncWithFallback.java
+++ b/src/main/java/org/cactoos/func/FuncWithFallback.java
@@ -95,7 +95,7 @@ public final class FuncWithFallback<X, Y> implements Func<X, Y> {
     /**
      * The func.
      */
-    private final Func<X, Y> func;
+    private final Func<? super X, ? extends Y> func;
 
     /**
      * The fallbacks.
@@ -108,7 +108,8 @@ public final class FuncWithFallback<X, Y> implements Func<X, Y> {
      * @param fbks The fallbacks
      */
     @SafeVarargs
-    public FuncWithFallback(final Func<X, Y> fnc, final Fallback<? extends Y>... fbks) {
+    public FuncWithFallback(final Func<? super X, ? extends Y> fnc,
+        final Fallback<? extends Y>... fbks) {
         this(fnc, new IterableOf<>(fbks));
     }
 
@@ -117,9 +118,8 @@ public final class FuncWithFallback<X, Y> implements Func<X, Y> {
      * @param fnc The func
      * @param fbks The fallbacks
      */
-    public FuncWithFallback(
-        final Func<X, Y> fnc, final Iterable<Fallback<? extends Y>> fbks
-    ) {
+    public FuncWithFallback(final Func<? super X, ? extends Y> fnc,
+        final Iterable<Fallback<? extends Y>> fbks) {
         this.func = fnc;
         this.fallbacks = fbks;
     }

--- a/src/main/java/org/cactoos/func/FuncWithFallback.java
+++ b/src/main/java/org/cactoos/func/FuncWithFallback.java
@@ -100,7 +100,7 @@ public final class FuncWithFallback<X, Y> implements Func<X, Y> {
     /**
      * The fallbacks.
      */
-    private final Iterable<Fallback<? extends Y>> fallbacks;
+    private final Iterable<? extends Fallback<? extends Y>> fallbacks;
 
     /**
      * Ctor.
@@ -119,7 +119,7 @@ public final class FuncWithFallback<X, Y> implements Func<X, Y> {
      * @param fbks The fallbacks
      */
     public FuncWithFallback(final Func<? super X, ? extends Y> fnc,
-        final Iterable<Fallback<? extends Y>> fbks) {
+        final Iterable<? extends Fallback<? extends Y>> fbks) {
         this.func = fnc;
         this.fallbacks = fbks;
     }

--- a/src/main/java/org/cactoos/func/package-info.java
+++ b/src/main/java/org/cactoos/func/package-info.java
@@ -26,7 +26,7 @@
  * Functions.
  *
  * @since 0.1
- * @todo #1533:30min Exploit generic variance for package org.cactoos.func
+ * @todo #1572:30min Exploit generic variance for package org.cactoos.func
  *  to ensure typing works as best as possible as it is explained in
  *  #1533 issue.
  */

--- a/src/main/java/org/cactoos/scalar/ScalarWithFallback.java
+++ b/src/main/java/org/cactoos/scalar/ScalarWithFallback.java
@@ -49,7 +49,7 @@ public final class ScalarWithFallback<T> implements Scalar<T> {
     /**
      * The origin scalar.
      */
-    private final Scalar<T> origin;
+    private final Scalar<? extends T> origin;
 
     /**
      * The fallback.
@@ -63,7 +63,7 @@ public final class ScalarWithFallback<T> implements Scalar<T> {
      */
     @SafeVarargs
     public ScalarWithFallback(
-        final Scalar<T> origin,
+        final Scalar<? extends T> origin,
         final Fallback<? extends T>... fbks
     ) {
         this(origin, new IterableOf<>(fbks));
@@ -74,7 +74,7 @@ public final class ScalarWithFallback<T> implements Scalar<T> {
      * @param origin Original scalar
      * @param fbks Fallbacks
      */
-    public ScalarWithFallback(final Scalar<T> origin,
+    public ScalarWithFallback(final Scalar<? extends T> origin,
         final Iterable<? extends Fallback<? extends T>> fbks) {
         this.origin = origin;
         this.fallbacks = fbks;

--- a/src/main/java/org/cactoos/scalar/ScalarWithFallback.java
+++ b/src/main/java/org/cactoos/scalar/ScalarWithFallback.java
@@ -54,7 +54,7 @@ public final class ScalarWithFallback<T> implements Scalar<T> {
     /**
      * The fallback.
      */
-    private final Iterable<Fallback<? extends T>> fallbacks;
+    private final Iterable<? extends Fallback<? extends T>> fallbacks;
 
     /**
      * Ctor.
@@ -75,7 +75,7 @@ public final class ScalarWithFallback<T> implements Scalar<T> {
      * @param fbks Fallbacks
      */
     public ScalarWithFallback(final Scalar<T> origin,
-        final Iterable<Fallback<? extends T>> fbks) {
+        final Iterable<? extends Fallback<? extends T>> fbks) {
         this.origin = origin;
         this.fallbacks = fbks;
     }

--- a/src/main/java/org/cactoos/scalar/ScalarWithFallback.java
+++ b/src/main/java/org/cactoos/scalar/ScalarWithFallback.java
@@ -54,7 +54,7 @@ public final class ScalarWithFallback<T> implements Scalar<T> {
     /**
      * The fallback.
      */
-    private final Iterable<Fallback<T>> fallbacks;
+    private final Iterable<Fallback<? extends T>> fallbacks;
 
     /**
      * Ctor.
@@ -64,7 +64,7 @@ public final class ScalarWithFallback<T> implements Scalar<T> {
     @SafeVarargs
     public ScalarWithFallback(
         final Scalar<T> origin,
-        final Fallback<T>... fbks
+        final Fallback<? extends T>... fbks
     ) {
         this(origin, new IterableOf<>(fbks));
     }
@@ -75,7 +75,7 @@ public final class ScalarWithFallback<T> implements Scalar<T> {
      * @param fbks Fallbacks
      */
     public ScalarWithFallback(final Scalar<T> origin,
-        final Iterable<Fallback<T>> fbks) {
+        final Iterable<Fallback<? extends T>> fbks) {
         this.origin = origin;
         this.fallbacks = fbks;
     }
@@ -105,7 +105,7 @@ public final class ScalarWithFallback<T> implements Scalar<T> {
      */
     @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
     private T fallback(final Throwable exp) throws Exception {
-        final Iterator<Map.Entry<Fallback<T>, Integer>> candidates =
+        final Iterator<? extends Map.Entry<Fallback<? extends T>, Integer>> candidates =
             new Sorted<>(
                 Comparator.comparing(Map.Entry::getValue),
                 new Filtered<>(
@@ -117,7 +117,7 @@ public final class ScalarWithFallback<T> implements Scalar<T> {
                             )
                         )
                     ),
-                    new MapOf<>(
+                    new MapOf<Fallback<? extends T>, Integer>(
                         fbk -> fbk,
                         fbk -> fbk.support(exp),
                         this.fallbacks


### PR DESCRIPTION
For #1572:
  - Generify `ScalarWithFallback` (generify this class since `FuncWithFallback` depends on it)
  - Generify `FuncWithFallback`

Now fallbacks for `ScalarWithFallback` and `FuncWithFallback` can produce object derived types from given original type.

```java
Fallback<Long> longOnNoFile = new Fallback.From<>(FileNotFoundException.class, _t -> 0L);
Fallback<Double> doubleOnIo = new Fallback.From<>(IOException.class, _t -> 0.0);
Fallback<Integer> intOtherwise = new Fallback.From<>(Exception.class, _t -> 0);

Func<String, Number> readFileLength = new FuncOf<>(fileName -> {
  throw new IOException("Access denied. You can't read file " + fileName);
});

FuncWithFallback<String, Number> safeReadFileLength =
  new FuncWithFallback<String, Number>(
    readFileLength,
    longOnNoFile,
    doubleOnIo,
    intOtherwise
  );
```
