### PR TITLE
Issue 1569 generify scalar package

### DIFF
--- a/src/main/java/org/cactoos/scalar/And.java
+++ b/src/main/java/org/cactoos/scalar/And.java
@@ -68,7 +68,7 @@ public final class And implements Scalar<Boolean> {
     /**
      * The iterator.
      */
-    private final Iterable<Scalar<Boolean>> origin;
+    private final Iterable<? extends Scalar<Boolean>> origin;
 
     /**
      * Ctor.
@@ -77,7 +77,7 @@ public final class And implements Scalar<Boolean> {
      * @param <X> Type of items in the iterable
      */
     @SafeVarargs
-    public <X> And(final Func<X, Boolean> func, final X... src) {
+    public <X> And(final Func<? super X, Boolean> func, final X... src) {
         this(func, new IterableOf<>(src));
     }
 
@@ -88,7 +88,10 @@ public final class And implements Scalar<Boolean> {
      * @param <X> Type of items in the iterable
      * @since 0.24
      */
-    public <X> And(final Func<X, Boolean> func, final Iterable<X> src) {
+    public <X> And(
+        final Func<? super X, Boolean> func,
+        final Iterable<? extends X> src
+    ) {
         this(
             new Mapped<>(
                 item -> new ScalarOf<>(() -> func.apply(item)),
@@ -105,7 +108,7 @@ public final class And implements Scalar<Boolean> {
      * @since 0.34
      */
     @SafeVarargs
-    public <X> And(final X subject, final Func<X, Boolean>... conditions) {
+    public <X> And(final X subject, final Func<? super X, Boolean>... conditions) {
         this(subject, new IterableOf<>(conditions));
     }
 
@@ -116,7 +119,7 @@ public final class And implements Scalar<Boolean> {
      * @param <X> Type of items in the iterable
      * @since 0.49
      */
-    public <X> And(final X subject, final Iterable<Func<X, Boolean>> conditions) {
+    public <X> And(final X subject, final Iterable<? extends Func<? super X, Boolean>> conditions) {
         this(
             new Mapped<>(
                 item -> new ScalarOf<>(() -> item.apply(subject)),
@@ -138,7 +141,7 @@ public final class And implements Scalar<Boolean> {
      * Ctor.
      * @param iterable The iterable.
      */
-    public And(final Iterable<Scalar<Boolean>> iterable) {
+    public And(final Iterable<? extends Scalar<Boolean>> iterable) {
         this.origin = iterable;
     }
 

--- a/src/main/java/org/cactoos/scalar/AndInThreads.java
+++ b/src/main/java/org/cactoos/scalar/AndInThreads.java
@@ -64,7 +64,7 @@ public final class AndInThreads implements Scalar<Boolean> {
     /**
      * The iterator.
      */
-    private final Iterable<Scalar<Boolean>> iterable;
+    private final Iterable<? extends Scalar<Boolean>> iterable;
 
     /**
      * Shut down the service when it's done.
@@ -78,7 +78,7 @@ public final class AndInThreads implements Scalar<Boolean> {
      * @param <X> Type of items in the iterable
      */
     @SafeVarargs
-    public <X> AndInThreads(final Func<X, Boolean> func, final X... src) {
+    public <X> AndInThreads(final Func<? super X, Boolean> func, final X... src) {
         this(func, new IterableOf<>(src));
     }
 
@@ -88,8 +88,8 @@ public final class AndInThreads implements Scalar<Boolean> {
      * @param src The iterable
      * @param <X> Type of items in the iterable
      */
-    public <X> AndInThreads(final Func<X, Boolean> func,
-        final Iterable<X> src) {
+    public <X> AndInThreads(final Func<? super X, Boolean> func,
+        final Iterable<? extends X> src) {
         this(
             new Mapped<>(
                 item -> new ScalarOf<>(() -> func.apply(item)),
@@ -111,7 +111,7 @@ public final class AndInThreads implements Scalar<Boolean> {
      * Ctor.
      * @param src The iterable
      */
-    public AndInThreads(final Iterable<Scalar<Boolean>> src) {
+    public AndInThreads(final Iterable<? extends Scalar<Boolean>> src) {
         this(Executors.newCachedThreadPool(), src, true);
     }
 
@@ -123,8 +123,11 @@ public final class AndInThreads implements Scalar<Boolean> {
      * @param <X> Type of items in the iterable
      */
     @SafeVarargs
-    public <X> AndInThreads(final ExecutorService svc,
-        final Proc<X> proc, final X... src) {
+    public <X> AndInThreads(
+        final ExecutorService svc,
+        final Proc<? super X> proc,
+        final X... src
+    ) {
         this(svc, new FuncOf<>(proc, true), src);
     }
 
@@ -136,8 +139,11 @@ public final class AndInThreads implements Scalar<Boolean> {
      * @param <X> Type of items in the iterable
      */
     @SafeVarargs
-    public <X> AndInThreads(final ExecutorService svc,
-        final Func<X, Boolean> func, final X... src) {
+    public <X> AndInThreads(
+        final ExecutorService svc,
+        final Func<? super X, Boolean> func,
+        final X... src
+    ) {
         this(svc, func, new IterableOf<>(src));
     }
 
@@ -148,8 +154,11 @@ public final class AndInThreads implements Scalar<Boolean> {
      * @param src The iterable
      * @param <X> Type of items in the iterable
      */
-    public <X> AndInThreads(final ExecutorService svc,
-        final Proc<X> proc, final Iterable<X> src) {
+    public <X> AndInThreads(
+        final ExecutorService svc,
+        final Proc<? super X> proc,
+        final Iterable<? extends X> src
+    ) {
         this(svc, new FuncOf<>(proc, true), src);
     }
 
@@ -160,8 +169,11 @@ public final class AndInThreads implements Scalar<Boolean> {
      * @param src The iterable
      * @param <X> Type of items in the iterable
      */
-    public <X> AndInThreads(final ExecutorService svc,
-        final Func<X, Boolean> func, final Iterable<X> src) {
+    public <X> AndInThreads(
+        final ExecutorService svc,
+        final Func<? super X, Boolean> func,
+        final Iterable<? extends X> src
+    ) {
         this(
             svc,
             new Mapped<>(
@@ -188,7 +200,7 @@ public final class AndInThreads implements Scalar<Boolean> {
      * @param src The iterable
      */
     public AndInThreads(final ExecutorService svc,
-        final Iterable<Scalar<Boolean>> src) {
+        final Iterable<? extends Scalar<Boolean>> src) {
         this(svc, src, false);
     }
 
@@ -199,7 +211,7 @@ public final class AndInThreads implements Scalar<Boolean> {
      * @param sht Shut it down
      */
     private AndInThreads(final ExecutorService svc,
-        final Iterable<Scalar<Boolean>> src, final boolean sht) {
+        final Iterable<? extends Scalar<Boolean>> src, final boolean sht) {
         this.service = svc;
         this.iterable = src;
         this.shut = sht;

--- a/src/main/java/org/cactoos/scalar/AndWithIndex.java
+++ b/src/main/java/org/cactoos/scalar/AndWithIndex.java
@@ -68,7 +68,7 @@ public final class AndWithIndex implements Scalar<Boolean> {
     /**
      * The iterator.
      */
-    private final Iterable<Func<Integer, Boolean>> iterable;
+    private final Iterable<? extends Func<Integer, Boolean>> iterable;
 
     /**
      * Ctor.
@@ -77,7 +77,7 @@ public final class AndWithIndex implements Scalar<Boolean> {
      * @param <X> Type of items in the iterable
      */
     @SafeVarargs
-    public <X> AndWithIndex(final Proc<X> proc, final X... src) {
+    public <X> AndWithIndex(final Proc<? super X> proc, final X... src) {
         this(new BiFuncOf<>(proc, true), src);
     }
 
@@ -88,7 +88,7 @@ public final class AndWithIndex implements Scalar<Boolean> {
      * @param <X> Type of items in the iterable
      */
     @SafeVarargs
-    public <X> AndWithIndex(final BiFunc<X, Integer, Boolean> func,
+    public <X> AndWithIndex(final BiFunc<? super X, Integer, Boolean> func,
         final X... src) {
         this(func, new IterableOf<>(src));
     }
@@ -100,8 +100,8 @@ public final class AndWithIndex implements Scalar<Boolean> {
      * @param <X> Type of items in the iterable
      * @since 0.24
      */
-    public <X> AndWithIndex(final BiProc<X, Integer> proc,
-        final Iterable<X> src) {
+    public <X> AndWithIndex(final BiProc<? super X, Integer> proc,
+        final Iterable<? extends X> src) {
         this(new BiFuncOf<>(proc, true), src);
     }
 
@@ -112,8 +112,8 @@ public final class AndWithIndex implements Scalar<Boolean> {
      * @param <X> Type of items in the iterable
      * @since 0.24
      */
-    public <X> AndWithIndex(final BiFunc<X, Integer, Boolean> func,
-        final Iterable<X> src) {
+    public <X> AndWithIndex(final BiFunc<? super X, Integer, Boolean> func,
+        final Iterable<? extends X> src) {
         this(
             new Mapped<>(
                 item -> new FuncOf<>(input -> func.apply(item, input)),
@@ -135,7 +135,7 @@ public final class AndWithIndex implements Scalar<Boolean> {
      * Ctor.
      * @param src The iterable
      */
-    public AndWithIndex(final Iterable<Func<Integer, Boolean>> src) {
+    public AndWithIndex(final Iterable<? extends Func<Integer, Boolean>> src) {
         this.iterable = src;
     }
 

--- a/src/main/java/org/cactoos/scalar/FirstOf.java
+++ b/src/main/java/org/cactoos/scalar/FirstOf.java
@@ -41,24 +41,24 @@ public final class FirstOf<T> implements Scalar<T> {
     /**
      * Condition for getting the element.
      */
-    private final Func<T, Boolean> condition;
+    private final Func<? super T, Boolean> condition;
 
     /**
      * Source iterable.
      */
-    private final Iterable<T> source;
+    private final Iterable<? extends T> source;
 
     /**
      * Fallback used if no value matches.
      */
-    private final Scalar<T> fallback;
+    private final Scalar<? extends T> fallback;
 
     /**
      * Constructor with default condition (always `true`) and plain fallback.
      * @param src Source iterable
      * @param fbck Fallback used if no value matches
      */
-    public FirstOf(final Iterable<T> src, final T fbck) {
+    public FirstOf(final Iterable<? extends T> src, final T fbck) {
         this(
             new FuncOf<>(new True()),
             src,
@@ -71,7 +71,7 @@ public final class FirstOf<T> implements Scalar<T> {
      * @param src Source iterable
      * @param fbck Fallback used if no value matches
      */
-    public FirstOf(final Iterable<T> src, final Scalar<T> fbck) {
+    public FirstOf(final Iterable<? extends T> src, final Scalar<? extends T> fbck) {
         this(
             new FuncOf<>(new True()),
             src,
@@ -85,8 +85,11 @@ public final class FirstOf<T> implements Scalar<T> {
      * @param src Source iterable
      * @param fbck Fallback used if no value matches
      */
-    public FirstOf(final Func<T, Boolean> cond, final Iterable<T> src,
-        final Scalar<T> fbck) {
+    public FirstOf(
+        final Func<? super T, Boolean> cond,
+        final Iterable<? extends T> src,
+        final Scalar<? extends T> fbck
+    ) {
         this.condition = cond;
         this.source = src;
         this.fallback = fbck;

--- a/src/main/java/org/cactoos/scalar/IoChecked.java
+++ b/src/main/java/org/cactoos/scalar/IoChecked.java
@@ -45,13 +45,13 @@ public final class IoChecked<T> implements Scalar<T> {
     /**
      * Original scalar.
      */
-    private final Scalar<T> origin;
+    private final Scalar<? extends T> origin;
 
     /**
      * Ctor.
      * @param scalar Encapsulated scalar
      */
-    public IoChecked(final Scalar<T> scalar) {
+    public IoChecked(final Scalar<? extends T> scalar) {
         this.origin = scalar;
     }
 

--- a/src/main/java/org/cactoos/scalar/ItemAt.java
+++ b/src/main/java/org/cactoos/scalar/ItemAt.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import org.cactoos.Func;
 import org.cactoos.Scalar;
 import org.cactoos.func.FuncOf;
+import org.cactoos.iterable.IterableOf;
 import org.cactoos.text.FormattedText;
 
 /**
@@ -53,7 +54,7 @@ public final class ItemAt<T> implements Scalar<T> {
      * @param position Position
      * @param iterable Iterable
      */
-    public ItemAt(final int position, final Iterable<T> iterable) {
+    public ItemAt(final int position, final Iterable<? extends T> iterable) {
         this(
             position,
             itr -> {
@@ -78,7 +79,7 @@ public final class ItemAt<T> implements Scalar<T> {
     public ItemAt(
         final int position,
         final T fallback,
-        final Iterable<T> iterable
+        final Iterable<? extends T> iterable
     ) {
         this(position, new FuncOf<>(new Constant<>(fallback)), iterable);
     }
@@ -92,8 +93,8 @@ public final class ItemAt<T> implements Scalar<T> {
      */
     public ItemAt(
         final int position,
-        final Func<Iterable<T>, T> fallback,
-        final Iterable<T> iterable
+        final Func<? super Iterable<? super T>, ? extends T> fallback,
+        final Iterable<? extends T> iterable
     ) {
         this.saved = new Sticky<T>(
             () -> {
@@ -106,7 +107,7 @@ public final class ItemAt<T> implements Scalar<T> {
                         ).asString()
                     );
                 }
-                final Iterator<T> src = iterable.iterator();
+                final Iterator<? extends T> src = iterable.iterator();
                 int cur;
                 for (cur = 0; cur < position && src.hasNext(); ++cur) {
                     src.next();
@@ -114,7 +115,7 @@ public final class ItemAt<T> implements Scalar<T> {
                 if (cur == position && src.hasNext()) {
                     ret = src.next();
                 } else {
-                    ret = fallback.apply(() -> src);
+                    ret = fallback.apply(new IterableOf<>(src));
                 }
                 return ret;
             }

--- a/src/main/java/org/cactoos/scalar/NoNulls.java
+++ b/src/main/java/org/cactoos/scalar/NoNulls.java
@@ -35,13 +35,13 @@ public final class NoNulls<T> implements Scalar<T> {
     /**
      * The scalar.
      */
-    private final Scalar<T> origin;
+    private final Scalar<? extends T> origin;
 
     /**
      * Ctor.
      * @param sclr The scalar
      */
-    public NoNulls(final Scalar<T> sclr) {
+    public NoNulls(final Scalar<? extends T> sclr) {
         this.origin = sclr;
     }
 

--- a/src/main/java/org/cactoos/scalar/PropertiesOf.java
+++ b/src/main/java/org/cactoos/scalar/PropertiesOf.java
@@ -97,7 +97,7 @@ public final class PropertiesOf implements Scalar<Properties> {
      * @param entries The map with properties
      * @since 0.23
      */
-    public PropertiesOf(final Iterable<Map.Entry<?, ?>> entries) {
+    public PropertiesOf(final Iterable<? extends Map.Entry<?, ?>> entries) {
         this(
             new MapOf<>(
                 input -> new MapEntry<>(
@@ -131,7 +131,7 @@ public final class PropertiesOf implements Scalar<Properties> {
      * Ctor.
      * @param sclr The underlying properties
      */
-    private PropertiesOf(final Scalar<Properties> sclr) {
+    private PropertiesOf(final Scalar<? extends Properties> sclr) {
         this.scalar = new IoChecked<>(sclr);
     }
 

--- a/src/main/java/org/cactoos/scalar/Repeated.java
+++ b/src/main/java/org/cactoos/scalar/Repeated.java
@@ -37,7 +37,7 @@ public final class Repeated<X> implements Scalar<X> {
     /**
      * Scalar.
      */
-    private final Scalar<X> scalar;
+    private final Scalar<? extends X> scalar;
 
     /**
      * Times to repeat.
@@ -53,7 +53,7 @@ public final class Repeated<X> implements Scalar<X> {
      * @param scalar Scalar to repeat.
      * @param times How many times.
      */
-    public Repeated(final Scalar<X> scalar, final int times) {
+    public Repeated(final Scalar<? extends X> scalar, final int times) {
         this.scalar = scalar;
         this.times = times;
     }

--- a/src/main/java/org/cactoos/scalar/Retry.java
+++ b/src/main/java/org/cactoos/scalar/Retry.java
@@ -58,7 +58,7 @@ public final class Retry<T> implements Scalar<T> {
     /**
      * Original scalar.
      */
-    private final Scalar<T> origin;
+    private final Scalar<? extends T> origin;
 
     /**
      * Exit condition.
@@ -74,7 +74,7 @@ public final class Retry<T> implements Scalar<T> {
      * Ctor.
      * @param scalar Scalar original
      */
-    public Retry(final Scalar<T> scalar) {
+    public Retry(final Scalar<? extends T> scalar) {
         this(scalar, Duration.ZERO);
     }
 
@@ -83,7 +83,7 @@ public final class Retry<T> implements Scalar<T> {
      * @param scalar Scalar original
      * @param wait The {@link java.time.Duration} to wait between attempts
      */
-    public Retry(final Scalar<T> scalar, final Duration wait) {
+    public Retry(final Scalar<? extends T> scalar, final Duration wait) {
         // @checkstyle MagicNumberCheck (1 line)
         this(scalar, 3, wait);
     }
@@ -93,7 +93,7 @@ public final class Retry<T> implements Scalar<T> {
      * @param scalar Scalar original
      * @param attempts Maximum number of attempts
      */
-    public Retry(final Scalar<T> scalar, final int attempts) {
+    public Retry(final Scalar<? extends T> scalar, final int attempts) {
         this(scalar, attempts, Duration.ZERO);
     }
 
@@ -103,7 +103,7 @@ public final class Retry<T> implements Scalar<T> {
      * @param attempts Maximum number of attempts
      * @param wait The {@link java.time.Duration} to wait between attempts
      */
-    public Retry(final Scalar<T> scalar, final int attempts,
+    public Retry(final Scalar<? extends T> scalar, final int attempts,
         final Duration wait) {
         this(scalar, attempt -> attempt >= attempts, wait);
     }
@@ -113,7 +113,7 @@ public final class Retry<T> implements Scalar<T> {
      * @param scalar Func original
      * @param exit Exit condition, returns TRUE if there is no reason to try
      */
-    public Retry(final Scalar<T> scalar,
+    public Retry(final Scalar<? extends T> scalar,
         final Func<Integer, Boolean> exit) {
         this(scalar, exit, Duration.ZERO);
     }
@@ -124,7 +124,7 @@ public final class Retry<T> implements Scalar<T> {
      * @param exit Exit condition, returns TRUE if there is no reason to try
      * @param wait The {@link java.time.Duration} to wait between attempts
      */
-    public Retry(final Scalar<T> scalar,
+    public Retry(final Scalar<? extends T> scalar,
         final Func<Integer, Boolean> exit, final Duration wait) {
         this.origin = scalar;
         this.func = exit;

--- a/src/main/java/org/cactoos/scalar/ScalarOfSupplier.java
+++ b/src/main/java/org/cactoos/scalar/ScalarOfSupplier.java
@@ -37,7 +37,7 @@ public final class ScalarOfSupplier<T> extends ScalarEnvelope<T> {
      *
      * @param supplier The supplier
      */
-    public ScalarOfSupplier(final Supplier<T> supplier) {
+    public ScalarOfSupplier(final Supplier<? extends T> supplier) {
         super(supplier::get);
     }
 

--- a/src/main/java/org/cactoos/scalar/Solid.java
+++ b/src/main/java/org/cactoos/scalar/Solid.java
@@ -40,7 +40,7 @@ public final class Solid<T> implements Scalar<T> {
     /**
      * Origin.
      */
-    private final Scalar<T> origin;
+    private final Scalar<? extends T> origin;
 
     /**
      * Cache.
@@ -56,7 +56,7 @@ public final class Solid<T> implements Scalar<T> {
      * Ctor.
      * @param origin The Scalar to cache and sync
      */
-    public Solid(final Scalar<T> origin) {
+    public Solid(final Scalar<? extends T> origin) {
         this.origin = origin;
         this.lock = new Object();
     }

--- a/src/main/java/org/cactoos/scalar/Sticky.java
+++ b/src/main/java/org/cactoos/scalar/Sticky.java
@@ -62,13 +62,13 @@ public final class Sticky<T> implements Scalar<T> {
     /**
      * Func.
      */
-    private final Func<Boolean, T> func;
+    private final Func<Boolean, ? extends T> func;
 
     /**
      * Ctor.
      * @param scalar The Scalar to cache
      */
-    public Sticky(final Scalar<T> scalar) {
+    public Sticky(final Scalar<? extends T> scalar) {
         this.func = new StickyFunc<>(
             input -> scalar.value()
         );

--- a/src/main/java/org/cactoos/scalar/Synced.java
+++ b/src/main/java/org/cactoos/scalar/Synced.java
@@ -52,7 +52,7 @@ public final class Synced<T> implements Scalar<T> {
     /**
      * The scalar to cache.
      */
-    private final Scalar<T> origin;
+    private final Scalar<? extends T> origin;
 
     /**
      * Sync lock.
@@ -63,7 +63,7 @@ public final class Synced<T> implements Scalar<T> {
      * Ctor.
      * @param src The Scalar to cache
      */
-    public Synced(final Scalar<T> src) {
+    public Synced(final Scalar<? extends T> src) {
         this(src, src);
     }
 
@@ -72,7 +72,7 @@ public final class Synced<T> implements Scalar<T> {
      * @param scalar The Scalar to cache
      * @param lock Sync lock
      */
-    public Synced(final Scalar<T> scalar, final Object lock) {
+    public Synced(final Scalar<? extends T> scalar, final Object lock) {
         this.origin = scalar;
         this.mutex = lock;
     }

--- a/src/main/java/org/cactoos/scalar/Ternary.java
+++ b/src/main/java/org/cactoos/scalar/Ternary.java
@@ -80,7 +80,11 @@ public final class Ternary<T> extends ScalarEnvelope<T> {
      * @param alter The alternative
      * @since 0.9
      */
-    public Ternary(final boolean cnd, final Scalar<T> cons, final Scalar<T> alter) {
+    public Ternary(
+        final boolean cnd,
+        final Scalar<? extends T> cons,
+        final Scalar<? extends T> alter
+    ) {
         this(new Constant<>(cnd), cons, alter);
     }
 
@@ -91,7 +95,11 @@ public final class Ternary<T> extends ScalarEnvelope<T> {
      * @param alter The alternative
      * @since 0.9
      */
-    public Ternary(final Scalar<Boolean> cnd, final Scalar<T> cons, final Scalar<T> alter) {
+    public Ternary(
+        final Scalar<Boolean> cnd,
+        final Scalar<? extends T> cons,
+        final Scalar<? extends T> alter
+    ) {
         this(
             new Object(),
             new FuncOf<>(cnd),
@@ -111,8 +119,10 @@ public final class Ternary<T> extends ScalarEnvelope<T> {
      * @checkstyle ParameterNumberCheck (5 lines)
      */
     public <X> Ternary(
-        final X input, final Func<X, Boolean> cnd,
-        final Func<X, T> cons, final Func<X, T> alter
+        final X input,
+        final Func<? super X, Boolean> cnd,
+        final Func<? super X, ? extends T> cons,
+        final Func<? super X, ? extends T> alter
     ) {
         this(new Constant<>(input), cnd, cons, alter);
     }
@@ -128,12 +138,14 @@ public final class Ternary<T> extends ScalarEnvelope<T> {
      * @checkstyle ParameterNumberCheck (5 lines)
      */
     public <X> Ternary(
-        final Scalar<X> input, final Func<X, Boolean> cnd,
-        final Func<X, T> cons, final Func<X, T> alter
+        final Scalar<? extends X> input,
+        final Func<? super X, Boolean> cnd,
+        final Func<? super X, ? extends T> cons,
+        final Func<? super X, ? extends T> alter
     ) {
         super(() -> {
             final X inp = input.value();
-            final Func<X, T> result;
+            final Func<? super X, ? extends T> result;
             if (cnd.apply(inp)) {
                 result = cons;
             } else {

--- a/src/main/java/org/cactoos/scalar/Unchecked.java
+++ b/src/main/java/org/cactoos/scalar/Unchecked.java
@@ -40,13 +40,13 @@ public final class Unchecked<T> implements Scalar<T> {
     /**
      * Original origin.
      */
-    private final Scalar<T> origin;
+    private final Scalar<? extends T> origin;
 
     /**
      * Ctor.
      * @param scalar Encapsulated origin
      */
-    public Unchecked(final Scalar<T> scalar) {
+    public Unchecked(final Scalar<? extends T> scalar) {
         this.origin = scalar;
     }
 

--- a/src/main/java/org/cactoos/scalar/Xor.java
+++ b/src/main/java/org/cactoos/scalar/Xor.java
@@ -77,7 +77,7 @@ public final class Xor extends ScalarEnvelope<Boolean> {
      * Ctor.
      * @param iterable The iterable.
      */
-    public Xor(final Iterable<Scalar<Boolean>> iterable) {
+    public Xor(final Iterable<? extends Scalar<Boolean>> iterable) {
         super(new Reduced<>((a, b) -> a ^ b, new Joined<>(new False(), iterable))
         );
     }

--- a/src/main/java/org/cactoos/scalar/package-info.java
+++ b/src/main/java/org/cactoos/scalar/package-info.java
@@ -26,8 +26,8 @@
  * Scalars.
  *
  * @since 0.12
- * @todo #1533:30min Exploit generic variance for package org.cactoos.scalar
- *  to ensure typing works as best as possible as it is explained in
- *  #1533 issue.
+ * @todo #1569:90min Create tests for the semantics of relaxed wildcards
+ *  in changed classes of {@link org.cactoos.scalar} package in #1569,
+ *  which is a child of #1533.
  */
 package org.cactoos.scalar;


### PR DESCRIPTION
For #1569.

Relaxed parameter types by adding wildcards in constructors of classes of `org.cactoos.scalar` package:

- `And`
- `AndInThreads`
- `AndWithIndex`
- `FirstOf`
- `IoChecked`
- `ItemAt`
- `NoNulls`
- `PropertiesOf`
- `Repeated`
- `Retry`
- `ScalarOfSupplier`
- `Solid`
- `Sticky`
- `Synced`
- `Ternary`
- `Unckecked`
- `Xor`