### PR TITLE
(#1575) Generify `org.cactoos.collection` package

### DIFF
--- a/src/main/java/org/cactoos/collection/Immutable.java
+++ b/src/main/java/org/cactoos/collection/Immutable.java
@@ -25,7 +25,6 @@ package org.cactoos.collection;
 
 import java.util.Collection;
 import java.util.Iterator;
-import org.cactoos.iterable.IterableOf;
 
 /**
  * Decorator that doesn't allow any mutation of the wrapped {@link Collection}.
@@ -71,7 +70,7 @@ public final class Immutable<X> implements Collection<X> {
 
     @Override
     public Iterator<X> iterator() {
-        return new IterableOf<X>(this.col.iterator()).iterator();
+        return new org.cactoos.iterator.Immutable<>(this.col.iterator());
     }
 
     @Override

--- a/src/main/java/org/cactoos/collection/Immutable.java
+++ b/src/main/java/org/cactoos/collection/Immutable.java
@@ -54,8 +54,8 @@ public final class Immutable<X> implements Collection<X> {
      * Ctor.
      * @param src Source collection
      */
-    public Immutable(final Collection<X> src) {
-        this.col = src;
+    public Immutable(final Collection<? extends X> src) {
+        this.col = (Collection<X>) src;
     }
 
     @Override

--- a/src/main/java/org/cactoos/collection/Immutable.java
+++ b/src/main/java/org/cactoos/collection/Immutable.java
@@ -25,6 +25,7 @@ package org.cactoos.collection;
 
 import java.util.Collection;
 import java.util.Iterator;
+import org.cactoos.iterable.IterableOf;
 
 /**
  * Decorator that doesn't allow any mutation of the wrapped {@link Collection}.
@@ -48,15 +49,14 @@ public final class Immutable<X> implements Collection<X> {
     /**
      * Original collection.
      */
-    private final Collection<X> col;
+    private final Collection<? extends X> col;
 
     /**
      * Ctor.
      * @param src Source collection
      */
-    @SuppressWarnings("unchecked")
     public Immutable(final Collection<? extends X> src) {
-        this.col = (Collection<X>) src;
+        this.col = src;
     }
 
     @Override
@@ -71,7 +71,7 @@ public final class Immutable<X> implements Collection<X> {
 
     @Override
     public Iterator<X> iterator() {
-        return this.col.iterator();
+        return new IterableOf<X>(this.col.iterator()).iterator();
     }
 
     @Override

--- a/src/main/java/org/cactoos/collection/Immutable.java
+++ b/src/main/java/org/cactoos/collection/Immutable.java
@@ -54,6 +54,7 @@ public final class Immutable<X> implements Collection<X> {
      * Ctor.
      * @param src Source collection
      */
+    @SuppressWarnings("unchecked")
     public Immutable(final Collection<? extends X> src) {
         this.col = (Collection<X>) src;
     }

--- a/src/main/java/org/cactoos/collection/NoNulls.java
+++ b/src/main/java/org/cactoos/collection/NoNulls.java
@@ -48,6 +48,7 @@ public final class NoNulls<X> implements Collection<X> {
      * Ctor.
      * @param items Original one
      */
+    @SuppressWarnings("unchecked")
     public NoNulls(final Collection<? extends X> items) {
         this.col = (Collection<X>) items;
     }

--- a/src/main/java/org/cactoos/collection/NoNulls.java
+++ b/src/main/java/org/cactoos/collection/NoNulls.java
@@ -47,10 +47,13 @@ public final class NoNulls<X> implements Collection<X> {
     /**
      * Ctor.
      * @param items Original one
+     * @implNote There's no wildcard for 'X' type parameter because of mutable
+     *  nature of the collection, the user can break the runtime,
+     *  using Collection&lt;X&gt;<b>::add*</b> methods, created from
+     *  Collection&lt;? extends X&gt;
      */
-    @SuppressWarnings("unchecked")
-    public NoNulls(final Collection<? extends X> items) {
-        this.col = (Collection<X>) items;
+    public NoNulls(final Collection<X> items) {
+        this.col = items;
     }
 
     @Override

--- a/src/main/java/org/cactoos/collection/NoNulls.java
+++ b/src/main/java/org/cactoos/collection/NoNulls.java
@@ -48,8 +48,8 @@ public final class NoNulls<X> implements Collection<X> {
      * Ctor.
      * @param items Original one
      */
-    public NoNulls(final Collection<X> items) {
-        this.col = items;
+    public NoNulls(final Collection<? extends X> items) {
+        this.col = (Collection<X>) items;
     }
 
     @Override

--- a/src/main/java/org/cactoos/collection/NoNulls.java
+++ b/src/main/java/org/cactoos/collection/NoNulls.java
@@ -45,12 +45,14 @@ public final class NoNulls<X> implements Collection<X> {
     private final Collection<X> col;
 
     /**
-     * Ctor.
-     * @param items Original one
-     * @implNote There's no wildcard for 'X' type parameter because of mutable
-     *  nature of the collection, the user can break the runtime,
-     *  using Collection&lt;X&gt;<b>::add*</b> methods, created from
-     *  Collection&lt;? extends X&gt;
+     * Ctor without '? extends X' wildcard because of the issue:
+     *  <ol>
+     *      <li>The client gets Collection of X</li>
+     *      <li>The client adds item of X to it</li>
+     *      <li>The client queries items of original Collection of ? extends X</li>
+     *      <li>Runtime exception occurs</li>
+     *  </ol>
+     * @param items Original one.
      */
     public NoNulls(final Collection<X> items) {
         this.col = items;

--- a/src/main/java/org/cactoos/collection/package-info.java
+++ b/src/main/java/org/cactoos/collection/package-info.java
@@ -26,8 +26,5 @@
  * Collections, tests.
  *
  * @since 0.14
- * @todo #1533:30min Continue to exploit generic variance for package
- *  org.cactoos.collection to ensure typing works as best as
- *  possible as it is explained in #1533 issue.
  */
 package org.cactoos.collection;

--- a/src/test/java/org/cactoos/collection/NoNullsTest.java
+++ b/src/test/java/org/cactoos/collection/NoNullsTest.java
@@ -25,8 +25,13 @@ package org.cactoos.collection;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import org.cactoos.Text;
+import org.cactoos.func.FuncOf;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.list.ListOf;
+import org.cactoos.text.Capitalized;
+import org.cactoos.text.Split;
+import org.cactoos.text.TextOfString;
 import org.hamcrest.collection.IsEmptyCollection;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNot;
@@ -293,6 +298,32 @@ final class NoNullsTest {
             "Must not be empty after an item was added",
             col.isEmpty(),
             new IsNot<>(new IsTrue())
+        ).affirm();
+    }
+
+    @Test
+    void addsAllAfterBeingActuallyDownCasted() throws Exception {
+        new Assertion<>(
+            "Must allAll when being casted to Collection<Text> by unchecked cast",
+            new FuncOf<Collection<Text>, Collection<Text>>(
+                texts -> {
+                    texts.addAll(
+                        new ListOf<Capitalized>(
+                            new Capitalized("c"),
+                            new Capitalized("d")
+                        )
+                    );
+                    return texts;
+                }
+            ).apply(
+                new NoNulls<>(
+                    new ListOf<TextOfString>(
+                        new TextOfString("a"),
+                        new TextOfString("b")
+                    )
+                )
+            ),
+            new IsEqual<>(new ListOf<>(new Split("a, b, C, D", ", ")))
         ).affirm();
     }
 

--- a/src/test/java/org/cactoos/collection/NoNullsTest.java
+++ b/src/test/java/org/cactoos/collection/NoNullsTest.java
@@ -25,13 +25,8 @@ package org.cactoos.collection;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import org.cactoos.Text;
-import org.cactoos.func.FuncOf;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.list.ListOf;
-import org.cactoos.text.Capitalized;
-import org.cactoos.text.Split;
-import org.cactoos.text.TextOfString;
 import org.hamcrest.collection.IsEmptyCollection;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNot;
@@ -298,32 +293,6 @@ final class NoNullsTest {
             "Must not be empty after an item was added",
             col.isEmpty(),
             new IsNot<>(new IsTrue())
-        ).affirm();
-    }
-
-    @Test
-    void addsAllAfterBeingActuallyDownCasted() throws Exception {
-        new Assertion<>(
-            "Must allAll when being casted to Collection<Text> by unchecked cast",
-            new FuncOf<Collection<Text>, Collection<Text>>(
-                texts -> {
-                    texts.addAll(
-                        new ListOf<Capitalized>(
-                            new Capitalized("c"),
-                            new Capitalized("d")
-                        )
-                    );
-                    return texts;
-                }
-            ).apply(
-                new NoNulls<>(
-                    new ListOf<TextOfString>(
-                        new TextOfString("a"),
-                        new TextOfString("b")
-                    )
-                )
-            ),
-            new IsEqual<>(new ListOf<>(new Split("a, b, C, D", ", ")))
         ).affirm();
     }
 


### PR DESCRIPTION
For #1575.

Generify parameter types in constructors of org.cactoos.collection package classses:

- Immutable
- NoNulls

It's done by using unchecked casts, because there are absolutely no other ways to achive this, due to JDK interfaces limitations.