### PR TITLE
(#1565) Improve generic variance for `org.cactoos.iterator`

### DIFF
--- a/src/main/java/org/cactoos/iterator/IteratorEnvelope.java
+++ b/src/main/java/org/cactoos/iterator/IteratorEnvelope.java
@@ -39,13 +39,13 @@ public abstract class IteratorEnvelope<X> implements Iterator<X> {
     /**
      * Wrapped {@link Iterator}.
      */
-    private final Iterator<X> wrapped;
+    private final Iterator<? extends X> wrapped;
 
     /**
      * Ctor.
      * @param iter The {@link Iterator} to wrap.
      */
-    public IteratorEnvelope(final Iterator<X> iter) {
+    public IteratorEnvelope(final Iterator<? extends X> iter) {
         this.wrapped = iter;
     }
 

--- a/src/main/java/org/cactoos/iterator/NoNulls.java
+++ b/src/main/java/org/cactoos/iterator/NoNulls.java
@@ -41,7 +41,7 @@ public final class NoNulls<X> implements Iterator<X> {
     /**
      * Iterator.
      */
-    private final Iterator<X> iterator;
+    private final Iterator<? extends X> iterator;
 
     /**
      * Position.
@@ -52,7 +52,7 @@ public final class NoNulls<X> implements Iterator<X> {
      * Ctor.
      * @param src Source iterable
      */
-    public NoNulls(final Iterator<X> src) {
+    public NoNulls(final Iterator<? extends X> src) {
         this.iterator = src;
         this.pos = new AtomicLong();
     }

--- a/src/main/java/org/cactoos/iterator/Shuffled.java
+++ b/src/main/java/org/cactoos/iterator/Shuffled.java
@@ -51,7 +51,7 @@ public final class Shuffled<T> implements Iterator<T> {
      * Ctor.
      * @param iterator The original iterator
      */
-    public Shuffled(final Iterator<T> iterator) {
+    public Shuffled(final Iterator<? extends T> iterator) {
         this(new SecureRandom(), iterator);
     }
 
@@ -60,7 +60,7 @@ public final class Shuffled<T> implements Iterator<T> {
      * @param random Randomizer.
      * @param iterator The original iterator
      */
-    public Shuffled(final Random random, final Iterator<T> iterator) {
+    public Shuffled(final Random random, final Iterator<? extends T> iterator) {
         this.scalar = new Unchecked<>(
             new Sticky<>(
                 () -> {

--- a/src/main/java/org/cactoos/iterator/Skipped.java
+++ b/src/main/java/org/cactoos/iterator/Skipped.java
@@ -38,14 +38,14 @@ public final class Skipped<T> implements Iterator<T> {
     /**
      * Sliced iterator.
      */
-    private final Iterator<T> sliced;
+    private final Iterator<? extends T> sliced;
 
     /**
      * Ctor.
      * @param skp Count skip elements
      * @param iterator Decorated iterator
      */
-    public Skipped(final int skp, final Iterator<T> iterator) {
+    public Skipped(final int skp, final Iterator<? extends T> iterator) {
         this.sliced = new Sliced<>(skp, iterator);
     }
 

--- a/src/main/java/org/cactoos/iterator/Sliced.java
+++ b/src/main/java/org/cactoos/iterator/Sliced.java
@@ -77,7 +77,7 @@ public final class Sliced<T> implements Iterator<T> {
      * @param start Starting index
      * @param iterator Decorated iterator
      */
-    public Sliced(final int start, final Iterator<T> iterator) {
+    public Sliced(final int start, final Iterator<? extends T> iterator) {
         this(start, any -> !iterator.hasNext(), iterator);
     }
 

--- a/src/main/java/org/cactoos/iterator/Sorted.java
+++ b/src/main/java/org/cactoos/iterator/Sorted.java
@@ -55,7 +55,7 @@ public final class Sorted<T> implements Iterator<T> {
      * @param items The underlying iterator
      */
     @SuppressWarnings("unchecked")
-    public Sorted(final Iterator<T> items) {
+    public Sorted(final Iterator<? extends T> items) {
         this((Comparator<T>) Comparator.naturalOrder(), items);
     }
 

--- a/src/main/java/org/cactoos/iterator/Synced.java
+++ b/src/main/java/org/cactoos/iterator/Synced.java
@@ -46,7 +46,7 @@ public final class Synced<T> implements Iterator<T> {
     /**
      * The original iterator.
      */
-    private final Iterator<T> iterator;
+    private final Iterator<? extends T> iterator;
 
     /**
      * The lock to use.
@@ -57,7 +57,7 @@ public final class Synced<T> implements Iterator<T> {
      * Ctor.
      * @param iterator The iterator to synchronize access to.
      */
-    public Synced(final Iterator<T> iterator) {
+    public Synced(final Iterator<? extends T> iterator) {
         this(new ReentrantReadWriteLock(), iterator);
     }
 
@@ -66,7 +66,7 @@ public final class Synced<T> implements Iterator<T> {
      * @param lock The lock to use for synchronization.
      * @param iterator The iterator to synchronize access to.
      */
-    public Synced(final ReadWriteLock lock, final Iterator<T> iterator) {
+    public Synced(final ReadWriteLock lock, final Iterator<? extends T> iterator) {
         this.iterator = iterator;
         this.lock = lock;
     }


### PR DESCRIPTION
For #1565:

Add covariant constructor params for

- `IteratorEnvelope`
- `Synced`
- `Sorted`
- `Skipped`
- `Sliced`
- `Shuffled`
- `NoNulls`
