### PR TITLE
(#1574) Generify `org.cactoos.text`

### DIFF
--- a/src/main/java/org/cactoos/text/Abbreviated.java
+++ b/src/main/java/org/cactoos/text/Abbreviated.java
@@ -76,7 +76,7 @@ public final class Abbreviated extends TextEnvelope {
      * @param text A String
      * @param max Max width of the result string
      */
-    public Abbreviated(final String text, final int max) {
+    public Abbreviated(final CharSequence text, final int max) {
         this(new TextOf(text), max);
     }
 

--- a/src/main/java/org/cactoos/text/Abbreviated.java
+++ b/src/main/java/org/cactoos/text/Abbreviated.java
@@ -73,7 +73,7 @@ public final class Abbreviated extends TextEnvelope {
     /**
      * Ctor.
      *
-     * @param text A String
+     * @param text A CharSequence
      * @param max Max width of the result string
      */
     public Abbreviated(final CharSequence text, final int max) {

--- a/src/main/java/org/cactoos/text/Flattened.java
+++ b/src/main/java/org/cactoos/text/Flattened.java
@@ -39,7 +39,7 @@ public final class Flattened extends TextEnvelope {
      * Ctor.
      * @param sclr The text
      */
-    public Flattened(final Scalar<Text> sclr) {
+    public Flattened(final Scalar<? extends Text> sclr) {
         super(new TextOf(new Mapped<>(Text::asString, sclr)));
     }
 }

--- a/src/main/java/org/cactoos/text/FormattedText.java
+++ b/src/main/java/org/cactoos/text/FormattedText.java
@@ -94,7 +94,7 @@ public final class FormattedText extends TextEnvelope {
      * @param ptn Pattern
      * @param arguments Arguments
      */
-    public FormattedText(final CharSequence ptn, final Collection<Object> arguments) {
+    public FormattedText(final CharSequence ptn, final Collection<?> arguments) {
         this(ptn, Locale.getDefault(Locale.Category.FORMAT), arguments);
     }
 
@@ -104,7 +104,7 @@ public final class FormattedText extends TextEnvelope {
      * @param ptn Pattern
      * @param arguments Arguments
      */
-    public FormattedText(final Text ptn, final Collection<Object> arguments) {
+    public FormattedText(final Text ptn, final Collection<?> arguments) {
         this(ptn, Locale.getDefault(Locale.Category.FORMAT), arguments);
     }
 
@@ -118,7 +118,7 @@ public final class FormattedText extends TextEnvelope {
     public FormattedText(
         final CharSequence ptn,
         final Locale locale,
-        final Collection<Object> arguments
+        final Collection<?> arguments
     ) {
         this(new TextOf(ptn), locale, arguments);
     }
@@ -133,7 +133,7 @@ public final class FormattedText extends TextEnvelope {
     public FormattedText(
         final Text ptn,
         final Locale locale,
-        final Collection<Object> args
+        final Collection<?> args
     ) {
         super(
             new Mapped(

--- a/src/main/java/org/cactoos/text/FormattedText.java
+++ b/src/main/java/org/cactoos/text/FormattedText.java
@@ -104,7 +104,7 @@ public final class FormattedText extends TextEnvelope {
      * @param ptn Pattern
      * @param arguments Arguments
      */
-    public FormattedText(final Text ptn, final Collection<?> arguments) {
+    public FormattedText(final Text ptn, final Collection<Object> arguments) {
         this(ptn, Locale.getDefault(Locale.Category.FORMAT), arguments);
     }
 

--- a/src/main/java/org/cactoos/text/Joined.java
+++ b/src/main/java/org/cactoos/text/Joined.java
@@ -72,7 +72,7 @@ public final class Joined extends TextEnvelope {
      * @param delimit Delimit among texts
      * @param txts Texts to be joined
      */
-    public Joined(final String delimit, final Text... txts) {
+    public Joined(final CharSequence delimit, final Text... txts) {
         this(new TextOf(delimit), new IterableOf<>(txts));
     }
 

--- a/src/main/java/org/cactoos/text/Mapped.java
+++ b/src/main/java/org/cactoos/text/Mapped.java
@@ -25,7 +25,6 @@ package org.cactoos.text;
 
 import org.cactoos.Func;
 import org.cactoos.Text;
-import org.cactoos.func.FuncOf;
 
 /**
  * Mapped text.

--- a/src/main/java/org/cactoos/text/Mapped.java
+++ b/src/main/java/org/cactoos/text/Mapped.java
@@ -25,6 +25,7 @@ package org.cactoos.text;
 
 import org.cactoos.Func;
 import org.cactoos.Text;
+import org.cactoos.func.FuncOf;
 
 /**
  * Mapped text.
@@ -39,7 +40,8 @@ public final class Mapped extends TextEnvelope {
      * @param fnc Function to apply
      * @param txt Original text
      */
-    public Mapped(final Func<String, ? extends CharSequence> fnc, final Text txt) {
+    public Mapped(final Func<? super String, ? extends CharSequence> fnc,
+        final Text txt) {
         super(new TextOf(() -> fnc.apply(txt.asString())));
     }
 

--- a/src/main/java/org/cactoos/text/Replaced.java
+++ b/src/main/java/org/cactoos/text/Replaced.java
@@ -49,10 +49,10 @@ public final class Replaced extends TextEnvelope {
      */
     public Replaced(
         final Text text,
-        final String find,
-        final String replace
+        final CharSequence find,
+        final CharSequence replace
     ) {
-        this(text, () -> Pattern.compile(find), matcher -> replace);
+        this(text, () -> Pattern.compile(find.toString()), matcher -> replace);
     }
 
     /**

--- a/src/main/java/org/cactoos/text/Replaced.java
+++ b/src/main/java/org/cactoos/text/Replaced.java
@@ -82,7 +82,7 @@ public final class Replaced extends TextEnvelope {
     public Replaced(
         final Text text,
         final Scalar<Pattern> regex,
-        final Func<? super Matcher, String> func
+        final Func<? super Matcher, ? extends CharSequence> func
     ) {
         super(
             new Mapped(
@@ -92,7 +92,7 @@ public final class Replaced extends TextEnvelope {
                     while (matcher.find()) {
                         matcher.appendReplacement(
                             buffer,
-                            func.apply(matcher)
+                            func.apply(matcher).toString()
                         );
                     }
                     matcher.appendTail(buffer);

--- a/src/main/java/org/cactoos/text/Replaced.java
+++ b/src/main/java/org/cactoos/text/Replaced.java
@@ -82,7 +82,7 @@ public final class Replaced extends TextEnvelope {
     public Replaced(
         final Text text,
         final Scalar<Pattern> regex,
-        final Func<Matcher, String> func
+        final Func<? super Matcher, String> func
     ) {
         super(
             new Mapped(

--- a/src/main/java/org/cactoos/text/Split.java
+++ b/src/main/java/org/cactoos/text/Split.java
@@ -77,7 +77,7 @@ public final class Split extends IterableEnvelope<Text> {
      * @param lmt The limit
      * @see String#split(String, int)
      */
-    public Split(final String text, final Text rgx, final int lmt) {
+    public Split(final CharSequence text, final Text rgx, final int lmt) {
         this(new TextOf(text), rgx, lmt);
     }
 

--- a/src/main/java/org/cactoos/text/Split.java
+++ b/src/main/java/org/cactoos/text/Split.java
@@ -98,7 +98,7 @@ public final class Split extends IterableEnvelope<Text> {
      * @param lmt The limit
      * @see String#split(String, int)
      */
-    public Split(final Text text, final String rgx, final int lmt) {
+    public Split(final Text text, final CharSequence rgx, final int lmt) {
         this(text, new TextOf(rgx), lmt);
     }
 

--- a/src/main/java/org/cactoos/text/Strict.java
+++ b/src/main/java/org/cactoos/text/Strict.java
@@ -50,7 +50,7 @@ public final class Strict extends TextEnvelope {
      * @param predicate The Func as a predicate
      * @param origin The Text
      */
-    public Strict(final Func<String, Boolean> predicate, final Text origin) {
+    public Strict(final Func<? super String, Boolean> predicate, final Text origin) {
         super(
             new Mapped(
                 str -> {

--- a/src/main/java/org/cactoos/text/Sub.java
+++ b/src/main/java/org/cactoos/text/Sub.java
@@ -79,7 +79,7 @@ public final class Sub extends TextEnvelope {
      * @param text The Text
      * @param strt Start position in the text
      */
-    public Sub(final Text text, final Func<String, Integer> strt) {
+    public Sub(final Text text, final Func<? super String, Integer> strt) {
         this(text, strt, String::length);
     }
 
@@ -109,7 +109,8 @@ public final class Sub extends TextEnvelope {
      * @param strt Start position in the text
      * @param finish End position in the text
      */
-    public Sub(final Text text, final int strt, final Func<String, Integer> finish) {
+    public Sub(final Text text, final int strt,
+        final Func<? super String, Integer> finish) {
         this(text, new Constant<>(strt), finish);
     }
 
@@ -131,7 +132,7 @@ public final class Sub extends TextEnvelope {
      * @param finish End position in the text
      */
     public Sub(final Text text, final Scalar<Integer> strt,
-        final Func<String, Integer> finish) {
+        final Func<? super String, Integer> finish) {
         this(text, new FuncOf<>(strt), finish);
     }
 
@@ -141,8 +142,8 @@ public final class Sub extends TextEnvelope {
      * @param start Start position in the text
      * @param end End position in the text
      */
-    public Sub(final Text text, final Func<String, Integer> start,
-        final Func<String, Integer> end) {
+    public Sub(final Text text, final Func<? super String, Integer> start,
+        final Func<? super String, Integer> end) {
         super(
             new Mapped(
                 origin -> {

--- a/src/main/java/org/cactoos/text/UncheckedText.java
+++ b/src/main/java/org/cactoos/text/UncheckedText.java
@@ -54,7 +54,7 @@ public final class UncheckedText implements Text {
      * @param txt Encapsulated text
      * @since 0.9
      */
-    public UncheckedText(final String txt) {
+    public UncheckedText(final CharSequence txt) {
         this(new TextOf(txt));
     }
 

--- a/src/main/java/org/cactoos/text/package-info.java
+++ b/src/main/java/org/cactoos/text/package-info.java
@@ -26,8 +26,5 @@
  * Text.
  *
  * @since 0.1
- * @todo #1533:30min Exploit generic variance for package org.cactoos.text
- *  to ensure typing works as best as possible as it is explained in
- *  #1533 issue.
  */
 package org.cactoos.text;

--- a/src/test/java/org/cactoos/text/StrictTest.java
+++ b/src/test/java/org/cactoos/text/StrictTest.java
@@ -49,7 +49,7 @@ final class StrictTest {
             seq -> seq.length() > 3
         );
         new Assertion<>(
-            "Given strings are not equal",
+            "Must be equal strings",
             new Strict(longerThanThree, new TextOf("sequence")),
             new IsText("sequence")
         ).affirm();

--- a/src/test/java/org/cactoos/text/StrictTest.java
+++ b/src/test/java/org/cactoos/text/StrictTest.java
@@ -45,12 +45,12 @@ final class StrictTest {
      */
     @Test
     void acceptsCharSequencePredicate() {
-        final Func<CharSequence, Boolean> longerThanThree = new FuncOf<>(
+        final Func<CharSequence, Boolean> lengthy = new FuncOf<>(
             seq -> seq.length() > 3
         );
         new Assertion<>(
             "Must be equal strings",
-            new Strict(longerThanThree, new TextOf("sequence")),
+            new Strict(lengthy, new TextOf("sequence")),
             new IsText("sequence")
         ).affirm();
     }

--- a/src/test/java/org/cactoos/text/StrictTest.java
+++ b/src/test/java/org/cactoos/text/StrictTest.java
@@ -24,6 +24,8 @@
 package org.cactoos.text;
 
 import java.util.regex.Pattern;
+import org.cactoos.Func;
+import org.cactoos.func.FuncOf;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.IsText;
@@ -37,6 +39,21 @@ import org.llorllale.cactoos.matchers.Throws;
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class StrictTest {
+
+    /**
+     * Ensures that Strict accepts a CharSequence predicate.
+     */
+    @Test
+    void acceptsCharSequencePredicate() {
+        final Func<CharSequence, Boolean> longerThanThree = new FuncOf<>(
+            seq -> seq.length() > 3
+        );
+        new Assertion<>(
+            "Given strings are not equal",
+            new Strict(longerThanThree, new TextOf("sequence")),
+            new IsText("sequence")
+        ).affirm();
+    }
 
     /**
      * Ensures that Strict is failing on a negative predicate result.

--- a/src/test/java/org/cactoos/text/SubTest.java
+++ b/src/test/java/org/cactoos/text/SubTest.java
@@ -39,12 +39,12 @@ final class SubTest {
 
     @Test
     void acceptsCharSequence() {
-        final Func<CharSequence, Integer> halfLength = new FuncOf<>(
+        final Func<CharSequence, Integer> half = new FuncOf<>(
             sequence -> sequence.length() / 2
         );
         new Assertion<>(
             "Must cut a text with start",
-            new Sub(new TextOf("sequence"), halfLength),
+            new Sub(new TextOf("sequence"), half),
             new IsText("ence")
         ).affirm();
     }

--- a/src/test/java/org/cactoos/text/SubTest.java
+++ b/src/test/java/org/cactoos/text/SubTest.java
@@ -43,7 +43,7 @@ final class SubTest {
             sequence -> sequence.length() / 2
         );
         new Assertion<>(
-            "Can't cut a text with start",
+            "Must cut a text with start",
             new Sub(new TextOf("sequence"), halfLength),
             new IsText("ence")
         ).affirm();

--- a/src/test/java/org/cactoos/text/SubTest.java
+++ b/src/test/java/org/cactoos/text/SubTest.java
@@ -23,9 +23,12 @@
  */
 package org.cactoos.text;
 
+import org.cactoos.Func;
+import org.cactoos.func.FuncOf;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasString;
+import org.llorllale.cactoos.matchers.IsText;
 
 /**
  * Test case for {@link Sub}.
@@ -33,6 +36,18 @@ import org.llorllale.cactoos.matchers.HasString;
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 final class SubTest {
+
+    @Test
+    void acceptsCharSequence() {
+        final Func<CharSequence, Integer> halfLength = new FuncOf<>(
+            sequence -> sequence.length() / 2
+        );
+        new Assertion<>(
+            "Can't cut a text with start",
+            new Sub(new TextOf("sequence"), halfLength),
+            new IsText("ence")
+        ).affirm();
+    }
 
     @Test
     void cutTextWithStartAndEnd() {


### PR DESCRIPTION
For #1574:

- Use `CharSequence` instead of `String` when possible
- Generic covariance for `Flattened`
- Wildcards for `Collection` if type parameter doesn't matter
- Counter-variance for `Func`
