### PR TITLE
(#1568) Generify org.cactoos.iterable package

### DIFF
--- a/src/main/java/org/cactoos/iterable/IterableOf.java
+++ b/src/main/java/org/cactoos/iterable/IterableOf.java
@@ -49,7 +49,7 @@ public final class IterableOf<X> implements Iterable<X> {
     /**
      * The encapsulated iterator.
      */
-    private final Scalar<Iterator<? extends X>> itr;
+    private final Scalar<? extends Iterator<? extends X>> itr;
 
     /**
      * Ctor.
@@ -73,7 +73,7 @@ public final class IterableOf<X> implements Iterable<X> {
      * Ctor.
      * @param sclr The encapsulated iterator of x
      */
-    public IterableOf(final Scalar<Iterator<? extends X>> sclr) {
+    public IterableOf(final Scalar<? extends Iterator<? extends X>> sclr) {
         this.itr = sclr;
     }
 

--- a/src/main/java/org/cactoos/iterable/Joined.java
+++ b/src/main/java/org/cactoos/iterable/Joined.java
@@ -23,8 +23,6 @@
  */
 package org.cactoos.iterable;
 
-import org.cactoos.list.ListOf;
-
 import java.util.Iterator;
 
 /**

--- a/src/main/java/org/cactoos/iterable/Joined.java
+++ b/src/main/java/org/cactoos/iterable/Joined.java
@@ -23,6 +23,8 @@
  */
 package org.cactoos.iterable;
 
+import org.cactoos.list.ListOf;
+
 import java.util.Iterator;
 
 /**
@@ -59,7 +61,7 @@ public final class Joined<T> extends IterableEnvelope<T> {
      * Ctor.
      * @param items Items to concatenate
      */
-    public Joined(final Iterable<Iterable<? extends T>> items) {
+    public Joined(final Iterable<? extends Iterable<? extends T>> items) {
         super(
             new IterableOf<>(
                 () -> new org.cactoos.iterator.Joined<>(

--- a/src/main/java/org/cactoos/iterable/NoNulls.java
+++ b/src/main/java/org/cactoos/iterable/NoNulls.java
@@ -38,13 +38,13 @@ public final class NoNulls<X> implements Iterable<X> {
     /**
      * Original iterable.
      */
-    private final Iterable<X> origin;
+    private final Iterable<? extends X> origin;
 
     /**
      * Ctor.
      * @param items The items
      */
-    public NoNulls(final Iterable<X> items) {
+    public NoNulls(final Iterable<? extends X> items) {
         this.origin = items;
     }
 

--- a/src/main/java/org/cactoos/iterable/Partitioned.java
+++ b/src/main/java/org/cactoos/iterable/Partitioned.java
@@ -48,7 +48,7 @@ public final class Partitioned<T> extends IterableEnvelope<List<T>> {
      * @param size The partitions size.
      * @param iterable The source {@link Iterable}.
      */
-    public Partitioned(final int size, final Iterable<T> iterable) {
+    public Partitioned(final int size, final Iterable<? extends T> iterable) {
         super(
             new IterableOf<>(
                 () -> new org.cactoos.iterator.Partitioned<>(

--- a/src/main/java/org/cactoos/iterable/RangeOf.java
+++ b/src/main/java/org/cactoos/iterable/RangeOf.java
@@ -39,7 +39,8 @@ public final class
      * @param max End of the range.
      * @param incrementor The {@link Func} to process for the next value.
      */
-    public RangeOf(final T min, final T max, final Func<T, T> incrementor) {
+    public RangeOf(final T min, final T max,
+        final Func<? super T, ? extends T> incrementor) {
         super(
             new IterableOf<>(
                 () -> new org.cactoos.iterator.RangeOf<>(min, max, incrementor)

--- a/src/main/java/org/cactoos/iterable/Repeated.java
+++ b/src/main/java/org/cactoos/iterable/Repeated.java
@@ -49,7 +49,7 @@ public final class Repeated<T> extends IterableEnvelope<T> {
      * @param total The total number of repetitions
      * @param elm The element to repeat
      */
-    public Repeated(final int total, final Scalar<T> elm) {
+    public Repeated(final int total, final Scalar<? extends T> elm) {
         super(
             new IterableOf<>(
                 () -> new org.cactoos.iterator.Repeated<>(total, elm)

--- a/src/main/java/org/cactoos/iterable/Shuffled.java
+++ b/src/main/java/org/cactoos/iterable/Shuffled.java
@@ -50,7 +50,7 @@ public final class Shuffled<T> extends IterableEnvelope<T> {
      * Ctor.
      * @param src The underlying iterable
      */
-    public Shuffled(final Iterable<T> src) {
+    public Shuffled(final Iterable<? extends T> src) {
         this(new SecureRandom(), src);
     }
 
@@ -59,7 +59,7 @@ public final class Shuffled<T> extends IterableEnvelope<T> {
      * @param rnd Randomizer.
      * @param src The underlying iterable
      */
-    public Shuffled(final Random rnd, final Iterable<T> src) {
+    public Shuffled(final Random rnd, final Iterable<? extends T> src) {
         super(
             new IterableOf<>(
                 () -> new org.cactoos.iterator.Shuffled<>(

--- a/src/main/java/org/cactoos/iterable/Skipped.java
+++ b/src/main/java/org/cactoos/iterable/Skipped.java
@@ -48,7 +48,7 @@ public final class Skipped<T> extends IterableEnvelope<T> {
      * @param skip Count skip elements
      * @param iterable Decorated iterable
      */
-    public Skipped(final int skip, final Iterable<T> iterable) {
+    public Skipped(final int skip, final Iterable<? extends T> iterable) {
         super(
             new IterableOf<>(
                 () -> new org.cactoos.iterator.Skipped<>(

--- a/src/main/java/org/cactoos/iterable/Sliced.java
+++ b/src/main/java/org/cactoos/iterable/Sliced.java
@@ -51,7 +51,7 @@ public final class Sliced<T> extends IterableEnvelope<T>  {
      * @param iterable Decorated iterable
      */
     public Sliced(final int start, final int count,
-        final Iterable<T> iterable) {
+        final Iterable<? extends T> iterable) {
         super(
             new IterableOf<>(
                 () -> new org.cactoos.iterator.Sliced<>(

--- a/src/main/java/org/cactoos/iterable/package-info.java
+++ b/src/main/java/org/cactoos/iterable/package-info.java
@@ -26,8 +26,5 @@
  * Iterables.
  *
  * @since 0.12
- * @todo #1533:30min Exploit generic variance for package org.cactoos.iterable
- *  to ensure typing works as best as possible as it is explained in
- *  #1533 issue.
  */
 package org.cactoos.iterable;


### PR DESCRIPTION
For #1568.

Generify parameter types in constructors of `org.cactoos.iterable` package classses:

- IterableOf
- Joined
- NoNulls
- Partitioned
- RangeOf
- Repeated
- Shuffled
- Skipped
- Sliced
