### PR TITLE
(#1567) Generify `org.cactoos.proc` package

### DIFF
--- a/src/main/java/org/cactoos/func/FuncOf.java
+++ b/src/main/java/org/cactoos/func/FuncOf.java
@@ -41,7 +41,7 @@ public final class FuncOf<X, Y> implements Func<X, Y> {
     /**
      * The func.
      */
-    private final Func<X, Y> func;
+    private final Func<? super X, ? extends Y> func;
 
     /**
      * Ctor.
@@ -61,7 +61,7 @@ public final class FuncOf<X, Y> implements Func<X, Y> {
      * Ctor.
      * @param scalar Origin scalar
      */
-    public FuncOf(final Scalar<Y> scalar) {
+    public FuncOf(final Scalar<? extends Y> scalar) {
         this(input -> scalar.value());
     }
 
@@ -69,7 +69,7 @@ public final class FuncOf<X, Y> implements Func<X, Y> {
      * Ctor.
      * @param fnc Func
      */
-    public FuncOf(final Func<X, Y> fnc) {
+    public FuncOf(final Func<? super X, ? extends Y> fnc) {
         this.func = fnc;
     }
 

--- a/src/main/java/org/cactoos/func/FuncOf.java
+++ b/src/main/java/org/cactoos/func/FuncOf.java
@@ -48,7 +48,7 @@ public final class FuncOf<X, Y> implements Func<X, Y> {
      * @param proc The proc
      * @param result Result to return
      */
-    public FuncOf(final Proc<X> proc, final Y result) {
+    public FuncOf(final Proc<? super X> proc, final Y result) {
         this(
             input -> {
                 proc.exec(input);

--- a/src/main/java/org/cactoos/func/Repeated.java
+++ b/src/main/java/org/cactoos/func/Repeated.java
@@ -38,7 +38,7 @@ public final class Repeated<X, Y> implements Func<X, Y> {
     /**
      * Original func.
      */
-    private final Func<X, Y> func;
+    private final Func<? super X, ? extends Y> func;
 
     /**
      * How many times to run.
@@ -54,7 +54,7 @@ public final class Repeated<X, Y> implements Func<X, Y> {
      * @param fnc Func original
      * @param max How many times
      */
-    public Repeated(final Func<X, Y> fnc, final int max) {
+    public Repeated(final Func<? super X, ? extends Y> fnc, final int max) {
         this.func = fnc;
         this.times = max;
     }

--- a/src/main/java/org/cactoos/proc/BiProcEnvelope.java
+++ b/src/main/java/org/cactoos/proc/BiProcEnvelope.java
@@ -39,13 +39,13 @@ public abstract class BiProcEnvelope<X, Y> implements BiProc<X, Y> {
     /**
      * BiProc to decorate.
      */
-    private final BiProc<X, Y> origin;
+    private final BiProc<? super X, ? super Y> origin;
 
     /**
      * Ctor.
      * @param origin The procedure
      */
-    public BiProcEnvelope(final BiProc<X, Y> origin) {
+    public BiProcEnvelope(final BiProc<? super X, ? super Y> origin) {
         this.origin = origin;
     }
 

--- a/src/main/java/org/cactoos/proc/BiProcNoNulls.java
+++ b/src/main/java/org/cactoos/proc/BiProcNoNulls.java
@@ -36,13 +36,13 @@ public final class BiProcNoNulls<X, Y> implements BiProc<X, Y> {
     /**
      * The proc.
      */
-    private final BiProc<X, Y> origin;
+    private final BiProc<? super X, ? super Y> origin;
 
     /**
      * Ctor.
      * @param proc The function
      */
-    public BiProcNoNulls(final BiProc<X, Y> proc) {
+    public BiProcNoNulls(final BiProc<? super X, ? super Y> proc) {
         this.origin = proc;
     }
 

--- a/src/main/java/org/cactoos/proc/BiProcOf.java
+++ b/src/main/java/org/cactoos/proc/BiProcOf.java
@@ -79,7 +79,7 @@ public final class BiProcOf<X, Y> extends BiProcEnvelope<X, Y> {
      * Ctor.
      * @param biprc The bi procedure
      */
-    public BiProcOf(final BiProc<X, Y> biprc) {
+    public BiProcOf(final BiProc<? super X, ? super Y> biprc) {
         super(biprc);
     }
 }

--- a/src/main/java/org/cactoos/proc/ProcEnvelope.java
+++ b/src/main/java/org/cactoos/proc/ProcEnvelope.java
@@ -38,13 +38,13 @@ public abstract class ProcEnvelope<X> implements Proc<X> {
     /**
      * Proc to decorate.
      */
-    private final Proc<X> origin;
+    private final Proc<? super X> origin;
 
     /**
      * Ctor.
      * @param origin The procedure
      */
-    public ProcEnvelope(final Proc<X> origin) {
+    public ProcEnvelope(final Proc<? super X> origin) {
         this.origin = origin;
     }
 

--- a/src/main/java/org/cactoos/proc/ProcNoNulls.java
+++ b/src/main/java/org/cactoos/proc/ProcNoNulls.java
@@ -35,13 +35,13 @@ public final class ProcNoNulls<X> implements Proc<X> {
     /**
      * The procedure.
      */
-    private final Proc<X> origin;
+    private final Proc<? super X> origin;
 
     /**
      * Ctor.
      * @param proc The procedure
      */
-    public ProcNoNulls(final Proc<X> proc) {
+    public ProcNoNulls(final Proc<? super X> proc) {
         this.origin = proc;
     }
 

--- a/src/main/java/org/cactoos/proc/ProcOf.java
+++ b/src/main/java/org/cactoos/proc/ProcOf.java
@@ -40,7 +40,7 @@ public final class ProcOf<X> extends ProcEnvelope<X> {
      * Ctor.
      * @param fnc The proc
      */
-    public ProcOf(final Func<X, ?> fnc) {
+    public ProcOf(final Func<? super X, ?> fnc) {
         this(
             input -> {
                 fnc.apply(input);
@@ -52,7 +52,7 @@ public final class ProcOf<X> extends ProcEnvelope<X> {
      * Ctor.
      * @param prc The proc
      */
-    public ProcOf(final Proc<X> prc) {
+    public ProcOf(final Proc<? super X> prc) {
         super(prc);
     }
 }

--- a/src/main/java/org/cactoos/proc/RepeatedProc.java
+++ b/src/main/java/org/cactoos/proc/RepeatedProc.java
@@ -38,7 +38,7 @@ public final class RepeatedProc<X> implements Proc<X> {
     /**
      * The repeated func.
      */
-    private final Func<X, Boolean> func;
+    private final Func<? super X, Boolean> func;
 
     /**
      * Ctor.
@@ -49,7 +49,7 @@ public final class RepeatedProc<X> implements Proc<X> {
      * @param prc Proc to repeat.
      * @param count How many times.
      */
-    public RepeatedProc(final Proc<X> prc, final int count) {
+    public RepeatedProc(final Proc<? super X> prc, final int count) {
         this.func = new Repeated<>(
             new FuncOf<>(prc, true),
             count

--- a/src/main/java/org/cactoos/proc/package-info.java
+++ b/src/main/java/org/cactoos/proc/package-info.java
@@ -26,7 +26,7 @@
  * Procedures.
  *
  * @since 0.47
- * @todo #1533:30min Exploit generic variance for package org.cactoos.proc
+ * @todo #1567:30min Exploit generic variance for package org.cactoos.proc
  *  to ensure typing works as best as possible as it is explained in
  *  #1533 issue.
  */


### PR DESCRIPTION
For #1567:

Generify incoming parameters (use `? super T`) for next classes:
- `ProcOf`, `ProcEnvelope` and `FuncOf`
- `ProcNoNulls`
- `BiProcOf` and `BiProcEnvelope`
- `BiProcNoNulls`
- `RepeatedProc` and `Repeated`

