### PR TITLE
(#1573) Generify `org.cactoos.experimental` package. 

### DIFF
--- a/src/main/java/org/cactoos/experimental/package-info.java
+++ b/src/main/java/org/cactoos/experimental/package-info.java
@@ -33,7 +33,5 @@
  * whatsoever.
  *
  * @since 1.0.0
- * @todo #1533:30min Exploit generic variance for package org.cactoos.experimental
- *  to ensure typing works as best as possible as it is explained in #1533 issue.
  */
 package org.cactoos.experimental;


### PR DESCRIPTION
For #1573.

- Generified parameter types in constructors of `org.cactoos.experimental.Threads` class
- Removed `todo` comment

Actually one class and one constructor, which contract, in my opinion, could be `relaxed`. 