### PR TITLE
tests migration to JUnit 5

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -8,7 +8,7 @@ jobs:
   codecov:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
@@ -20,7 +20,8 @@ jobs:
           restore-keys: |
             maven-
       - run: mvn install -Pjacoco
-      - uses: codecov/codecov-action@v4.0.0-beta.3
+      - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./target/site/jacoco/jacoco.xml
           fail_ci_if_error: true

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2022, macos-12]
+        os: [ubuntu-22.04, windows-2022, macos-12]
         java: [11, 17]
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -8,7 +8,7 @@ jobs:
   sonar:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
           java-version: 11

--- a/.github/workflows/up.yml
+++ b/.github/workflows/up.yml
@@ -6,7 +6,7 @@ jobs:
   up:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/checkout@v4
       - run: |-
           git fetch --tags --force && \
           latest=$(git tag --sort=creatordate | tail -1) && \

--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -11,5 +11,5 @@ jobs:
   xcop:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/checkout@v4
       - uses: g4s8/xcop-action@master

--- a/pom.xml
+++ b/pom.xml
@@ -122,40 +122,11 @@ SOFTWARE.
         </exclusion>
       </exclusions>
     </dependency>
-    <!--
-     @todo #1453:30min Continue migration of tests to JUnit 5. Junit 4 Rule
-      should be replaced with a Jupiter counterpart. `@Text(expected=..)`
-      with `Throws`. After that remove this dependencies.
-    -->
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <version>5.10.2</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <version>5.10.2</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
-      <version>5.10.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-core</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
   <build>
@@ -246,7 +217,7 @@ SOFTWARE.
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.21.1</version>
+            <version>0.22.0</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>checkstyle:/src/site/resources/.*</exclude>

--- a/src/test/java/org/cactoos/BytesTest.java
+++ b/src/test/java/org/cactoos/BytesTest.java
@@ -33,9 +33,10 @@ import org.llorllale.cactoos.matchers.Throws;
  * @since 0.11
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class BytesTest {
-
-    public void failForNullArgument() throws Exception {
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class BytesTest {
+    @Test
+    void failForNullArgument() {
         new Assertion<>(
             "Must fail for null argument.",
             () -> new NoNulls(null).asBytes(),
@@ -43,7 +44,8 @@ public final class BytesTest {
         ).affirm();
     }
 
-    public void failForNullResult() throws Exception {
+    @Test
+    void failForNullResult() {
         new Assertion<>(
             "Must fail for null result.",
             () -> new NoNulls(() -> null).asBytes(),
@@ -52,7 +54,7 @@ public final class BytesTest {
     }
 
     @Test
-    public void okForNoNulls() throws Exception {
+    void okForNoNulls() throws Exception {
         new NoNulls(() -> new byte[1]).asBytes();
     }
 }

--- a/src/test/java/org/cactoos/ScalarTest.java
+++ b/src/test/java/org/cactoos/ScalarTest.java
@@ -33,6 +33,7 @@ import org.llorllale.cactoos.matchers.Throws;
  * @since 0.11
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class ScalarTest {
 
     @Test

--- a/src/test/java/org/cactoos/TextTest.java
+++ b/src/test/java/org/cactoos/TextTest.java
@@ -35,6 +35,7 @@ import org.llorllale.cactoos.matchers.Throws;
  * @since 0.11
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class TextTest {
 
     @Test

--- a/src/test/java/org/cactoos/bytes/BytesOfTest.java
+++ b/src/test/java/org/cactoos/bytes/BytesOfTest.java
@@ -78,7 +78,7 @@ final class BytesOfTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    void readsInputIntoBytes() throws Exception {
+    void readsInputIntoBytes() {
         new Assertion<>(
             "must read bytes from Input",
             new TextOf(
@@ -94,7 +94,7 @@ final class BytesOfTest {
     }
 
     @Test
-    void readsFromReader() throws Exception {
+    void readsFromReader() {
         final String source = "hello, друг!";
         new Assertion<>(
             "must read string through a reader",
@@ -115,7 +115,7 @@ final class BytesOfTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    void readsInputIntoBytesWithSmallBuffer() throws Exception {
+    void readsInputIntoBytesWithSmallBuffer() {
         new Assertion<>(
             "must read bytes from Input with a small reading buffer",
             new TextOf(

--- a/src/test/java/org/cactoos/bytes/HexOfTest.java
+++ b/src/test/java/org/cactoos/bytes/HexOfTest.java
@@ -38,10 +38,10 @@ import org.llorllale.cactoos.matchers.Throws;
  * @since 0.29
  * @checkstyle JavadocMethodCheck (500 line)
  */
-public final class HexOfTest {
+final class HexOfTest {
 
     @Test
-    public void emptyText() throws Exception {
+    void emptyText() throws Exception {
         new Assertion<>(
             "Must represent an empty hexadecimal text",
             new HexOf(new TextOf("")).asBytes(),
@@ -50,7 +50,7 @@ public final class HexOfTest {
     }
 
     @Test
-    public void validHex() throws Exception {
+    void validHex() throws Exception {
         final byte[] bytes = new byte[256];
         for (int index = 0; index < 256; ++index) {
             bytes[index] = (byte) (index + Byte.MIN_VALUE);
@@ -67,7 +67,7 @@ public final class HexOfTest {
     }
 
     @Test
-    public void invalidHexLength() throws Exception {
+    void invalidHexLength() throws Exception {
         new Assertion<>(
             "Must invalid hex length",
             () -> new HexOf(new TextOf("ABF")).asBytes(),
@@ -79,7 +79,7 @@ public final class HexOfTest {
     }
 
     @Test
-    public void invalidHex() throws Exception {
+    void invalidHex() throws Exception {
         new Assertion<>(
             "Must invalid hex",
             () -> new HexOf(new TextOf("ABG!")).asBytes(),

--- a/src/test/java/org/cactoos/bytes/ReaderAsBytesTest.java
+++ b/src/test/java/org/cactoos/bytes/ReaderAsBytesTest.java
@@ -25,9 +25,7 @@ package org.cactoos.bytes;
 
 import java.io.StringReader;
 import org.cactoos.text.TextOf;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.TemporaryFolder;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.IsText;
 import org.llorllale.cactoos.matchers.IsTrue;
@@ -38,15 +36,10 @@ import org.llorllale.cactoos.matchers.IsTrue;
  * @since 0.12
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class ReaderAsBytesTest {
-    /**
-     * Temporary files and folders generator.
-     */
-    @Rule
-    public final TemporaryFolder folder = new TemporaryFolder();
+final class ReaderAsBytesTest {
 
     @Test
-    public void readsString() throws Exception {
+    void readsString() throws Exception {
         final String source = "hello, друг!";
         new Assertion<>(
             "Must read string through a reader",
@@ -60,7 +53,7 @@ public final class ReaderAsBytesTest {
     }
 
     @Test
-    public void readsAndClosesReader() throws Exception {
+    void readsAndClosesReader() throws Exception {
         final EmptyClosableReader reader = new EmptyClosableReader();
         new ReaderAsBytes(reader).asBytes();
         new Assertion<>(

--- a/src/test/java/org/cactoos/collection/ImmutableTest.java
+++ b/src/test/java/org/cactoos/collection/ImmutableTest.java
@@ -36,7 +36,7 @@ import org.llorllale.cactoos.matchers.Throws;
  * @since 1.16
  */
 @SuppressWarnings("PMD.TooManyMethods")
-public class ImmutableTest {
+final class ImmutableTest {
 
     @Test
     void size() {

--- a/src/test/java/org/cactoos/func/AsyncTest.java
+++ b/src/test/java/org/cactoos/func/AsyncTest.java
@@ -38,6 +38,7 @@ import org.llorllale.cactoos.matchers.Satisfies;
  *
  * @since 0.10
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class AsyncTest {
     @Test
     void runsInBackground() {

--- a/src/test/java/org/cactoos/func/BiFuncNoNullsTest.java
+++ b/src/test/java/org/cactoos/func/BiFuncNoNullsTest.java
@@ -23,43 +23,62 @@
  */
 package org.cactoos.func;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link BiFuncNoNulls}.
  * @since 0.11
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class BiFuncNoNullsTest {
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class BiFuncNoNullsTest {
 
-    @Test(expected = IllegalArgumentException.class)
-    public void failForNullFunc() throws Exception {
-        new BiFuncNoNulls<>(null).apply(new Object(), new Object());
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void failForNullFirstArg() throws Exception {
-        new BiFuncNoNulls<>(
-            (first, second) -> first
-        ).apply(null, new Object());
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void failForNullSecondArg() throws Exception {
-        new BiFuncNoNulls<>(
-            (first, second) -> first
-        ).apply(new Object(), null);
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void failForNullResult() throws Exception {
-        new BiFuncNoNulls<>(
-            (first, second) -> null
-        ).apply(new Object(), new Object());
+    @Test
+    void failForNullFunc() {
+        new Assertion<>(
+            "Must fail if function is null.",
+            () -> new BiFuncNoNulls<>(null).apply(new Object(), new Object()),
+            new Throws<>(IllegalArgumentException.class)
+        ).affirm();
     }
 
     @Test
-    public void okForNoNulls() throws Exception {
+    void failForNullFirstArg() {
+        new Assertion<>(
+            "Must fail if first arg is null.",
+            () -> new BiFuncNoNulls<>(
+                (first, second) -> first
+                ).apply(null, new Object()),
+            new Throws<>(IllegalArgumentException.class)
+        ).affirm();
+    }
+
+    @Test
+    void failForNullSecondArg() {
+        new Assertion<>(
+            "Must fail if second arg is null.",
+            () -> new BiFuncNoNulls<>(
+                (first, second) -> first
+            ).apply(new Object(), null),
+            new Throws<>(IllegalArgumentException.class)
+        ).affirm();
+    }
+
+    @Test
+    void failForNullResult() {
+        new Assertion<>(
+            "Must fail if function is null.",
+            () -> new BiFuncNoNulls<>(
+                (first, second) -> null
+            ).apply(new Object(), new Object()),
+            new Throws<>(IllegalStateException.class)
+        ).affirm();
+    }
+
+    @Test
+    void okForNoNulls() throws Exception {
         new BiFuncNoNulls<>(
             (first, second) -> first
         ).apply(new Object(), new Object());

--- a/src/test/java/org/cactoos/func/ChainedTest.java
+++ b/src/test/java/org/cactoos/func/ChainedTest.java
@@ -38,6 +38,7 @@ import org.llorllale.cactoos.matchers.HasValue;
  * @since 0.7
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class ChainedTest {
 
     @Test

--- a/src/test/java/org/cactoos/func/CheckedBiFuncTest.java
+++ b/src/test/java/org/cactoos/func/CheckedBiFuncTest.java
@@ -27,8 +27,9 @@ import java.io.EOFException;
 import java.io.IOException;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link CheckedBiFunc}.
@@ -36,30 +37,39 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @since 0.32
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class CheckedBiFuncTest {
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class CheckedBiFuncTest {
 
-    @Test(expected = IllegalStateException.class)
-    public void runtimeExceptionIsNotWrapped() throws Exception {
-        new CheckedBiFunc<>(
-            (first, second) -> {
-                throw new IllegalStateException("runtime1");
-            },
-            IOException::new
-        ).apply(true, true);
-    }
-
-    @Test(expected = IOException.class)
-    public void checkedExceptionIsWrapped() throws Exception {
-        new CheckedBiFunc<>(
-            (first, second) -> {
-                throw new EOFException("runtime2");
-            },
-            IOException::new
-        ).apply(true, true);
+    @Test
+    void runtimeExceptionIsNotWrapped() {
+        new Assertion<>(
+            "Must fail if function is null.",
+            () -> new CheckedBiFunc<>(
+                (first, second) -> {
+                    throw new IllegalStateException("runtime1");
+                },
+                IOException::new
+            ).apply(true, true),
+            new Throws<>(IllegalStateException.class)
+        ).affirm();
     }
 
     @Test
-    public void extraWrappingIgnored() {
+    void checkedExceptionIsWrapped() {
+        new Assertion<>(
+            "Must fail if function is null.",
+            () -> new CheckedBiFunc<>(
+                (first, second) -> {
+                    throw new EOFException("runtime2");
+                },
+                IOException::new
+            ).apply(true, true),
+            new Throws<>(IOException.class)
+        ).affirm();
+    }
+
+    @Test
+    void extraWrappingIgnored() {
         try {
             new CheckedBiFunc<>(
                 (first, second) -> {
@@ -77,7 +87,7 @@ public final class CheckedBiFuncTest {
     }
 
     @Test
-    public void noExceptionThrown() throws Exception {
+    void noExceptionThrown() throws Exception {
         new Assertion<>(
             "Must not throw an exception",
             new CheckedBiFunc<>(

--- a/src/test/java/org/cactoos/func/CheckedFuncTest.java
+++ b/src/test/java/org/cactoos/func/CheckedFuncTest.java
@@ -27,8 +27,9 @@ import java.io.EOFException;
 import java.io.IOException;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link CheckedFunc}.
@@ -36,30 +37,39 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @since 0.32
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class CheckedFuncTest {
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class CheckedFuncTest {
 
-    @Test(expected = IllegalStateException.class)
-    public void runtimeExceptionIsNotWrapped() throws Exception {
-        new CheckedFunc<>(
-            input -> {
-                throw new IllegalStateException("runtime1");
-            },
-            IOException::new
-        ).apply(true);
-    }
-
-    @Test(expected = IOException.class)
-    public void checkedExceptionIsWrapped() throws Exception {
-        new CheckedFunc<>(
-            input -> {
-                throw new EOFException("runtime2");
-            },
-            IOException::new
-        ).apply(true);
+    @Test
+    void runtimeExceptionIsNotWrapped() {
+        new Assertion<>(
+            "Runtime exception should be rethrown",
+            () -> new CheckedFunc<>(
+                input -> {
+                    throw new IllegalStateException("runtime1");
+                },
+                IOException::new
+            ).apply(true),
+            new Throws<>(IllegalStateException.class)
+        ).affirm();
     }
 
     @Test
-    public void extraWrappingIgnored() {
+    void checkedExceptionIsWrapped() {
+        new Assertion<>(
+            "Checked exception was not wrapped",
+            () -> new CheckedFunc<>(
+                input -> {
+                    throw new EOFException("runtime2");
+                },
+                IOException::new
+            ).apply(true),
+            new Throws<>(IOException.class)
+        ).affirm();
+    }
+
+    @Test
+    void extraWrappingIgnored() {
         try {
             new CheckedFunc<>(
                 input -> {
@@ -77,7 +87,7 @@ public final class CheckedFuncTest {
     }
 
     @Test
-    public void noExceptionThrown() throws Exception {
+    void noExceptionThrown() throws Exception {
         new Assertion<>(
             "Must not throw an exception",
             new CheckedFunc<>(

--- a/src/test/java/org/cactoos/func/FallbackFromTest.java
+++ b/src/test/java/org/cactoos/func/FallbackFromTest.java
@@ -36,7 +36,7 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @since 0.31
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "PMD.JUnitTestsShouldIncludeAssert"})
 final class FallbackFromTest {
 
     @Test

--- a/src/test/java/org/cactoos/func/FlattenedTest.java
+++ b/src/test/java/org/cactoos/func/FlattenedTest.java
@@ -33,6 +33,7 @@ import org.llorllale.cactoos.matchers.IsApplicable;
 *
 * @since 0.49
 */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class FlattenedTest {
     @Test
     void flattens() {

--- a/src/test/java/org/cactoos/func/FuncEnvelopeTest.java
+++ b/src/test/java/org/cactoos/func/FuncEnvelopeTest.java
@@ -37,6 +37,7 @@ import org.llorllale.cactoos.matchers.IsText;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocTypeCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class FuncEnvelopeTest {
 
     @Test

--- a/src/test/java/org/cactoos/func/FuncNoNullsTest.java
+++ b/src/test/java/org/cactoos/func/FuncNoNullsTest.java
@@ -24,33 +24,48 @@
 package org.cactoos.func;
 
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link FuncNoNulls}.
  * @since 0.10
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class FuncNoNullsTest {
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class FuncNoNullsTest {
 
-    @Test(expected = IllegalArgumentException.class)
-    public void failForNullFunc() throws Exception {
-        new FuncNoNulls<>(null).apply(new Object());
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void failForNullInput() throws Exception {
-        new FuncNoNulls<>(input -> input).apply(null);
+    @Test
+    void failForNullFunc() {
+        new Assertion<>(
+            "Doesn't fail for null func",
+            () -> new FuncNoNulls<>(null).apply(new Object()),
+            new Throws<>(IllegalArgumentException.class)
+        ).affirm();
     }
 
     @Test
-    public void okForNoNulls() throws Exception {
+    void failForNullInput() {
+        new Assertion<>(
+            "Doesn't fail for null input",
+            () -> new FuncNoNulls<>(input -> input).apply(null),
+            new Throws<>(IllegalArgumentException.class)
+        ).affirm();
+    }
+
+    @Test
+    void okForNoNulls() throws Exception {
         new FuncNoNulls<>(input -> input).apply(new Object());
     }
 
-    @Test(expected = IOException.class)
-    public void failForNullResult() throws Exception {
-        new FuncNoNulls<>(input -> null).apply(new Object());
+    @Test
+    void failForNullResult() {
+        new Assertion<>(
+            "Doesn't fail for null result",
+            () -> new FuncNoNulls<>(input -> null).apply(new Object()),
+            new Throws<>(IOException.class)
+        ).affirm();
     }
 
 }

--- a/src/test/java/org/cactoos/func/FuncOfTest.java
+++ b/src/test/java/org/cactoos/func/FuncOfTest.java
@@ -35,6 +35,7 @@ import org.llorllale.cactoos.matchers.Satisfies;
  *
  * @since 0.20
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class FuncOfTest {
     @Test
     void convertsProcIntoFunc() throws Exception {

--- a/src/test/java/org/cactoos/func/FuncWithFallbackTest.java
+++ b/src/test/java/org/cactoos/func/FuncWithFallbackTest.java
@@ -28,9 +28,10 @@ import java.util.IllegalFormatException;
 import java.util.IllegalFormatWidthException;
 import org.cactoos.Fallback;
 import org.cactoos.iterable.IterableOf;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.IsApplicable;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link FuncWithFallback}.
@@ -38,11 +39,11 @@ import org.llorllale.cactoos.matchers.IsApplicable;
  * @since 0.2
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-@SuppressWarnings("unchecked")
-public final class FuncWithFallbackTest {
+@SuppressWarnings({"unchecked", "PMD.JUnitTestsShouldIncludeAssert"})
+final class FuncWithFallbackTest {
 
     @Test
-    public void usesMainFunc() {
+    void usesMainFunc() {
         final String expected = "It's success";
         new Assertion<>(
             "Can't use the main function if no exception",
@@ -58,7 +59,7 @@ public final class FuncWithFallbackTest {
     }
 
     @Test
-    public void usesFallback() {
+    void usesFallback() {
         final String expected = "Never mind";
         new Assertion<>(
             "Can't use the callback in case of exception",
@@ -73,7 +74,7 @@ public final class FuncWithFallbackTest {
     }
 
     @Test
-    public void usesFallbackOfInterruptedException() {
+    void usesFallbackOfInterruptedException() {
         final String expected = "Fallback from InterruptedException";
         new Assertion<>(
             "Can't use a fallback from Interrupted in case of exception",
@@ -90,7 +91,7 @@ public final class FuncWithFallbackTest {
     }
 
     @Test
-    public void usesTheClosestFallback() {
+    void usesTheClosestFallback() {
         final String expected = "Fallback from IllegalFormatException";
         new Assertion<>(
             "Can't find the closest fallback",
@@ -113,14 +114,18 @@ public final class FuncWithFallbackTest {
         ).affirm();
     }
 
-    @Test(expected = Exception.class)
-    public void noFallbackIsProvided() throws Exception {
-        new FuncWithFallback<>(
-            input -> {
-                throw new IllegalFormatWidthException(1);
-            },
-            new IterableOf<>()
-        ).apply(1);
+    @Test
+    void noFallbackIsProvided() {
+        new Assertion<>(
+            "Cann't find fallback",
+            () -> new FuncWithFallback<>(
+                input -> {
+                    throw new IllegalFormatWidthException(1);
+                },
+                new IterableOf<>()
+            ).apply(1),
+            new Throws<>(Exception.class)
+        ).affirm();
     }
 
 }

--- a/src/test/java/org/cactoos/func/IoCheckedBiFuncTest.java
+++ b/src/test/java/org/cactoos/func/IoCheckedBiFuncTest.java
@@ -24,7 +24,7 @@
 package org.cactoos.func;
 
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.Throws;
 
@@ -33,10 +33,11 @@ import org.llorllale.cactoos.matchers.Throws;
  * @since 0.13
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class IoCheckedBiFuncTest {
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class IoCheckedBiFuncTest {
 
     @Test
-    public void rethrowsIoException() {
+    void rethrowsIoException() {
         final IOException exception = new IOException("intended");
         new Assertion<>(
             "Must rethrow IOException",
@@ -52,21 +53,29 @@ public final class IoCheckedBiFuncTest {
         ).affirm();
     }
 
-    @Test(expected = IOException.class)
-    public void rethrowsCheckedToIoException() throws Exception {
-        new IoCheckedBiFunc<>(
-            (fst, scd) -> {
-                throw new IOException("intended to fail");
-            }
-        ).apply(1, 2);
+    @Test
+    void rethrowsCheckedToIoException() {
+        new Assertion<>(
+            "IOException should be rethrown",
+            () -> new IoCheckedBiFunc<>(
+                (fst, scd) -> {
+                    throw new IOException("intended to fail");
+                }
+            ).apply(1, 2),
+            new Throws<>(IOException.class)
+        ).affirm();
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void runtimeExceptionGoesOut() throws IOException {
-        new IoCheckedBiFunc<>(
-            (fst, scd) -> {
-                throw new IllegalStateException("intended to fail here");
-            }
-        ).apply(1, 2);
+    @Test
+    void runtimeExceptionGoesOut() {
+        new Assertion<>(
+            "Runtime exception should be rethrown",
+            () -> new IoCheckedBiFunc<>(
+                (fst, scd) -> {
+                    throw new IllegalStateException("intended to fail here");
+                }
+            ).apply(1, 2),
+            new Throws<>(IllegalStateException.class)
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/func/IoCheckedFuncTest.java
+++ b/src/test/java/org/cactoos/func/IoCheckedFuncTest.java
@@ -34,6 +34,7 @@ import org.llorllale.cactoos.matchers.Throws;
  * @since 0.4
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class IoCheckedFuncTest {
 
     @Test

--- a/src/test/java/org/cactoos/func/RepeatedTest.java
+++ b/src/test/java/org/cactoos/func/RepeatedTest.java
@@ -39,6 +39,7 @@ import org.llorllale.cactoos.matchers.Throws;
  * @since 0.13.1
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class RepeatedTest {
 
     @Test

--- a/src/test/java/org/cactoos/func/RetryTest.java
+++ b/src/test/java/org/cactoos/func/RetryTest.java
@@ -36,7 +36,8 @@ import org.llorllale.cactoos.matchers.Throws;
  * @since 0.8
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals",
+    "PMD.JUnitTestsShouldIncludeAssert"})
 final class RetryTest {
 
     @Test

--- a/src/test/java/org/cactoos/func/SolidBiFuncTest.java
+++ b/src/test/java/org/cactoos/func/SolidBiFuncTest.java
@@ -38,6 +38,7 @@ import org.llorllale.cactoos.matchers.RunsInThreads;
  * @since 1.0
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class SolidBiFuncTest {
     @Test
     void testThatFuncIsSynchronized() {

--- a/src/test/java/org/cactoos/func/SolidFuncTest.java
+++ b/src/test/java/org/cactoos/func/SolidFuncTest.java
@@ -37,6 +37,7 @@ import org.llorllale.cactoos.matchers.RunsInThreads;
  * @since 0.24
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class SolidFuncTest {
 
     @Test

--- a/src/test/java/org/cactoos/func/StickyBiFuncTest.java
+++ b/src/test/java/org/cactoos/func/StickyBiFuncTest.java
@@ -34,6 +34,7 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @since 0.13
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class StickyBiFuncTest {
 
     @Test

--- a/src/test/java/org/cactoos/func/StickyFuncTest.java
+++ b/src/test/java/org/cactoos/func/StickyFuncTest.java
@@ -36,6 +36,7 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @since 0.4
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class StickyFuncTest {
 
     @Test

--- a/src/test/java/org/cactoos/func/SyncFuncTest.java
+++ b/src/test/java/org/cactoos/func/SyncFuncTest.java
@@ -36,6 +36,7 @@ import org.llorllale.cactoos.matchers.RunsInThreads;
  * @since 0.24
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class SyncFuncTest {
     @Test
     void funcWorksInThreads() {

--- a/src/test/java/org/cactoos/func/TimedFuncTest.java
+++ b/src/test/java/org/cactoos/func/TimedFuncTest.java
@@ -28,33 +28,39 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 import org.cactoos.iterable.Endless;
 import org.cactoos.scalar.And;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.IsTrue;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link Timed}.
  * @since 0.29.3
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class TimedFuncTest {
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class TimedFuncTest {
 
-    @Test(expected = TimeoutException.class)
-    public void functionGetsInterrupted() throws Exception {
+    @Test
+    void functionGetsInterrupted() {
         final long period = 100L;
-        new Timed<Boolean, Boolean>(
-            input -> {
-                return new And(
-                    new Endless<>(() -> input)
-                ).value();
-            },
-            period
-        ).apply(true);
+        new Assertion<>(
+            "Not interrupted after timeout",
+            () -> new Timed<Boolean, Boolean>(
+                input -> {
+                    return new And(
+                        new Endless<>(() -> input)
+                    ).value();
+                },
+                period
+            ).apply(true),
+            new Throws<>(TimeoutException.class)
+        ).affirm();
     }
 
     @Test
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
-    public void futureTaskIsCancelled() {
+    void futureTaskIsCancelled() {
         final long time = 2000L;
         final Future<Boolean> future = Executors.newSingleThreadExecutor()
             .submit(
@@ -80,7 +86,7 @@ public final class TimedFuncTest {
     }
 
     @Test
-    public void functionIsExecuted() throws Exception {
+    void functionIsExecuted() throws Exception {
         final long period = 3000L;
         new Assertion<>(
             "Must execute the function",

--- a/src/test/java/org/cactoos/func/UncheckedBiFuncTest.java
+++ b/src/test/java/org/cactoos/func/UncheckedBiFuncTest.java
@@ -25,28 +25,34 @@ package org.cactoos.func;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.IsTrue;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link UncheckedBiFunc}.
  * @since 0.13
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class UncheckedBiFuncTest {
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class UncheckedBiFuncTest {
 
-    @Test(expected = UncheckedIOException.class)
-    public void rethrowsCheckedToUncheckedException() {
-        new UncheckedBiFunc<>(
-            (fst, scd) -> {
-                throw new IOException("intended");
-            }
-        ).apply(1, 2);
+    @Test
+    void rethrowsCheckedToUncheckedException() {
+        new Assertion<>(
+            "Checked exception does not rethrown as unchecked",
+            () -> new UncheckedBiFunc<>(
+                (fst, scd) -> {
+                    throw new IOException("intended");
+                }
+            ).apply(1, 2),
+            new Throws<>(UncheckedIOException.class)
+        ).affirm();
     }
 
     @Test
-    public void testUncheckedBiFunc() {
+    void testUncheckedBiFunc() {
         new Assertion<>(
             "Must return value",
             new UncheckedBiFunc<>(
@@ -56,13 +62,17 @@ public final class UncheckedBiFuncTest {
         ).affirm();
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void runtimeExceptionGoesOut() {
-        new UncheckedBiFunc<>(
-            (fst, scd) -> {
-                throw new IllegalStateException("intended to fail");
-            }
-        ).apply(1, 2);
+    @Test
+    void runtimeExceptionGoesOut() {
+        new Assertion<>(
+            "Runtime exception rethrown without changes",
+            () -> new UncheckedBiFunc<>(
+                (fst, scd) -> {
+                    throw new IllegalStateException("intended to fail");
+                }
+            ).apply(1, 2),
+            new Throws<>(IllegalStateException.class)
+        ).affirm();
     }
 
 }

--- a/src/test/java/org/cactoos/func/UncheckedFuncTest.java
+++ b/src/test/java/org/cactoos/func/UncheckedFuncTest.java
@@ -26,7 +26,9 @@ package org.cactoos.func;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import org.cactoos.Func;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link UncheckedFunc}.
@@ -34,24 +36,33 @@ import org.junit.Test;
  * @since 0.2
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class UncheckedFuncTest {
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class UncheckedFuncTest {
 
-    @Test(expected = UncheckedIOException.class)
-    public void rethrowsCheckedToUncheckedException() {
-        new UncheckedFunc<>(
-            (Func<Integer, String>) i -> {
-                throw new IOException("intended");
-            }
-        ).apply(1);
+    @Test
+    void rethrowsCheckedToUncheckedException() {
+        new Assertion<>(
+            "Exception should be rethrown as unchecked",
+            () -> new UncheckedFunc<>(
+                (Func<Integer, String>) i -> {
+                    throw new IOException("intended");
+                }
+            ).apply(1),
+            new Throws<>(UncheckedIOException.class)
+        ).affirm();
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void runtimeExceptionGoesOut() {
-        new UncheckedFunc<>(
-            i -> {
-                throw new IllegalStateException("intended to fail");
-            }
-        ).apply(1);
+    @Test
+    void runtimeExceptionGoesOut() {
+        new Assertion<>(
+            "Runtime exception should be rethrown as is",
+            () -> new UncheckedFunc<>(
+                i -> {
+                    throw new IllegalStateException("intended to fail");
+                }
+            ).apply(1),
+            new Throws<>(IllegalStateException.class)
+        ).affirm();
     }
 
 }

--- a/src/test/java/org/cactoos/io/AppendToTest.java
+++ b/src/test/java/org/cactoos/io/AppendToTest.java
@@ -26,11 +26,11 @@ package org.cactoos.io;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
 import org.cactoos.text.Concatenated;
 import org.cactoos.text.Randomized;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasContent;
 import org.llorllale.cactoos.matchers.Throws;
@@ -40,19 +40,14 @@ import org.llorllale.cactoos.matchers.Throws;
  *
  * @since 1.0
  */
-public final class AppendToTest {
-
-    /**
-     * Temporary files and folders generator.
-     */
-    @Rule
-    public final TemporaryFolder folder = new TemporaryFolder();
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class AppendToTest {
 
     /**
      * Ensures that AppendTo is failing on a negative predicate result.
      */
     @Test
-    public void failsIfFileDoesNotExist() throws Exception {
+    void failsIfFileDoesNotExist() throws Exception {
         final File source = new File(
             new Randomized(
                 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'
@@ -70,11 +65,12 @@ public final class AppendToTest {
 
     /**
      * Ensures that AppendTo is appending to a given file.
+     * @param wdir TempDir to work in
      * @throws Exception if fails
      */
     @Test
-    public void appendsToFile() throws Exception {
-        final File source = this.folder.newFile();
+    void appendsToFile(@TempDir final Path wdir) throws Exception {
+        final File source = wdir.resolve("apptest.txt").toFile();
         final String first = "abdcd";
         new OutputTo(source).stream().write(first.getBytes());
         final String second = "efgh";
@@ -88,11 +84,12 @@ public final class AppendToTest {
 
     /**
      * Ensures that AppendTo is appending unicode text to a given file.
+     * @param wdir TempDir to work in
      * @throws Exception if fails
      */
     @Test
-    public void appendsUnicodeToFile() throws Exception {
-        final File source = this.folder.newFile();
+    void appendsUnicodeToFile(@TempDir final Path wdir) throws Exception {
+        final File source = wdir.resolve("appunitest.txt").toFile();
         final String first = "Hello, товарищ output #3 äÄ ";
         new OutputTo(source)
             .stream()

--- a/src/test/java/org/cactoos/io/AppendToTest.java
+++ b/src/test/java/org/cactoos/io/AppendToTest.java
@@ -24,6 +24,7 @@
 package org.cactoos.io;
 
 import java.io.File;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
@@ -67,14 +68,22 @@ final class AppendToTest {
      * Ensures that AppendTo is appending to a given file.
      * @param wdir TempDir to work in
      * @throws Exception if fails
+     * @todo #1586:2h Tests failed on Windows due to not closed streams.
+     *  It will be good to have feature to autoclose streams
      */
     @Test
     void appendsToFile(@TempDir final Path wdir) throws Exception {
         final File source = wdir.resolve("apptest.txt").toFile();
         final String first = "abdcd";
-        new OutputTo(source).stream().write(first.getBytes());
+        try (OutputStream out = new OutputTo(source).stream()) {
+            out.write(first.getBytes());
+            out.flush();
+        }
         final String second = "efgh";
-        new AppendTo(source).stream().write(second.getBytes());
+        try (OutputStream out = new AppendTo(source).stream()) {
+            out.write(second.getBytes());
+            out.flush();
+        }
         new Assertion<>(
             "Does not contain expected text",
             new InputOf(source),
@@ -91,13 +100,17 @@ final class AppendToTest {
     void appendsUnicodeToFile(@TempDir final Path wdir) throws Exception {
         final File source = wdir.resolve("appunitest.txt").toFile();
         final String first = "Hello, товарищ output #3 äÄ ";
-        new OutputTo(source)
-            .stream()
-            .write(first.getBytes(StandardCharsets.UTF_8));
+        try (OutputStream out = new OutputTo(source)
+            .stream()) {
+            out.write(first.getBytes(StandardCharsets.UTF_8));
+            out.flush();
+        }
         final String second = "#4 äÄ üÜ öÖ and ß";
-        new AppendTo(source)
-            .stream()
-            .write(second.getBytes(StandardCharsets.UTF_8));
+        try (OutputStream out = new AppendTo(source)
+            .stream()) {
+            out.write(second.getBytes(StandardCharsets.UTF_8));
+            out.flush();
+        }
         new Assertion<>(
             "Can't find expected unicode text content",
             new InputOf(source),

--- a/src/test/java/org/cactoos/io/AppendToTest.java
+++ b/src/test/java/org/cactoos/io/AppendToTest.java
@@ -68,7 +68,7 @@ final class AppendToTest {
      * Ensures that AppendTo is appending to a given file.
      * @param wdir TempDir to work in
      * @throws Exception if fails
-     * @todo #1586:2h Tests failed on Windows due to not closed streams.
+     * @todo #1586:1h Tests failed on Windows due to not closed streams.
      *  It will be good to have feature to autoclose streams
      */
     @Test

--- a/src/test/java/org/cactoos/io/AppendToTest.java
+++ b/src/test/java/org/cactoos/io/AppendToTest.java
@@ -69,7 +69,7 @@ final class AppendToTest {
      * @param wdir TempDir to work in
      * @throws Exception if fails
      * @todo #1586:1h Tests failed on Windows due to not closed streams.
-     *  It will be good to have feature to autoclose streams
+     *  It will be good to have feature to simplify autoclosing streams.
      */
     @Test
     void appendsToFile(@TempDir final Path wdir) throws Exception {

--- a/src/test/java/org/cactoos/io/CheckedInputTest.java
+++ b/src/test/java/org/cactoos/io/CheckedInputTest.java
@@ -35,6 +35,7 @@ import org.llorllale.cactoos.matchers.Throws;
  * @since 0.31
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class CheckedInputTest {
 
     @Test

--- a/src/test/java/org/cactoos/io/CheckedOutputTest.java
+++ b/src/test/java/org/cactoos/io/CheckedOutputTest.java
@@ -35,6 +35,7 @@ import org.llorllale.cactoos.matchers.Throws;
  * @since 0.31
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class CheckedOutputTest {
 
     @Test

--- a/src/test/java/org/cactoos/io/CloseShieldInputStreamTest.java
+++ b/src/test/java/org/cactoos/io/CloseShieldInputStreamTest.java
@@ -36,6 +36,7 @@ import org.llorllale.cactoos.matchers.Satisfies;
  * Test case for {@link CloseShieldInputStream}.
  * @since 1.0.0
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class CloseShieldInputStreamTest {
 
     @Test

--- a/src/test/java/org/cactoos/io/CloseShieldInputTest.java
+++ b/src/test/java/org/cactoos/io/CloseShieldInputTest.java
@@ -34,6 +34,7 @@ import org.llorllale.cactoos.matchers.IsText;
  * Test case for {@link CloseShieldInput}.
  * @since 1.0.0
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class CloseShieldInputTest {
 
     @Test

--- a/src/test/java/org/cactoos/io/CloseShieldOutputStreamTest.java
+++ b/src/test/java/org/cactoos/io/CloseShieldOutputStreamTest.java
@@ -38,6 +38,7 @@ import org.llorllale.cactoos.matchers.IsText;
  * Test case for {@link CloseShieldOutputStream}.
  * @since 1.0.0
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class CloseShieldOutputStreamTest {
 
     @Test

--- a/src/test/java/org/cactoos/io/CloseShieldOutputTest.java
+++ b/src/test/java/org/cactoos/io/CloseShieldOutputTest.java
@@ -32,6 +32,7 @@ import org.llorllale.cactoos.matchers.Assertion;
  * Test case for {@link CloseShieldOutput}.
  * @since 1.0.0
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class CloseShieldOutputTest {
 
     @Test

--- a/src/test/java/org/cactoos/io/DeadInputTest.java
+++ b/src/test/java/org/cactoos/io/DeadInputTest.java
@@ -33,6 +33,7 @@ import org.llorllale.cactoos.matchers.HasContent;
  * @since 0.16
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class DeadInputTest {
 
     @Test

--- a/src/test/java/org/cactoos/io/DeadOutputTest.java
+++ b/src/test/java/org/cactoos/io/DeadOutputTest.java
@@ -34,6 +34,7 @@ import org.llorllale.cactoos.matchers.HasContent;
  * @since 0.16
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class DeadOutputTest {
 
     @Test

--- a/src/test/java/org/cactoos/io/DirectoryTest.java
+++ b/src/test/java/org/cactoos/io/DirectoryTest.java
@@ -27,9 +27,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasSize;
 
@@ -38,17 +37,11 @@ import org.llorllale.cactoos.matchers.HasSize;
  * @since 0.12
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class DirectoryTest {
-
-    /**
-     * Temporary folder.
-     */
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class DirectoryTest {
 
     @Test
-    public void listsFilesAndFoldersInDirectory() throws IOException {
-        final Path dir = this.folder.newFolder().toPath();
+    void listsFilesAndFoldersInDirectory(@TempDir final Path dir) throws IOException {
         dir.resolve("x/y").toFile().mkdirs();
         Files.write(dir.resolve("x/y/test"), "".getBytes());
         new Assertion<>(
@@ -59,9 +52,8 @@ public final class DirectoryTest {
     }
 
     @Test
-    public void listsFilesInDirectoryByFile() throws Exception {
-        final File file = this.folder.newFolder();
-        final Path dir = file.toPath();
+    void listsFilesInDirectoryByFile(@TempDir final Path dir) throws Exception {
+        final File file = dir.toFile();
         dir.resolve("parent/child").toFile().mkdirs();
         Files.write(dir.resolve("parent/child/file"), "".getBytes());
         new Assertion<>(

--- a/src/test/java/org/cactoos/io/GzipInputTest.java
+++ b/src/test/java/org/cactoos/io/GzipInputTest.java
@@ -32,19 +32,21 @@ import java.io.Writer;
 import java.util.zip.GZIPOutputStream;
 import org.cactoos.scalar.LengthOf;
 import org.cactoos.text.TextOf;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.IsText;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link GzipInput}.
  * @since 0.29
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class GzipInputTest {
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class GzipInputTest {
 
     @Test
-    public void readFromGzipInput() throws Exception {
+    void readFromGzipInput() throws Exception {
         final String content = "Hello!";
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         try (
@@ -66,10 +68,14 @@ public final class GzipInputTest {
         ).affirm();
     }
 
-    @Test(expected = EOFException.class)
-    public void readFromDeadGzipInput() throws Exception {
-        new LengthOf(
-            new GzipInput(new DeadInput())
-        ).value();
+    @Test
+    void readFromDeadGzipInput() {
+        new Assertion<>(
+            "Can't read from empty input",
+            () -> new LengthOf(
+                new GzipInput(new DeadInput())
+            ).value(),
+            new Throws<>(EOFException.class)
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/io/GzipOutputTest.java
+++ b/src/test/java/org/cactoos/io/GzipOutputTest.java
@@ -31,30 +31,26 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.zip.GZIPOutputStream;
 import org.cactoos.scalar.LengthOf;
 import org.hamcrest.core.IsEqual;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link GzipOutput}.
  * @checkstyle JavadocMethodCheck (500 lines)
  * @since 0.29
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class GzipOutputTest {
-    /**
-     * Temporary files and folders generator.
-     */
-    @Rule
-    public final TemporaryFolder folder = new TemporaryFolder();
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals",
+    "PMD.JUnitTestsShouldIncludeAssert"})
+final class GzipOutputTest {
 
     @Test
-    public void writeToGzipOutput() throws Exception {
+    void writeToGzipOutput() throws Exception {
         final String content = "Hello!";
         final ByteArrayOutputStream expected = new ByteArrayOutputStream();
         try (
@@ -85,20 +81,22 @@ public final class GzipOutputTest {
         ).affirm();
     }
 
-    @Test(expected = IOException.class)
-    public void writeToClosedGzipOutput() throws Exception {
+    @Test
+    void writeToClosedGzipOutput(@TempDir final Path wdir) throws Exception {
         final OutputStream stream =
             Files.newOutputStream(
-                Paths.get(
-                    this.folder.newFile("cactoos.txt").getPath()
-                )
+                wdir.resolve("cactoos.txt")
             );
         stream.close();
-        new LengthOf(
-            new TeeInput(
-                "Hello!",
-                new GzipOutput(new OutputTo(stream))
-            )
-        ).value();
+        new Assertion<>(
+            "Cann't write to closed stream",
+            () -> new LengthOf(
+                new TeeInput(
+                    "Hello!",
+                    new GzipOutput(new OutputTo(stream))
+                )
+            ).value(),
+            new Throws<>(IOException.class)
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/io/HeadInputStreamTest.java
+++ b/src/test/java/org/cactoos/io/HeadInputStreamTest.java
@@ -36,7 +36,8 @@ import org.llorllale.cactoos.matchers.IsText;
  * @since 0.31
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals",
+    "PMD.JUnitTestsShouldIncludeAssert"})
 final class HeadInputStreamTest {
 
     @Test

--- a/src/test/java/org/cactoos/io/HeadOfTest.java
+++ b/src/test/java/org/cactoos/io/HeadOfTest.java
@@ -34,6 +34,7 @@ import org.llorllale.cactoos.matchers.HasString;
  * @since 0.31
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class HeadOfTest {
 
     @Test

--- a/src/test/java/org/cactoos/io/InputNoNullsTest.java
+++ b/src/test/java/org/cactoos/io/InputNoNullsTest.java
@@ -23,27 +23,38 @@
  */
 package org.cactoos.io;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link InputNoNulls}.
  * @since 0.10
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class InputNoNullsTest {
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class InputNoNullsTest {
 
-    @Test(expected = Exception.class)
-    public void failForNullInput() throws Exception {
-        new InputNoNulls(null).stream();
-    }
-
-    @Test(expected = Exception.class)
-    public void failForNullStream() throws Exception {
-        new InputNoNulls(() -> null).stream();
+    @Test
+    void failForNullInput() {
+        new Assertion<>(
+            "Does not fail on null input",
+            () -> new InputNoNulls(null).stream(),
+            new Throws<>(Exception.class)
+        ).affirm();
     }
 
     @Test
-    public void okForNoNullInput() throws Exception {
+    void failForNullStream() {
+        new Assertion<>(
+            "Does not fail on null stream",
+            () -> new InputNoNulls(() -> null).stream(),
+            new Throws<>(Exception.class)
+        ).affirm();
+    }
+
+    @Test
+    void okForNoNullInput() throws Exception {
         new InputNoNulls(new DeadInput()).stream();
     }
 }

--- a/src/test/java/org/cactoos/io/InputOfTest.java
+++ b/src/test/java/org/cactoos/io/InputOfTest.java
@@ -57,7 +57,8 @@ import org.takes.tk.TkHtml;
  * @since 0.1
  * @checkstyle ClassFanOutComplexityCheck (500 lines)
  */
-@SuppressWarnings({"PMD.TooManyMethods", "PMD.ExcessiveImports", "unchecked"})
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.ExcessiveImports",
+    "unchecked", "PMD.JUnitTestsShouldIncludeAssert"})
 final class InputOfTest {
     @Test
     void readsAlternativeInputForFileCase() {

--- a/src/test/java/org/cactoos/io/InputStreamOfTest.java
+++ b/src/test/java/org/cactoos/io/InputStreamOfTest.java
@@ -32,9 +32,8 @@ import java.nio.file.Path;
 import org.cactoos.bytes.BytesOf;
 import org.cactoos.scalar.LengthOf;
 import org.cactoos.text.TextOf;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasContent;
 import org.llorllale.cactoos.matchers.IsText;
@@ -46,18 +45,13 @@ import org.llorllale.cactoos.matchers.Satisfies;
  * @since 0.13
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-@SuppressWarnings("PMD.TooManyMethods")
-public final class InputStreamOfTest {
-    /**
-     * Temporary files and folders generator.
-     */
-    @Rule
-    public final TemporaryFolder folder = new TemporaryFolder();
+@SuppressWarnings({"PMD.TooManyMethods",
+    "PMD.JUnitTestsShouldIncludeAssert"})
+final class InputStreamOfTest {
 
     @Test
-    public void readsSimpleFileContent() throws IOException {
-        final Path temp = this.folder.newFile("cactoos-1.txt-1")
-            .toPath();
+    void readsSimpleFileContent(@TempDir final Path wdir) throws IOException {
+        final Path temp = wdir.resolve("cactoos-1.txt-1");
         final String content = "Hello, товарищ!";
         Files.write(temp, content.getBytes(StandardCharsets.UTF_8));
         new Assertion<>(
@@ -68,7 +62,7 @@ public final class InputStreamOfTest {
     }
 
     @Test
-    public void readsFromReader() {
+    void readsFromReader() {
         final String content = "Hello, дорогой товарищ!";
         new Assertion<>(
             "Must read from reader",
@@ -78,7 +72,7 @@ public final class InputStreamOfTest {
     }
 
     @Test
-    public void readsFromReaderThroughSmallBuffer() {
+    void readsFromReaderThroughSmallBuffer() {
         final String content = "Hello, صديق!";
         new Assertion<>(
             "Must read from reader through small buffer",
@@ -88,7 +82,7 @@ public final class InputStreamOfTest {
     }
 
     @Test
-    public void makesDataAvailable() throws IOException {
+    void makesDataAvailable() throws IOException {
         final String content = "Hello,חבר!";
         new Assertion<>(
             "Must show that data is available",
@@ -98,8 +92,8 @@ public final class InputStreamOfTest {
     }
 
     @Test
-    public void readsFileContent() throws Exception {
-        final File file = this.folder.newFile("readFileContent.txt-2");
+    void readsFileContent(@TempDir final Path wdir) throws Exception {
+        final File file = wdir.resolve("readFileContent.txt-2").toFile();
         final String content = "Content in a file";
         new LengthOf(
             new TeeInput(content, file)
@@ -112,7 +106,7 @@ public final class InputStreamOfTest {
     }
 
     @Test
-    public void readsBytes() {
+    void readsBytes() {
         final String content = "Bytes content";
         new Assertion<>(
             "Must read from bytes",
@@ -122,7 +116,7 @@ public final class InputStreamOfTest {
     }
 
     @Test
-    public void readsBytesArray() throws Exception {
+    void readsBytesArray() throws Exception {
         final String content = "Bytes array content";
         final byte[] bytes = new BytesOf(content).asBytes();
         new Assertion<>(
@@ -133,7 +127,7 @@ public final class InputStreamOfTest {
     }
 
     @Test
-    public void readsText() {
+    void readsText() {
         final String content = "Text content";
         new Assertion<>(
             "Must read from text",
@@ -143,9 +137,9 @@ public final class InputStreamOfTest {
     }
 
     @Test
-    public void readsFromUri() throws Exception {
+    void readsFromUri(@TempDir final Path wdir) throws Exception {
         final String content = "Content for reading through URI";
-        final File file = this.folder.newFile("readFromUri.txt-3");
+        final File file = wdir.resolve("readFromUri.txt-3").toFile();
         new LengthOf(
             new TeeInput(content, file)
         ).value();
@@ -157,9 +151,9 @@ public final class InputStreamOfTest {
     }
 
     @Test
-    public void readsFromUrl() throws Exception {
+    void readsFromUrl(@TempDir final Path wdir) throws Exception {
         final String content = "Content for reading through URL";
-        final File file = this.folder.newFile("readFromUrl.txt-4");
+        final File file = wdir.resolve("readFromUrl.txt-4").toFile();
         new LengthOf(
             new TeeInput(content, file)
         ).value();
@@ -171,7 +165,7 @@ public final class InputStreamOfTest {
     }
 
     @Test
-    public void readsFromReaderWithMax() {
+    void readsFromReaderWithMax() {
         final String content = "Reading with charset name and buffer size";
         final int max = 3;
         new Assertion<>(
@@ -188,7 +182,7 @@ public final class InputStreamOfTest {
     }
 
     @Test
-    public void readsFromReaderWithCharsetWithMax() {
+    void readsFromReaderWithCharsetWithMax() {
         final String content = "Reading with charset and buffer size";
         new Assertion<>(
             "Must read from reader with charset and buffer size",
@@ -204,7 +198,7 @@ public final class InputStreamOfTest {
     }
 
     @Test
-    public void readsFromReaderWithCharset() {
+    void readsFromReaderWithCharset() {
         final String content = "Content for reading with charset";
         new Assertion<>(
             "Must read from reader with charset name",
@@ -219,8 +213,8 @@ public final class InputStreamOfTest {
     }
 
     @Test
-    public void readsFromTextWithCharset() throws Exception {
-        final File file = this.folder.newFile("readTextWithCharset.txt-5");
+    void readsFromTextWithCharset(@TempDir final Path wdir) throws Exception {
+        final File file = wdir.resolve("readTextWithCharset.txt-5").toFile();
         final String content = "Content for reading text with charset";
         new LengthOf(
             new TeeInput(content, file)
@@ -238,7 +232,7 @@ public final class InputStreamOfTest {
     }
 
     @Test
-    public void readsFromCharSequenceWithCharsetName() {
+    void readsFromCharSequenceWithCharsetName() {
         final String content = "Simple content";
         new Assertion<>(
             "Must read from char sequence with charset name",
@@ -253,7 +247,7 @@ public final class InputStreamOfTest {
     }
 
     @Test
-    public void readsFromCharSequenceWithCharset() {
+    void readsFromCharSequenceWithCharset() {
         final String content = "Another simple content";
         new Assertion<>(
             "Must read from char sequence with charset",

--- a/src/test/java/org/cactoos/io/InputWithFallbackTest.java
+++ b/src/test/java/org/cactoos/io/InputWithFallbackTest.java
@@ -36,6 +36,7 @@ import org.llorllale.cactoos.matchers.EndsWith;
  * @since 0.9
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class InputWithFallbackTest {
 
     @Test

--- a/src/test/java/org/cactoos/io/JoinedTest.java
+++ b/src/test/java/org/cactoos/io/JoinedTest.java
@@ -33,6 +33,7 @@ import org.llorllale.cactoos.matchers.HasContent;
  * Unit tests for {@link Joined}.
  * @since 0.36
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class JoinedTest {
     /**
      * Must join inputs in the given order.

--- a/src/test/java/org/cactoos/io/LSInputOfTest.java
+++ b/src/test/java/org/cactoos/io/LSInputOfTest.java
@@ -35,6 +35,7 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle AbbreviationAsWordInNameCheck (5 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class LSInputOfTest {
 
     @Test

--- a/src/test/java/org/cactoos/io/LoggingInputStreamTest.java
+++ b/src/test/java/org/cactoos/io/LoggingInputStreamTest.java
@@ -37,6 +37,7 @@ import org.llorllale.cactoos.matchers.Throws;
  * @since 0.39
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class LoggingInputStreamTest {
 
     @Test

--- a/src/test/java/org/cactoos/io/LoggingInputTest.java
+++ b/src/test/java/org/cactoos/io/LoggingInputTest.java
@@ -40,12 +40,9 @@ import org.llorllale.cactoos.matchers.HasString;
  * @since 0.29
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-@SuppressWarnings(
-    {
-        "PMD.MoreThanOneLogger",
-        "PMD.AvoidDuplicateLiterals"
-    }
-)
+@SuppressWarnings({"PMD.MoreThanOneLogger",
+    "PMD.AvoidDuplicateLiterals",
+    "PMD.JUnitTestsShouldIncludeAssert"})
 final class LoggingInputTest {
 
     @Test

--- a/src/test/java/org/cactoos/io/LoggingOutputTest.java
+++ b/src/test/java/org/cactoos/io/LoggingOutputTest.java
@@ -33,9 +33,8 @@ import org.cactoos.scalar.LengthOf;
 import org.hamcrest.core.AllOf;
 import org.hamcrest.core.IsNot;
 import org.hamcrest.core.StringContains;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.llorllale.cactoos.matchers.Assertion;
 
 /**
@@ -44,21 +43,13 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @since 0.29
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-@SuppressWarnings(
-    {
-        "PMD.MoreThanOneLogger",
-        "PMD.AvoidDuplicateLiterals"
-    }
-)
-public final class LoggingOutputTest {
-    /**
-     * Temporary files and folders generator.
-     */
-    @Rule
-    public final TemporaryFolder folder = new TemporaryFolder();
+@SuppressWarnings({"PMD.MoreThanOneLogger",
+    "PMD.AvoidDuplicateLiterals",
+    "PMD.JUnitTestsShouldIncludeAssert"})
+final class LoggingOutputTest {
 
     @Test
-    public void logWriteZero() throws Exception {
+    void logWriteZero() throws Exception {
         final Logger logger = new FakeLogger();
         new LengthOf(
             new TeeInput(
@@ -78,7 +69,7 @@ public final class LoggingOutputTest {
     }
 
     @Test
-    public void logWriteOneByte() throws Exception {
+    void logWriteOneByte() throws Exception {
         final Logger logger = new FakeLogger();
         try (
             OutputStream out = new LoggingOutput(
@@ -97,7 +88,7 @@ public final class LoggingOutputTest {
     }
 
     @Test
-    public void logWriteText() throws Exception {
+    void logWriteText() throws Exception {
         final Logger logger = new FakeLogger();
         try (
             OutputStream out = new LoggingOutput(
@@ -117,9 +108,9 @@ public final class LoggingOutputTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void logWriteToLargeTextFile() throws Exception {
+    void logWriteToLargeTextFile(@TempDir final Path wdir) throws Exception {
         final Logger logger = new FakeLogger();
-        final Path temp = this.folder.newFolder("ccts-1").toPath();
+        final Path temp = wdir.resolve("ccts-1");
         final Path path = temp.resolve("x/y/z/file.txt");
         try (OutputStream output = new LoggingOutput(
             new OutputTo(path),
@@ -151,9 +142,9 @@ public final class LoggingOutputTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void logAllWriteToLargeTextFile() throws Exception {
+    void logAllWriteToLargeTextFile(@TempDir final Path wdir) throws Exception {
         final Logger logger = new FakeLogger(Level.WARNING);
-        final Path temp = this.folder.newFolder("ccts-2").toPath();
+        final Path temp = wdir.resolve("ccts-2");
         final Path path = temp.resolve("a/b/c/file.txt");
         try (OutputStream output = new LoggingOutput(
             new OutputTo(path),

--- a/src/test/java/org/cactoos/io/OutputNoNullsTest.java
+++ b/src/test/java/org/cactoos/io/OutputNoNullsTest.java
@@ -23,27 +23,38 @@
  */
 package org.cactoos.io;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link OutputNoNulls}.
  * @since 0.10
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class OutputNoNullsTest {
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class OutputNoNullsTest {
 
-    @Test(expected = Exception.class)
-    public void failForNullOutput() throws Exception {
-        new OutputNoNulls(null).stream();
-    }
-
-    @Test(expected = Exception.class)
-    public void failForNullStream() throws Exception {
-        new OutputNoNulls(() -> null).stream();
+    @Test
+    void failForNullOutput() {
+        new Assertion<>(
+            "Doesn't fail for null output",
+            () -> new OutputNoNulls(null).stream(),
+            new Throws<>(Exception.class)
+        ).affirm();
     }
 
     @Test
-    public void okForNoNullOutput() throws Exception {
+    void failForNullStream() {
+        new Assertion<>(
+            "Doesn't fail for null output stream",
+            () -> new OutputNoNulls(() -> null).stream(),
+            new Throws<>(Exception.class)
+        ).affirm();
+    }
+
+    @Test
+    void okForNoNullOutput() throws Exception {
         new OutputNoNulls(new DeadOutput()).stream();
     }
 }

--- a/src/test/java/org/cactoos/io/OutputStreamToTest.java
+++ b/src/test/java/org/cactoos/io/OutputStreamToTest.java
@@ -26,9 +26,8 @@ package org.cactoos.io;
 import java.io.IOException;
 import java.nio.file.Path;
 import org.cactoos.text.TextOf;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.IsText;
 
@@ -38,17 +37,12 @@ import org.llorllale.cactoos.matchers.IsText;
  * @since 0.13
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class OutputStreamToTest {
-    /**
-     * Temporary files and folders generator.
-     */
-    @Rule
-    public final TemporaryFolder folder = new TemporaryFolder();
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class OutputStreamToTest {
 
     @Test
-    public void writesLargeContentToFile() throws IOException {
-        final Path temp = this.folder.newFile("cactoos-1.txt-1")
-            .toPath();
+    void writesLargeContentToFile(@TempDir final Path wdir) throws IOException {
+        final Path temp = wdir.resolve("cactoos-1.txt-1");
         new Assertion<>(
             "Must copy Input to Output and return Input",
             new TextOf(

--- a/src/test/java/org/cactoos/io/OutputToTest.java
+++ b/src/test/java/org/cactoos/io/OutputToTest.java
@@ -27,9 +27,8 @@ import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import org.cactoos.scalar.LengthOf;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasContent;
 
@@ -39,18 +38,12 @@ import org.llorllale.cactoos.matchers.HasContent;
  * @since 0.15
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class OutputToTest {
-
-    /**
-     * Temporary folder.
-     */
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class OutputToTest {
 
     @Test
-    public void writesIntoPath() throws Exception {
-        final Path temp = this.folder.newFolder("cactoos-1").toPath();
-        final Path path = temp.resolve("one/two/three/file.txt");
+    void writesIntoPath(@TempDir final Path wdir) throws Exception {
+        final Path path = wdir.resolve("one/two/three/file.txt");
         final String content = "Hello, товарищ!";
         new LengthOf(new TeeInput(content, new OutputTo(path))).value();
         new Assertion<>(
@@ -61,9 +54,8 @@ public final class OutputToTest {
     }
 
     @Test
-    public void writesIntoFile() throws Exception {
-        final Path temp = this.folder.newFolder("cactoos-2").toPath();
-        final Path path = temp.resolve("a/b/c/file.txt");
+    void writesIntoFile(@TempDir final Path wdir) throws Exception {
+        final Path path = wdir.resolve("a/b/c/file.txt");
         final String txt = "Hello, друг!";
         new LengthOf(
             new TeeInput(txt, new SyncOutput(new OutputTo(path.toFile())))
@@ -76,7 +68,7 @@ public final class OutputToTest {
     }
 
     @Test
-    public void writesIntoWriter() throws Exception {
+    void writesIntoWriter() throws Exception {
         final String txt = "Hello, writer!";
         final StringWriter output = new StringWriter();
         new LengthOf(new TeeInput(txt, new OutputTo(output))).value();
@@ -88,7 +80,7 @@ public final class OutputToTest {
     }
 
     @Test
-    public void writesIntoWriterWithCharset() throws Exception {
+    void writesIntoWriterWithCharset() throws Exception {
         final String txt = "Hello, writer with charset!";
         final StringWriter output = new StringWriter();
         new LengthOf(
@@ -102,7 +94,7 @@ public final class OutputToTest {
     }
 
     @Test
-    public void writesIntoWriterWithCharsetByName() throws Exception {
+    void writesIntoWriterWithCharsetByName() throws Exception {
         final String txt = "Hello, writer with charset by name!";
         final StringWriter output = new StringWriter();
         new LengthOf(
@@ -116,7 +108,7 @@ public final class OutputToTest {
     }
 
     @Test
-    public void writesIntoWriterWithCharsetAndSize() throws Exception {
+    void writesIntoWriterWithCharsetAndSize() throws Exception {
         final String txt = "Hello, writer with charset and size!";
         final StringWriter output = new StringWriter();
         new LengthOf(
@@ -133,7 +125,7 @@ public final class OutputToTest {
     }
 
     @Test
-    public void writesIntoWriterWithSize() throws Exception {
+    void writesIntoWriterWithSize() throws Exception {
         final String txt = "Hello, writer with size!";
         final StringWriter output = new StringWriter();
         new LengthOf(
@@ -150,7 +142,7 @@ public final class OutputToTest {
     }
 
     @Test
-    public void writesIntoWriterWithCharsetByNameAndSize() throws Exception {
+    void writesIntoWriterWithCharsetByNameAndSize() throws Exception {
         final String txt = "Hello, writer with charset by name and size!";
         final StringWriter output = new StringWriter();
         new LengthOf(
@@ -167,7 +159,7 @@ public final class OutputToTest {
     }
 
     @Test
-    public void writesIntoWriterWithDecoderAndSize() throws Exception {
+    void writesIntoWriterWithDecoderAndSize() throws Exception {
         final String txt = "Hello, writer with decoder and size!";
         final StringWriter output = new StringWriter();
         new LengthOf(

--- a/src/test/java/org/cactoos/io/ReaderOfTest.java
+++ b/src/test/java/org/cactoos/io/ReaderOfTest.java
@@ -26,11 +26,11 @@ package org.cactoos.io;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import org.cactoos.bytes.BytesOf;
 import org.cactoos.text.TextOf;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.IsText;
 
@@ -39,17 +39,12 @@ import org.llorllale.cactoos.matchers.IsText;
  * @since 0.13
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-@SuppressWarnings("PMD.TooManyMethods")
-public final class ReaderOfTest {
-
-    /**
-     * Temporary files generator.
-     */
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+@SuppressWarnings({"PMD.TooManyMethods",
+    "PMD.JUnitTestsShouldIncludeAssert"})
+final class ReaderOfTest {
 
     @Test
-    public void readsEmpty() throws Exception {
+    void readsEmpty() {
         final String empty = "";
         new Assertion<>(
             "Must read empty string",
@@ -59,7 +54,7 @@ public final class ReaderOfTest {
     }
 
     @Test
-    public void readsCharVarArg() throws Exception {
+    void readsCharVarArg() throws Exception {
         new Assertion<>(
             "Must read chars var args",
             new TextOf(new ReaderOf('a', 'b', 'c')),
@@ -68,7 +63,7 @@ public final class ReaderOfTest {
     }
 
     @Test
-    public void readsCharArrayWithCharset() throws Exception {
+    void readsCharArrayWithCharset() throws Exception {
         final String message =
             "char array on äÄ üÜ öÖ ß жш";
         new Assertion<>(
@@ -84,7 +79,7 @@ public final class ReaderOfTest {
     }
 
     @Test
-    public void readsCharArrayWithCharsetByName() throws Exception {
+    void readsCharArrayWithCharsetByName() throws Exception {
         final String message =
             "char array with charset on äÄ üÜ öÖ ß жш";
         new Assertion<>(
@@ -100,7 +95,7 @@ public final class ReaderOfTest {
     }
 
     @Test
-    public void readsByteArray() throws Exception {
+    void readsByteArray() throws Exception {
         final String message =
             "byte array on äÄ üÜ öÖ ß жш";
         new Assertion<>(
@@ -115,7 +110,7 @@ public final class ReaderOfTest {
     }
 
     @Test
-    public void readsByteArrayWithCharset() throws Exception {
+    void readsByteArrayWithCharset() throws Exception {
         final String message =
             "byte array with charset on äÄ üÜ öÖ ß жш";
         new Assertion<>(
@@ -131,7 +126,7 @@ public final class ReaderOfTest {
     }
 
     @Test
-    public void readsByteArrayWithCharsetByName() throws Exception {
+    void readsByteArrayWithCharsetByName() throws Exception {
         final String message =
             "bte array with charset by name on äÄ üÜ öÖ ß жш";
         new Assertion<>(
@@ -147,10 +142,10 @@ public final class ReaderOfTest {
     }
 
     @Test
-    public void readsPath() throws Exception {
+    void readsPath(@TempDir final Path wdir) throws Exception {
         final String message =
             "path on äÄ üÜ öÖ ß жш";
-        final File input = this.folder.newFile();
+        final File input = wdir.resolve("reader1.txt").toFile();
         Files.write(
             input.toPath(),
             message.getBytes(StandardCharsets.UTF_8)
@@ -163,10 +158,10 @@ public final class ReaderOfTest {
     }
 
     @Test
-    public void readsFile() throws Exception {
+    void readsFile(@TempDir final Path wdir) throws Exception {
         final String message =
             "file on äÄ üÜ öÖ ß жш";
-        final File input = this.folder.newFile();
+        final File input = wdir.resolve("reader2.txt").toFile();
         Files.write(
             input.toPath(),
             message.getBytes(StandardCharsets.UTF_8)
@@ -179,10 +174,10 @@ public final class ReaderOfTest {
     }
 
     @Test
-    public void readsUrl() throws Exception {
+    void readsUrl(@TempDir final Path wdir) throws Exception {
         final String message =
             "URL on äÄ üÜ öÖ ß жш";
-        final File input = this.folder.newFile();
+        final File input = wdir.resolve("reader3.txt").toFile();
         Files.write(
             input.toPath(),
             message.getBytes(StandardCharsets.UTF_8)
@@ -201,10 +196,10 @@ public final class ReaderOfTest {
     }
 
     @Test
-    public void readsUri() throws Exception {
+    void readsUri(@TempDir final Path wdir) throws Exception {
         final String message =
             "URI on äÄ üÜ öÖ ß жш";
-        final File input = this.folder.newFile();
+        final File input = wdir.resolve("reader4.txt").toFile();
         Files.write(
             input.toPath(),
             message.getBytes(StandardCharsets.UTF_8)
@@ -217,7 +212,7 @@ public final class ReaderOfTest {
     }
 
     @Test
-    public void readsBytes() throws Exception {
+    void readsBytes() throws Exception {
         final String input =
             "Bytes on äÄ üÜ öÖ ß жш";
         new Assertion<>(
@@ -228,7 +223,7 @@ public final class ReaderOfTest {
     }
 
     @Test
-    public void readsText() throws Exception {
+    void readsText() throws Exception {
         final String input =
             "Text on äÄ üÜ öÖ ß жш";
         new Assertion<>(
@@ -239,7 +234,7 @@ public final class ReaderOfTest {
     }
 
     @Test
-    public void readsTextWithCharset() throws Exception {
+    void readsTextWithCharset() throws Exception {
         final String input =
             "Text with charset on äÄ üÜ öÖ ß жш";
         new Assertion<>(
@@ -255,7 +250,7 @@ public final class ReaderOfTest {
     }
 
     @Test
-    public void readsTextWithCharsetByName() throws Exception {
+    void readsTextWithCharsetByName() throws Exception {
         final String input =
             "Text with charset by name on äÄ üÜ öÖ ß жш";
         new Assertion<>(
@@ -271,7 +266,7 @@ public final class ReaderOfTest {
     }
 
     @Test
-    public void readsCharSequence() throws Exception {
+    void readsCharSequence() throws Exception {
         final String input =
             "char sequence on äÄ üÜ öÖ ß жш";
         new Assertion<>(
@@ -282,7 +277,7 @@ public final class ReaderOfTest {
     }
 
     @Test
-    public void readsCharSequenceWithCharset() throws Exception {
+    void readsCharSequenceWithCharset() throws Exception {
         final String input =
             "char sequence with charset on äÄ üÜ öÖ ß жш";
         new Assertion<>(
@@ -298,7 +293,7 @@ public final class ReaderOfTest {
     }
 
     @Test
-    public void readsCharSequenceWithCharsetByName() throws Exception {
+    void readsCharSequenceWithCharsetByName() throws Exception {
         final String input =
             "char sequence with charset by name on äÄ üÜ öÖ ß жш";
         new Assertion<>(
@@ -314,7 +309,7 @@ public final class ReaderOfTest {
     }
 
     @Test
-    public void readsInput() throws Exception {
+    void readsInput() throws Exception {
         final String input =
             "Input on äÄ üÜ öÖ ß жш";
         new Assertion<>(
@@ -325,7 +320,7 @@ public final class ReaderOfTest {
     }
 
     @Test
-    public void readsInputWithCharset() throws Exception {
+    void readsInputWithCharset() throws Exception {
         final String input =
             "Input with charset on äÄ üÜ öÖ ß жш";
         new Assertion<>(
@@ -341,7 +336,7 @@ public final class ReaderOfTest {
     }
 
     @Test
-    public void readsInputWithCharsetByName() throws Exception {
+    void readsInputWithCharsetByName() throws Exception {
         final String input =
             "Input with charset by name on äÄ üÜ öÖ ß жш";
         new Assertion<>(
@@ -357,7 +352,7 @@ public final class ReaderOfTest {
     }
 
     @Test
-    public void readsInputWithCharsetDecoder() throws Exception {
+    void readsInputWithCharsetDecoder() throws Exception {
         final String input =
             "Input with charset decoder on äÄ üÜ öÖ ß жш";
         new Assertion<>(
@@ -373,7 +368,7 @@ public final class ReaderOfTest {
     }
 
     @Test
-    public void readsInputStream() throws Exception {
+    void readsInputStream() throws Exception {
         final String input =
             "InputStream on äÄ üÜ öÖ ß жш";
         new Assertion<>(
@@ -384,7 +379,7 @@ public final class ReaderOfTest {
     }
 
     @Test
-    public void readsInputStreamWithCharset() throws Exception {
+    void readsInputStreamWithCharset() throws Exception {
         final String input =
             "InputStream with charset on äÄ üÜ öÖ ß жш";
         new Assertion<>(
@@ -400,7 +395,7 @@ public final class ReaderOfTest {
     }
 
     @Test
-    public void readsInputStreamWithCharsetByName() throws Exception {
+    void readsInputStreamWithCharsetByName() throws Exception {
         final String input =
             "InputStream with charset by name on äÄ üÜ öÖ ß жш";
         new Assertion<>(
@@ -416,7 +411,7 @@ public final class ReaderOfTest {
     }
 
     @Test
-    public void readsInputStreamWithCharsetDecoder() throws Exception {
+    void readsInputStreamWithCharsetDecoder() throws Exception {
         final String input =
             "InputStream with charset decoder on äÄ üÜ öÖ ß жш";
         new Assertion<>(

--- a/src/test/java/org/cactoos/io/ResourceOfTest.java
+++ b/src/test/java/org/cactoos/io/ResourceOfTest.java
@@ -30,10 +30,11 @@ import org.cactoos.bytes.BytesOf;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.TextOf;
 import org.hamcrest.core.IsEqual;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.EndsWith;
 import org.llorllale.cactoos.matchers.StartsWith;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link ResourceOf}.
@@ -41,10 +42,11 @@ import org.llorllale.cactoos.matchers.StartsWith;
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class ResourceOfTest {
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class ResourceOfTest {
 
     @Test
-    public void readsBinaryResource() throws Exception {
+    void readsBinaryResource() throws Exception {
         new Assertion<>(
             "Can't read bytes from a classpath resource",
             Arrays.copyOfRange(
@@ -65,7 +67,7 @@ public final class ResourceOfTest {
     }
 
     @Test
-    public void readsTextResource() throws Exception {
+    void readsTextResource() throws Exception {
         new Assertion<>(
             "Must read a text resource from classpath",
             ResourceOfTest.large(),
@@ -74,7 +76,7 @@ public final class ResourceOfTest {
     }
 
     @Test
-    public void readsTextResourceThroughClassloader() throws Exception {
+    void readsTextResourceThroughClassloader() throws Exception {
         new Assertion<>(
             "Must read a text resource from classloader",
             ResourceOfTest.large(),
@@ -83,7 +85,7 @@ public final class ResourceOfTest {
     }
 
     @Test
-    public void readAbsentResourceTest() throws Exception {
+    void readAbsentResourceTest() throws Exception {
         new Assertion<>(
             "Can't replace an absent resource with a text",
             new TextOf(
@@ -98,17 +100,21 @@ public final class ResourceOfTest {
         ).affirm();
     }
 
-    @Test(expected = IOException.class)
-    public void throwsWhenResourceIsAbsent() throws Exception {
-        new TextOf(
-            new ResourceOf(
-                "bar/this-resource-is-definitely-absent.txt"
-            )
-        ).asString();
+    @Test
+    void throwsWhenResourceIsAbsent() {
+        new Assertion<>(
+            "Doesn't fail for absent resource",
+            () -> new TextOf(
+                new ResourceOf(
+                    "bar/this-resource-is-definitely-absent.txt"
+                )
+            ).asString(),
+            new Throws<>(IOException.class)
+        ).affirm();
     }
 
     @Test
-    public void acceptsTextAsResourceName() throws Exception {
+    void acceptsTextAsResourceName() throws Exception {
         new Assertion<>(
             "Can't accept Text as resource name",
             new TextOf(
@@ -121,7 +127,7 @@ public final class ResourceOfTest {
     }
 
     @Test
-    public void acceptsTextsAsResourceNameAndFallback() throws Exception {
+    void acceptsTextsAsResourceNameAndFallback() throws Exception {
         new Assertion<>(
             "Can't use Texts as parameters",
             new TextOf(

--- a/src/test/java/org/cactoos/io/SlowInputStreamTest.java
+++ b/src/test/java/org/cactoos/io/SlowInputStreamTest.java
@@ -33,6 +33,7 @@ import org.llorllale.cactoos.matchers.Assertion;
  *
  * @since 0.47
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class SlowInputStreamTest {
 
     @Test

--- a/src/test/java/org/cactoos/io/SlowInputTest.java
+++ b/src/test/java/org/cactoos/io/SlowInputTest.java
@@ -36,6 +36,7 @@ import org.llorllale.cactoos.matchers.HasValue;
  * @since 0.12
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class SlowInputTest {
 
     @Test

--- a/src/test/java/org/cactoos/io/StickyTest.java
+++ b/src/test/java/org/cactoos/io/StickyTest.java
@@ -39,6 +39,7 @@ import org.llorllale.cactoos.matchers.Satisfies;
  * Test case for {@link Sticky}.
  * @since 0.6
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class StickyTest {
 
     @Test

--- a/src/test/java/org/cactoos/io/TailOfTest.java
+++ b/src/test/java/org/cactoos/io/TailOfTest.java
@@ -27,18 +27,20 @@ import java.util.Arrays;
 import java.util.Random;
 import org.cactoos.bytes.BytesOf;
 import org.hamcrest.core.IsEqual;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Tests for {@link TailOf}.
  * @since 0.30
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class TailOfTest {
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class TailOfTest {
 
     @Test
-    public void tailsOnLongStream() throws Exception {
+    void tailsOnLongStream() throws Exception {
         final int size = 4;
         final byte[] bytes = this.generate(size);
         new Assertion<>(
@@ -54,7 +56,7 @@ public final class TailOfTest {
     }
 
     @Test
-    public void tailsOnExactStream() throws Exception {
+    void tailsOnExactStream() throws Exception {
         final int size = 4;
         final byte[] bytes = this.generate(size);
         new Assertion<>(
@@ -70,7 +72,7 @@ public final class TailOfTest {
     }
 
     @Test
-    public void tailsOnExactStreamAndBuffer() throws Exception {
+    void tailsOnExactStreamAndBuffer() throws Exception {
         final int size = 4;
         final byte[] bytes = this.generate(size);
         new Assertion<>(
@@ -87,7 +89,7 @@ public final class TailOfTest {
     }
 
     @Test
-    public void tailsOnShorterStream() throws Exception {
+    void tailsOnShorterStream() throws Exception {
         final int size = 4;
         final byte[] bytes = this.generate(size);
         new Assertion<>(
@@ -103,7 +105,7 @@ public final class TailOfTest {
     }
 
     @Test
-    public void tailsOnStreamLongerThanBufferAndBytes() throws Exception {
+    void tailsOnStreamLongerThanBufferAndBytes() throws Exception {
         final int size = 4;
         final byte[] bytes = this.generate(size);
         new Assertion<>(
@@ -121,16 +123,20 @@ public final class TailOfTest {
         ).affirm();
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void failsIfBufferSizeSmallerThanTailSize() throws Exception {
+    @Test
+    void failsIfBufferSizeSmallerThanTailSize() throws Exception {
         final int size = 4;
-        new BytesOf(
-            new TailOf(
-                new InputOf(new BytesOf(this.generate(size))),
-                size,
-                size - 1
-            )
-        ).asBytes();
+        new Assertion<>(
+            "Can't read in smaller buffer",
+            () -> new BytesOf(
+                new TailOf(
+                    new InputOf(new BytesOf(this.generate(size))),
+                    size,
+                    size - 1
+                )
+            ).asBytes(),
+        new Throws<>(IllegalArgumentException.class)
+        ).affirm();
     }
 
     /**

--- a/src/test/java/org/cactoos/io/TeeInputFromByteArrayTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputFromByteArrayTest.java
@@ -25,10 +25,10 @@ package org.cactoos.io;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import org.cactoos.scalar.LengthOf;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasContent;
 
@@ -38,19 +38,14 @@ import org.llorllale.cactoos.matchers.HasContent;
  * @since 1.0
  * @checkstyle JavadocMethodCheck (100 lines)
  */
-public final class TeeInputFromByteArrayTest {
-
-    /**
-     * Temporary files generator.
-     */
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class TeeInputFromByteArrayTest {
 
     @Test
-    public void copiesFromByteArrayToPath() throws Exception {
+    void copiesFromByteArrayToPath(@TempDir final Path wdir) throws Exception {
         final String message =
             "Hello, товарищ path äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("copytest.txt").toFile();
         new LengthOf(
             new TeeInput(
                 message.getBytes(StandardCharsets.UTF_8),
@@ -65,10 +60,10 @@ public final class TeeInputFromByteArrayTest {
     }
 
     @Test
-    public void copiesFromByteArrayToFile() throws Exception {
+    void copiesFromByteArrayToFile(@TempDir final Path wdir) throws Exception {
         final String message =
             "Hello, товарищ file äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("copyarraytest.txt").toFile();
         new LengthOf(
             new TeeInput(
                 message.getBytes(StandardCharsets.UTF_8),
@@ -83,10 +78,10 @@ public final class TeeInputFromByteArrayTest {
     }
 
     @Test
-    public void copiesFromByteArrayToOutput() throws Exception {
+    void copiesFromByteArrayToOutput(@TempDir final Path wdir) throws Exception {
         final String message =
             "Hello, товарищ output äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("copytooutput.txt").toFile();
         new LengthOf(
             new TeeInput(
                 message.getBytes(StandardCharsets.UTF_8),

--- a/src/test/java/org/cactoos/io/TeeInputFromBytesTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputFromBytesTest.java
@@ -24,11 +24,11 @@
 package org.cactoos.io;
 
 import java.io.File;
+import java.nio.file.Path;
 import org.cactoos.bytes.BytesOf;
 import org.cactoos.scalar.LengthOf;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasContent;
 
@@ -38,19 +38,14 @@ import org.llorllale.cactoos.matchers.HasContent;
  * @since 1.0
  * @checkstyle JavadocMethodCheck (100 lines)
  */
-public final class TeeInputFromBytesTest {
-
-    /**
-     * Temporary files generator.
-     */
-    @Rule
-    public final TemporaryFolder folder = new TemporaryFolder();
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class TeeInputFromBytesTest {
 
     @Test
-    public void copiesFromBytesToPath() throws Exception {
+    void copiesFromBytesToPath(@TempDir final Path wdir) throws Exception {
         final String message =
             "Hello, товарищ path äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teebytes1.txt").toFile();
         new LengthOf(
             new TeeInput(new BytesOf(message), output.toPath())
         ).value();
@@ -62,10 +57,10 @@ public final class TeeInputFromBytesTest {
     }
 
     @Test
-    public void copiesFromBytesToFile() throws Exception {
+    void copiesFromBytesToFile(@TempDir final Path wdir) throws Exception {
         final String message =
             "Hello, товарищ file äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teebytes2.txt").toFile();
         new LengthOf(
             new TeeInput(new BytesOf(message), output)
         ).value();
@@ -77,10 +72,10 @@ public final class TeeInputFromBytesTest {
     }
 
     @Test
-    public void copiesFromBytesToOutput() throws Exception {
+    void copiesFromBytesToOutput(@TempDir final Path wdir) throws Exception {
         final String message =
             "Hello, товарищ output äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teebytes3.txt").toFile();
         new LengthOf(
             new TeeInput(new BytesOf(message), new OutputTo(output))
         ).value();

--- a/src/test/java/org/cactoos/io/TeeInputFromCharArrayTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputFromCharArrayTest.java
@@ -25,10 +25,10 @@ package org.cactoos.io;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import org.cactoos.scalar.LengthOf;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasContent;
 
@@ -38,19 +38,14 @@ import org.llorllale.cactoos.matchers.HasContent;
  * @since 1.0
  * @checkstyle JavadocMethodCheck (215 lines)
  */
-public final class TeeInputFromCharArrayTest {
-
-    /**
-     * Temporary files generator.
-     */
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class TeeInputFromCharArrayTest {
 
     @Test
-    public void copiesFromCharArrayWithCharsetToFile() throws Exception {
+    void copiesFromCharArrayWithCharsetToFile(@TempDir final Path wdir) throws Exception {
         final String input =
             "Hello, товарищ file #1 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("tee1.txt").toFile();
         new LengthOf(
             new TeeInput(input.toCharArray(), output, StandardCharsets.UTF_8)
         ).value();
@@ -62,11 +57,11 @@ public final class TeeInputFromCharArrayTest {
     }
 
     @Test
-    public void copiesFromCharArrayWithCharsetByNameToFile()
+    void copiesFromCharArrayWithCharsetByNameToFile(@TempDir final Path wdir)
         throws Exception {
         final String input =
             "Hello, товарищ file #2 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("tee2.txt").toFile();
         new LengthOf(
             new TeeInput(input.toCharArray(), output, StandardCharsets.UTF_8.name())
         ).value();
@@ -78,10 +73,10 @@ public final class TeeInputFromCharArrayTest {
     }
 
     @Test
-    public void copiesFromCharArrayToOutput() throws Exception {
+    void copiesFromCharArrayToOutput(@TempDir final Path wdir) throws Exception {
         final String input =
             "Hello, товарищ output #1 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("tee3.txt").toFile();
         new LengthOf(
             new TeeInput(input.toCharArray(), new OutputTo(output))
         ).value();
@@ -93,10 +88,10 @@ public final class TeeInputFromCharArrayTest {
     }
 
     @Test
-    public void copiesFromCharArrayWithCharsetToOutput() throws Exception {
+    void copiesFromCharArrayWithCharsetToOutput(@TempDir final Path wdir) throws Exception {
         final String input =
             "Hello, товарищ output #2 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("tee4.txt").toFile();
         new LengthOf(
             new TeeInput(input.toCharArray(), new OutputTo(output), StandardCharsets.UTF_8)
         ).value();
@@ -108,11 +103,11 @@ public final class TeeInputFromCharArrayTest {
     }
 
     @Test
-    public void copiesFromCharArrayWithCharsetByNameToOutput()
+    void copiesFromCharArrayWithCharsetByNameToOutput(@TempDir final Path wdir)
         throws Exception {
         final String input =
             "Hello, товарищ output #3 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("tee5.txt").toFile();
         new LengthOf(
             new TeeInput(input.toCharArray(), new OutputTo(output), StandardCharsets.UTF_8.name())
         ).value();
@@ -124,10 +119,10 @@ public final class TeeInputFromCharArrayTest {
     }
 
     @Test
-    public void copiesFromCharArrayToPath() throws Exception {
+    void copiesFromCharArrayToPath(@TempDir final Path wdir) throws Exception {
         final String input =
             "Hello, товарищ path #1 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("tee6.txt").toFile();
         new LengthOf(
             new TeeInput(input.toCharArray(), output.toPath())
         ).value();
@@ -139,10 +134,10 @@ public final class TeeInputFromCharArrayTest {
     }
 
     @Test
-    public void copiesFromCharArrayWithCharsetToPath() throws Exception {
+    void copiesFromCharArrayWithCharsetToPath(@TempDir final Path wdir) throws Exception {
         final String input =
             "Hello, товарищ path #2 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("tee7.txt").toFile();
         new LengthOf(
             new TeeInput(input.toCharArray(), output.toPath(), StandardCharsets.UTF_8)
         ).value();
@@ -154,11 +149,11 @@ public final class TeeInputFromCharArrayTest {
     }
 
     @Test
-    public void copiesFromCharArrayWithCharsetByNameToPath()
+    void copiesFromCharArrayWithCharsetByNameToPath(@TempDir final Path wdir)
         throws Exception {
         final String input =
             "Hello, товарищ path #3 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("tee8.txt").toFile();
         new LengthOf(
             new TeeInput(input.toCharArray(), output.toPath(), StandardCharsets.UTF_8.name())
         ).value();
@@ -170,8 +165,8 @@ public final class TeeInputFromCharArrayTest {
     }
 
     @Test
-    public void copiesFromCharArrayToFile() throws Exception {
-        final File output = this.folder.newFile();
+    void copiesFromCharArrayToFile(@TempDir final Path wdir) throws Exception {
+        final File output = wdir.resolve("tee9.txt").toFile();
         final String input =
             "Hello, товарищ file äÄ üÜ öÖ and ß";
         new LengthOf(

--- a/src/test/java/org/cactoos/io/TeeInputFromCharSequenceTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputFromCharSequenceTest.java
@@ -25,10 +25,10 @@ package org.cactoos.io;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import org.cactoos.scalar.LengthOf;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasContent;
 
@@ -38,19 +38,14 @@ import org.llorllale.cactoos.matchers.HasContent;
  * @since 1.0
  * @checkstyle JavadocMethodCheck (215 lines)
  */
-public final class TeeInputFromCharSequenceTest {
-
-    /**
-     * Temporary files generator.
-     */
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class TeeInputFromCharSequenceTest {
 
     @Test
-    public void copiesFromCharSequenceToFile() throws Exception {
+    void copiesFromCharSequenceToFile(@TempDir final Path wdir) throws Exception {
         final String input =
             "Hello, товарищ file #1 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teeinput1.txt").toFile();
         new LengthOf(
             new TeeInput(input, output)
         ).value();
@@ -62,10 +57,11 @@ public final class TeeInputFromCharSequenceTest {
     }
 
     @Test
-    public void copiesFromCharSequenceWithCharsetToFile() throws Exception {
+    void copiesFromCharSequenceWithCharsetToFile(@TempDir final Path wdir)
+        throws Exception {
         final String input =
             "Hello, товарищ file #2 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teeinput2.txt").toFile();
         new LengthOf(
             new TeeInput(input, output, StandardCharsets.UTF_8)
         ).value();
@@ -77,11 +73,11 @@ public final class TeeInputFromCharSequenceTest {
     }
 
     @Test
-    public void copiesFromCharSequenceWithCharsetByNameToFile()
+    void copiesFromCharSequenceWithCharsetByNameToFile(@TempDir final Path wdir)
         throws Exception {
         final String input =
             "Hello, товарищ file #3 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teeinput3.txt").toFile();
         new LengthOf(
             new TeeInput(input, output, StandardCharsets.UTF_8.name())
         ).value();
@@ -93,10 +89,10 @@ public final class TeeInputFromCharSequenceTest {
     }
 
     @Test
-    public void copiesFromCharSequenceToPath() throws Exception {
+    void copiesFromCharSequenceToPath(@TempDir final Path wdir) throws Exception {
         final String input =
             "Hello, товарищ path #1 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teeinput4.txt").toFile();
         new LengthOf(
             new TeeInput(input, output.toPath())
         ).value();
@@ -108,10 +104,11 @@ public final class TeeInputFromCharSequenceTest {
     }
 
     @Test
-    public void copiesFromCharSequenceWithCharsetToPath() throws Exception {
+    void copiesFromCharSequenceWithCharsetToPath(@TempDir final Path wdir)
+        throws Exception {
         final String input =
             "Hello, товарищ path #2 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teeinput5.txt").toFile();
         new LengthOf(
             new TeeInput(input, output.toPath(), StandardCharsets.UTF_8)
         ).value();
@@ -123,11 +120,11 @@ public final class TeeInputFromCharSequenceTest {
     }
 
     @Test
-    public void copiesFromCharSequenceWithCharsetByNameToPath()
+    void copiesFromCharSequenceWithCharsetByNameToPath(@TempDir final Path wdir)
         throws Exception {
         final String input =
             "Hello, товарищ path #3 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teeinput6.txt").toFile();
         new LengthOf(
             new TeeInput(input, output.toPath(), StandardCharsets.UTF_8.name())
         ).value();
@@ -139,10 +136,10 @@ public final class TeeInputFromCharSequenceTest {
     }
 
     @Test
-    public void copiesFromCharSequenceToOutput() throws Exception {
+    void copiesFromCharSequenceToOutput(@TempDir final Path wdir) throws Exception {
         final String input =
             "Hello, товарищ output #1 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teeinput7.txt").toFile();
         new LengthOf(
             new TeeInput(input, new OutputTo(output))
         ).value();
@@ -154,10 +151,11 @@ public final class TeeInputFromCharSequenceTest {
     }
 
     @Test
-    public void copiesFromCharSequenceWithCharsetToOutput() throws Exception {
+    void copiesFromCharSequenceWithCharsetToOutput(@TempDir final Path wdir)
+        throws Exception {
         final String input =
             "Hello, товарищ output #2 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teeinput8.txt").toFile();
         new LengthOf(
             new TeeInput(input, new OutputTo(output), StandardCharsets.UTF_8)
         ).value();
@@ -169,11 +167,11 @@ public final class TeeInputFromCharSequenceTest {
     }
 
     @Test
-    public void copiesFromCharSequenceWithCharsetByNameToOutput()
+    void copiesFromCharSequenceWithCharsetByNameToOutput(@TempDir final Path wdir)
         throws Exception {
         final String input =
             "Hello, товарищ output #3 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teeinput9.txt").toFile();
         new LengthOf(
             new TeeInput(input, new OutputTo(output), StandardCharsets.UTF_8.name())
         ).value();

--- a/src/test/java/org/cactoos/io/TeeInputFromFileTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputFromFileTest.java
@@ -26,10 +26,10 @@ package org.cactoos.io;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import org.cactoos.scalar.LengthOf;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasContent;
 
@@ -38,24 +38,19 @@ import org.llorllale.cactoos.matchers.HasContent;
  * @since 1.0
  * @checkstyle JavadocMethodCheck (120 lines)
  */
-public final class TeeInputFromFileTest {
-
-    /**
-     * Temporary files generator.
-     */
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class TeeInputFromFileTest {
 
     @Test
-    public void copiesFromFileToFile() throws Exception {
+    void copiesFromFileToFile(@TempDir final Path wdir) throws Exception {
         final String message =
             "Hello, товарищ file #1 äÄ üÜ öÖ and ß";
-        final File input = this.folder.newFile();
+        final File input = wdir.resolve("teeinput1-1.txt").toFile();
         Files.write(
             input.toPath(),
             message.getBytes(StandardCharsets.UTF_8)
         );
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teeinput1-2.txt").toFile();
         new LengthOf(
             new TeeInput(
                 input,
@@ -70,15 +65,15 @@ public final class TeeInputFromFileTest {
     }
 
     @Test
-    public void copiesFromFileToPath() throws Exception {
+    void copiesFromFileToPath(@TempDir final Path wdir) throws Exception {
         final String message =
             "Hello, товарищ path #1 äÄ üÜ öÖ and ß";
-        final File input = this.folder.newFile();
+        final File input = wdir.resolve("teeinput2-1.txt").toFile();
         Files.write(
             input.toPath(),
             message.getBytes(StandardCharsets.UTF_8)
         );
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teeinput2-2.txt").toFile();
         new LengthOf(
             new TeeInput(
                 input,
@@ -93,15 +88,15 @@ public final class TeeInputFromFileTest {
     }
 
     @Test
-    public void copiesFromFileToOutput() throws Exception {
+    void copiesFromFileToOutput(@TempDir final Path wdir) throws Exception {
         final String message =
             "Hello, товарищ output #1 äÄ üÜ öÖ and ß";
-        final File input = this.folder.newFile();
+        final File input = wdir.resolve("teeinput3-1.txt").toFile();
         Files.write(
             input.toPath(),
             message.getBytes(StandardCharsets.UTF_8)
         );
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teeinput3-2.txt").toFile();
         new LengthOf(
             new TeeInput(
                 input,

--- a/src/test/java/org/cactoos/io/TeeInputFromInputTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputFromInputTest.java
@@ -25,10 +25,10 @@ package org.cactoos.io;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import org.cactoos.scalar.LengthOf;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasContent;
 
@@ -38,18 +38,13 @@ import org.llorllale.cactoos.matchers.HasContent;
  * @since 1.0
  * @checkstyle JavadocMethodCheck (200 lines)
  */
-public final class TeeInputFromInputTest {
-
-    /**
-     * Temporary files generator.
-     */
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class TeeInputFromInputTest {
 
     @Test
-    public void copiesFromInputToPath() throws Exception {
+    void copiesFromInputToPath(@TempDir final Path wdir) throws Exception {
         final String input = "Hello, товарищ path #1 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("copy1.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new InputOf(input),
@@ -64,9 +59,9 @@ public final class TeeInputFromInputTest {
     }
 
     @Test
-    public void copiesFromInputToFile() throws Exception {
+    void copiesFromInputToFile(@TempDir final Path wdir) throws Exception {
         final String input = "Hello, товарищ file #1 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("copy2.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new InputOf(input),
@@ -81,9 +76,9 @@ public final class TeeInputFromInputTest {
     }
 
     @Test
-    public void copiesFromInputToWriter() throws Exception {
+    void copiesFromInputToWriter(@TempDir final Path wdir) throws Exception {
         final String input = "Hello, товарищ write #1 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("copy3.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new InputOf(input),
@@ -98,9 +93,9 @@ public final class TeeInputFromInputTest {
     }
 
     @Test
-    public void copiesFromInputWithSizeToWriter() throws Exception {
+    void copiesFromInputWithSizeToWriter(@TempDir final Path wdir) throws Exception {
         final String input = "Hello, товарищ writer #2 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("copy4.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new InputOf(input),
@@ -116,9 +111,9 @@ public final class TeeInputFromInputTest {
     }
 
     @Test
-    public void copiesFromInputWithCharsetToWriter() throws Exception {
+    void copiesFromInputWithCharsetToWriter(@TempDir final Path wdir) throws Exception {
         final String input = "Hello, товарищ writer #3 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("copy5.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new InputOf(input),
@@ -134,9 +129,9 @@ public final class TeeInputFromInputTest {
     }
 
     @Test
-    public void copiesFromInputWithCharsetAndSizeToWriter() throws Exception {
+    void copiesFromInputWithCharsetAndSizeToWriter(@TempDir final Path wdir) throws Exception {
         final String input = "Hello, товарищ writer #4 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("copy5.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new InputOf(input),
@@ -153,9 +148,9 @@ public final class TeeInputFromInputTest {
     }
 
     @Test
-    public void copiesFromInputWithCharsetByNameToWriter() throws Exception {
+    void copiesFromInputWithCharsetByNameToWriter(@TempDir final Path wdir) throws Exception {
         final String input = "Hello, товарищ writer #5 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("copy6.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new InputOf(input),
@@ -171,10 +166,10 @@ public final class TeeInputFromInputTest {
     }
 
     @Test
-    public void copiesFromInputWithCharsetByNameAndSizeToWriter()
+    void copiesFromInputWithCharsetByNameAndSizeToWriter(@TempDir final Path wdir)
         throws Exception {
         final String input = "Hello, товарищ writer #6 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("copy7.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new InputOf(input),

--- a/src/test/java/org/cactoos/io/TeeInputFromPathTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputFromPathTest.java
@@ -28,9 +28,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.cactoos.scalar.LengthOf;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasContent;
 
@@ -40,24 +39,19 @@ import org.llorllale.cactoos.matchers.HasContent;
  * @since 1.0
  * @checkstyle JavadocMethodCheck (120 lines)
  */
-public final class TeeInputFromPathTest {
-
-    /**
-     * Temporary files generator.
-     */
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class TeeInputFromPathTest {
 
     @Test
-    public void copiesFromPathToPath() throws Exception {
+    void copiesFromPathToPath(@TempDir final Path wdir) throws Exception {
         final String message =
             "Hello, товарищ path #1 äÄ üÜ öÖ and ß";
-        final File input = this.folder.newFile();
+        final File input = wdir.resolve("copytest11.txt").toFile();
         Files.write(
             input.toPath(),
             message.getBytes(StandardCharsets.UTF_8)
         );
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("copytest12.txt").toFile();
         new LengthOf(
             new TeeInput(input.toPath(), output.toPath())
         ).value();
@@ -69,15 +63,15 @@ public final class TeeInputFromPathTest {
     }
 
     @Test
-    public void copiesFromPathToFile() throws Exception {
+    void copiesFromPathToFile(@TempDir final Path wdir) throws Exception {
         final String message =
             "Hello, товарищ file #1 äÄ üÜ öÖ and ß";
-        final File input = this.folder.newFile();
+        final File input = wdir.resolve("copytest21.txt").toFile();
         Files.write(
             input.toPath(),
             message.getBytes(StandardCharsets.UTF_8)
         );
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("copytest22.txt").toFile();
         new LengthOf(
             new TeeInput(input.toPath(), output)
         ).value();
@@ -89,15 +83,15 @@ public final class TeeInputFromPathTest {
     }
 
     @Test
-    public void copiesFromPathToOutput() throws Exception {
+    void copiesFromPathToOutput(@TempDir final Path wdir) throws Exception {
         final String message =
             "Hello, товарищ output #1 äÄ üÜ öÖ and ß";
-        final File input = this.folder.newFile();
+        final File input = wdir.resolve("copytest31.txt").toFile();
         Files.write(
             input.toPath(),
             message.getBytes(StandardCharsets.UTF_8)
         );
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("copytest32.txt").toFile();
         new LengthOf(
             new TeeInput(input.toPath(), new OutputTo(output))
         ).value();

--- a/src/test/java/org/cactoos/io/TeeInputFromReaderTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputFromReaderTest.java
@@ -25,10 +25,10 @@ package org.cactoos.io;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import org.cactoos.scalar.LengthOf;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasContent;
 
@@ -38,20 +38,14 @@ import org.llorllale.cactoos.matchers.HasContent;
  * @since 1.0
  * @checkstyle JavadocMethodCheck (400 lines)
  */
-@SuppressWarnings("PMD.TooManyMethods")
-public final class TeeInputFromReaderTest {
-
-    /**
-     * Temporary files generator.
-     */
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.JUnitTestsShouldIncludeAssert"})
+final class TeeInputFromReaderTest {
 
     @Test
-    public void copiesFromReaderToFile() throws Exception {
+    void copiesFromReaderToFile(@TempDir final Path wdir) throws Exception {
         final String input =
             "Hello, товарищ file #1 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teereader1.txt").toFile();
         new LengthOf(
             new TeeInput(new ReaderOf(input), output)
         ).value();
@@ -63,10 +57,10 @@ public final class TeeInputFromReaderTest {
     }
 
     @Test
-    public void copiesFromReaderWithSizeToFile() throws Exception {
+    void copiesFromReaderWithSizeToFile(@TempDir final Path wdir) throws Exception {
         final String input =
             "Hello, товарищ file #2 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teereader2.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new ReaderOf(input),
@@ -82,10 +76,10 @@ public final class TeeInputFromReaderTest {
     }
 
     @Test
-    public void copiesFromReaderWithCharsetToFile() throws Exception {
+    void copiesFromReaderWithCharsetToFile(@TempDir final Path wdir) throws Exception {
         final String input =
             "Hello, товарищ file #3 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teereader3.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new ReaderOf(input),
@@ -101,10 +95,10 @@ public final class TeeInputFromReaderTest {
     }
 
     @Test
-    public void copiesFromReaderWithCharsetAndSizeToFile() throws Exception {
+    void copiesFromReaderWithCharsetAndSizeToFile(@TempDir final Path wdir) throws Exception {
         final String input =
             "Hello, товарищ file #4 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teereader4.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new ReaderOf(input),
@@ -121,10 +115,10 @@ public final class TeeInputFromReaderTest {
     }
 
     @Test
-    public void copiesFromReaderWithCharsetByNameToFile() throws Exception {
+    void copiesFromReaderWithCharsetByNameToFile(@TempDir final Path wdir) throws Exception {
         final String input =
             "Hello, товарищ file #5 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teereader6.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new ReaderOf(input),
@@ -140,11 +134,11 @@ public final class TeeInputFromReaderTest {
     }
 
     @Test
-    public void copiesFromReaderWithCharsetByNameAndSizeToFile()
+    void copiesFromReaderWithCharsetByNameAndSizeToFile(@TempDir final Path wdir)
         throws Exception {
         final String input =
             "Hello, товарищ file #6 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teereader7.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new ReaderOf(input),
@@ -161,10 +155,10 @@ public final class TeeInputFromReaderTest {
     }
 
     @Test
-    public void copiesFromReaderToPath() throws Exception {
+    void copiesFromReaderToPath(@TempDir final Path wdir) throws Exception {
         final String input =
             "Hello, товарищ path #1 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teereader8.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new ReaderOf(input),
@@ -179,10 +173,10 @@ public final class TeeInputFromReaderTest {
     }
 
     @Test
-    public void copiesFromReaderWithSizeToPath() throws Exception {
+    void copiesFromReaderWithSizeToPath(@TempDir final Path wdir) throws Exception {
         final String input =
             "Hello, товарищ path #2 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teereader9.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new ReaderOf(input),
@@ -198,10 +192,11 @@ public final class TeeInputFromReaderTest {
     }
 
     @Test
-    public void copiesFromReaderWithCharsetToPath() throws Exception {
+    void copiesFromReaderWithCharsetToPath(@TempDir final Path wdir)
+        throws Exception {
         final String input =
             "Hello, товарищ path #3 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teereader10.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new ReaderOf(input),
@@ -217,10 +212,11 @@ public final class TeeInputFromReaderTest {
     }
 
     @Test
-    public void copiesFromReaderWithCharsetAndSizeToPath() throws Exception {
+    void copiesFromReaderWithCharsetAndSizeToPath(@TempDir final Path wdir)
+        throws Exception {
         final String input =
             "Hello, товарищ path #4 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teereader11.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new ReaderOf(input),
@@ -237,10 +233,11 @@ public final class TeeInputFromReaderTest {
     }
 
     @Test
-    public void copiesFromReaderWithCharsetByNameToPath() throws Exception {
+    void copiesFromReaderWithCharsetByNameToPath(@TempDir final Path wdir)
+        throws Exception {
         final String input =
             "Hello, товарищ path #5 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teereader12.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new ReaderOf(input),
@@ -256,11 +253,11 @@ public final class TeeInputFromReaderTest {
     }
 
     @Test
-    public void copiesFromReaderWithCharsetByNameAndSizeToPath()
+    void copiesFromReaderWithCharsetByNameAndSizeToPath(@TempDir final Path wdir)
         throws Exception {
         final String input =
             "Hello, товарищ path #6 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teereader13.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new ReaderOf(input),
@@ -277,10 +274,10 @@ public final class TeeInputFromReaderTest {
     }
 
     @Test
-    public void copiesFromReaderToOutput() throws Exception {
+    void copiesFromReaderToOutput(@TempDir final Path wdir) throws Exception {
         final String input =
             "Hello, товарищ output #1 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teereader14.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new ReaderOf(input),
@@ -295,10 +292,11 @@ public final class TeeInputFromReaderTest {
     }
 
     @Test
-    public void copiesFromReaderWithSizeToOutput() throws Exception {
+    void copiesFromReaderWithSizeToOutput(@TempDir final Path wdir)
+        throws Exception {
         final String input =
             "Hello, товарищ output #2 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teereader15.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new ReaderOf(input),
@@ -314,10 +312,11 @@ public final class TeeInputFromReaderTest {
     }
 
     @Test
-    public void copiesFromReaderWithCharsetToOutput() throws Exception {
+    void copiesFromReaderWithCharsetToOutput(@TempDir final Path wdir)
+        throws Exception {
         final String input =
             "Hello, товарищ output #3 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teereader16.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new ReaderOf(input),
@@ -333,11 +332,11 @@ public final class TeeInputFromReaderTest {
     }
 
     @Test
-    public void copiesFromReaderWithCharsetAndSizeToOutput()
+    void copiesFromReaderWithCharsetAndSizeToOutput(@TempDir final Path wdir)
         throws Exception {
         final String input =
             "Hello, товарищ output #4 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teereader17.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new ReaderOf(input),
@@ -354,10 +353,11 @@ public final class TeeInputFromReaderTest {
     }
 
     @Test
-    public void copiesFromReaderWithCharsetByNameToOutput() throws Exception {
+    void copiesFromReaderWithCharsetByNameToOutput(@TempDir final Path wdir)
+        throws Exception {
         final String input =
             "Hello, товарищ output #5 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teereader18.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new ReaderOf(input),
@@ -373,11 +373,11 @@ public final class TeeInputFromReaderTest {
     }
 
     @Test
-    public void copiesFromReaderWithCharsetByNameAndSizeToOutput()
+    void copiesFromReaderWithCharsetByNameAndSizeToOutput(@TempDir final Path wdir)
         throws Exception {
         final String input =
             "Hello, товарищ output #6 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teereader19.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new ReaderOf(input),

--- a/src/test/java/org/cactoos/io/TeeInputFromTextTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputFromTextTest.java
@@ -25,11 +25,11 @@ package org.cactoos.io;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import org.cactoos.scalar.LengthOf;
 import org.cactoos.text.TextOf;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasContent;
 
@@ -39,19 +39,14 @@ import org.llorllale.cactoos.matchers.HasContent;
  * @since 1.0
  * @checkstyle JavadocMethodCheck (215 lines)
  */
-public final class TeeInputFromTextTest {
-
-    /**
-     * Temporary files generator.
-     */
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class TeeInputFromTextTest {
 
     @Test
-    public void copiesFromTextToPath() throws Exception {
+    void copiesFromTextToPath(@TempDir final Path wdir) throws Exception {
         final String input =
             "Hello, товарищ path #1 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teetext1.txt").toFile();
         new LengthOf(
             new TeeInput(new TextOf(input), output.toPath())
         ).value();
@@ -63,10 +58,10 @@ public final class TeeInputFromTextTest {
     }
 
     @Test
-    public void copiesFromTextWithCharsetToPath() throws Exception {
+    void copiesFromTextWithCharsetToPath(@TempDir final Path wdir) throws Exception {
         final String input =
             "Hello, товарищ path #2 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teetext2.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new TextOf(input),
@@ -82,10 +77,10 @@ public final class TeeInputFromTextTest {
     }
 
     @Test
-    public void copiesFromTextWithCharsetByNameToPath() throws Exception {
+    void copiesFromTextWithCharsetByNameToPath(@TempDir final Path wdir) throws Exception {
         final String input =
             "Hello, товарищ path #3 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teetext3.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new TextOf(input),
@@ -101,10 +96,10 @@ public final class TeeInputFromTextTest {
     }
 
     @Test
-    public void copiesFromTextToFile() throws Exception {
+    void copiesFromTextToFile(@TempDir final Path wdir) throws Exception {
         final String input =
             "Hello, товарищ file #1 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teetext4.txt").toFile();
         new LengthOf(
             new TeeInput(new TextOf(input), output)
         ).value();
@@ -116,10 +111,10 @@ public final class TeeInputFromTextTest {
     }
 
     @Test
-    public void copiesFromTextWithCharsetToFile() throws Exception {
+    void copiesFromTextWithCharsetToFile(@TempDir final Path wdir) throws Exception {
         final String input =
             "Hello, товарищ file #2 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teetext5.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new TextOf(input),
@@ -135,10 +130,10 @@ public final class TeeInputFromTextTest {
     }
 
     @Test
-    public void copiesFromTextWithCharsetByNameToFile() throws Exception {
+    void copiesFromTextWithCharsetByNameToFile(@TempDir final Path wdir) throws Exception {
         final String input =
             "Hello, товарищ file #3 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teetext6.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new TextOf(input),
@@ -154,10 +149,10 @@ public final class TeeInputFromTextTest {
     }
 
     @Test
-    public void copiesFromTextToOutput() throws Exception {
+    void copiesFromTextToOutput(@TempDir final Path wdir) throws Exception {
         final String input =
             "Hello, товарищ output #1 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teetext7.txt").toFile();
         new LengthOf(
             new TeeInput(new TextOf(input), new OutputTo(output))
         ).value();
@@ -169,10 +164,11 @@ public final class TeeInputFromTextTest {
     }
 
     @Test
-    public void copiesFromTextWithCharsetToOutput() throws Exception {
+    void copiesFromTextWithCharsetToOutput(@TempDir final Path wdir)
+        throws Exception {
         final String input =
             "Hello, товарищ output #2 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teetext8.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new TextOf(input),
@@ -188,10 +184,11 @@ public final class TeeInputFromTextTest {
     }
 
     @Test
-    public void copiesFromTextWithCharsetByNameToOutput() throws Exception {
+    void copiesFromTextWithCharsetByNameToOutput(@TempDir final Path wdir)
+        throws Exception {
         final String input =
             "Hello, товарищ output #3 äÄ üÜ öÖ and ß";
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teetext9.txt").toFile();
         new LengthOf(
             new TeeInput(
                 new TextOf(input),

--- a/src/test/java/org/cactoos/io/TeeInputFromUriTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputFromUriTest.java
@@ -26,10 +26,10 @@ package org.cactoos.io;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import org.cactoos.scalar.LengthOf;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasContent;
 
@@ -39,23 +39,18 @@ import org.llorllale.cactoos.matchers.HasContent;
  * @since 1.0
  * @checkstyle JavadocMethodCheck (120 lines)
  */
-public final class TeeInputFromUriTest {
-
-    /**
-     * Temporary files generator.
-     */
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class TeeInputFromUriTest {
 
     @Test
-    public void copiesFromUriToPath() throws Exception {
+    void copiesFromUriToPath(@TempDir final Path wdir) throws Exception {
         final String message = "Hello, товарищ path #1 äÄ üÜ öÖ and ß";
-        final File input = this.folder.newFile();
+        final File input = wdir.resolve("teeuri1-1.txt").toFile();
         Files.write(
             input.toPath(),
             message.getBytes(StandardCharsets.UTF_8)
         );
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teeuri1-2.txt").toFile();
         new LengthOf(
             new TeeInput(
                 input.toURI(),
@@ -70,14 +65,14 @@ public final class TeeInputFromUriTest {
     }
 
     @Test
-    public void copiesFromUriToFile() throws Exception {
+    void copiesFromUriToFile(@TempDir final Path wdir) throws Exception {
         final String message = "Hello, товарищ file #1 äÄ üÜ öÖ and ß";
-        final File input = this.folder.newFile();
+        final File input = wdir.resolve("teeuri2-1.txt").toFile();
         Files.write(
             input.toPath(),
             message.getBytes(StandardCharsets.UTF_8)
         );
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teeuri2-2.txt").toFile();
         new LengthOf(
             new TeeInput(
                 input.toURI(),
@@ -92,14 +87,14 @@ public final class TeeInputFromUriTest {
     }
 
     @Test
-    public void copiesFromUriToOutput() throws Exception {
+    void copiesFromUriToOutput(@TempDir final Path wdir) throws Exception {
         final String message = "Hello, товарищ output #1 äÄ üÜ öÖ and ß";
-        final File input = this.folder.newFile();
+        final File input = wdir.resolve("teeuri3-1.txt").toFile();
         Files.write(
             input.toPath(),
             message.getBytes(StandardCharsets.UTF_8)
         );
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teeuri3-2.txt").toFile();
         new LengthOf(
             new TeeInput(
                 input.toURI(),

--- a/src/test/java/org/cactoos/io/TeeInputFromUrlTest.java
+++ b/src/test/java/org/cactoos/io/TeeInputFromUrlTest.java
@@ -26,10 +26,10 @@ package org.cactoos.io;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import org.cactoos.scalar.LengthOf;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasContent;
 
@@ -39,24 +39,19 @@ import org.llorllale.cactoos.matchers.HasContent;
  * @since 1.0
  * @checkstyle JavadocMethodCheck (125 lines)
  */
-public final class TeeInputFromUrlTest {
-
-    /**
-     * Temporary files generator.
-     */
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class TeeInputFromUrlTest {
 
     @Test
-    public void copiesFromUrlToPath() throws Exception {
+    void copiesFromUrlToPath(@TempDir final Path wdir) throws Exception {
         final String message =
             "Hello, товарищ path #1 äÄ üÜ öÖ and ß";
-        final File input = this.folder.newFile();
+        final File input = wdir.resolve("teeurl1-1.txt").toFile();
         Files.write(
             input.toPath(),
             message.getBytes(StandardCharsets.UTF_8)
         );
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teeurl1-2.txt").toFile();
         new LengthOf(
             new TeeInput(input.toURI().toURL(), output.toPath())
         ).value();
@@ -68,15 +63,15 @@ public final class TeeInputFromUrlTest {
     }
 
     @Test
-    public void copiesFromUrlToFile() throws Exception {
+    void copiesFromUrlToFile(@TempDir final Path wdir) throws Exception {
         final String message =
             "Hello, товарищ file #1 äÄ üÜ öÖ and ß";
-        final File input = this.folder.newFile();
+        final File input = wdir.resolve("teeurl2-1.txt").toFile();
         Files.write(
             input.toPath(),
             message.getBytes(StandardCharsets.UTF_8)
         );
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teeurl2-2.txt").toFile();
         new LengthOf(
             new TeeInput(input.toURI().toURL(), output)
         ).value();
@@ -88,15 +83,15 @@ public final class TeeInputFromUrlTest {
     }
 
     @Test
-    public void copiesFromUrlToOutput() throws Exception {
+    void copiesFromUrlToOutput(@TempDir final Path wdir) throws Exception {
         final String message =
             "Hello, товарищ output #1 äÄ üÜ öÖ and ß";
-        final File input = this.folder.newFile();
+        final File input = wdir.resolve("teeurl3-1.txt").toFile();
         Files.write(
             input.toPath(),
             message.getBytes(StandardCharsets.UTF_8)
         );
-        final File output = this.folder.newFile();
+        final File output = wdir.resolve("teeurl3-2.txt").toFile();
         new LengthOf(
             new TeeInput(input.toURI().toURL(), new OutputTo(output))
         ).value();

--- a/src/test/java/org/cactoos/io/TeeOutputStreamTest.java
+++ b/src/test/java/org/cactoos/io/TeeOutputStreamTest.java
@@ -37,6 +37,7 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @since 0.16
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class TeeOutputStreamTest {
 
     @Test

--- a/src/test/java/org/cactoos/io/TeeOutputTest.java
+++ b/src/test/java/org/cactoos/io/TeeOutputTest.java
@@ -26,10 +26,10 @@ package org.cactoos.io;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import org.cactoos.text.TextOf;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasContent;
 import org.llorllale.cactoos.matchers.IsText;
@@ -39,15 +39,11 @@ import org.llorllale.cactoos.matchers.IsText;
  * @since 0.16
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class TeeOutputTest {
-    /**
-     * Temporary files generator.
-     */
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class TeeOutputTest {
 
     @Test
-    public void copiesContent() {
+    void copiesContent() {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         new Assertion<>(
             "Can't copy Output to Output and return Input",
@@ -65,7 +61,7 @@ public final class TeeOutputTest {
     }
 
     @Test
-    public void copiesWithWriter() {
+    void copiesWithWriter() {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         new Assertion<>(
             "Can't copy Output with writer",
@@ -83,7 +79,7 @@ public final class TeeOutputTest {
     }
 
     @Test
-    public void copiesWithWriterAndCharset() {
+    void copiesWithWriterAndCharset() {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         new Assertion<>(
             "Can't copy Output with writer and charset",
@@ -104,9 +100,9 @@ public final class TeeOutputTest {
     }
 
     @Test
-    public void copiesWithPath() throws Exception {
+    void copiesWithPath(@TempDir final Path wdir) {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final File file = this.folder.newFile();
+        final File file = wdir.resolve("tree1.txt").toFile();
         new Assertion<>(
             "Must copy Output with path",
             new TextOf(
@@ -125,9 +121,9 @@ public final class TeeOutputTest {
     }
 
     @Test
-    public void copiesWithFile() throws Exception {
+    void copiesWithFile(@TempDir final Path wdir) {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final File file = this.folder.newFile();
+        final File file = wdir.resolve("tree2.txt").toFile();
         new Assertion<>(
             "Must copy Output with file",
             new TextOf(
@@ -146,7 +142,7 @@ public final class TeeOutputTest {
     }
 
     @Test
-    public void copiesWithOutputStream() {
+    void copiesWithOutputStream() {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         new Assertion<>(
             "Can't copy Output with output stream",

--- a/src/test/java/org/cactoos/io/TeeReaderTest.java
+++ b/src/test/java/org/cactoos/io/TeeReaderTest.java
@@ -36,6 +36,7 @@ import org.llorllale.cactoos.matchers.HasContent;
  * @since 0.13
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class TeeReaderTest {
 
     @Test

--- a/src/test/java/org/cactoos/io/TempFileTest.java
+++ b/src/test/java/org/cactoos/io/TempFileTest.java
@@ -42,6 +42,7 @@ import org.llorllale.cactoos.matchers.StartsWith;
  *
  * @since 1.0
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class TempFileTest {
 
     @Test

--- a/src/test/java/org/cactoos/io/TempFolderTest.java
+++ b/src/test/java/org/cactoos/io/TempFolderTest.java
@@ -41,6 +41,7 @@ import org.llorllale.cactoos.matchers.IsTrue;
  * @since 1.0
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class TempFolderTest {
 
     @Test

--- a/src/test/java/org/cactoos/io/UncheckedOutputTest.java
+++ b/src/test/java/org/cactoos/io/UncheckedOutputTest.java
@@ -24,7 +24,9 @@
 package org.cactoos.io;
 
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link UncheckedOutput}.
@@ -32,15 +34,20 @@ import org.junit.Test;
  * @since 0.11
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class UncheckedOutputTest {
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class UncheckedOutputTest {
 
-    @Test(expected = RuntimeException.class)
-    public void rethrowsCheckedToUncheckedException() {
-        new UncheckedOutput(
-            () -> {
-                throw new IOException("intended");
-            }
-        ).stream();
+    @Test
+    void rethrowsCheckedToUncheckedException() {
+        new Assertion<>(
+            "Exception is not rethrown as runtime",
+            () -> new UncheckedOutput(
+                () -> {
+                    throw new IOException("intended");
+                }
+            ).stream(),
+            new Throws<>(RuntimeException.class)
+        ).affirm();
     }
 
 }

--- a/src/test/java/org/cactoos/io/WriterAsOutputStreamTest.java
+++ b/src/test/java/org/cactoos/io/WriterAsOutputStreamTest.java
@@ -32,9 +32,8 @@ import java.nio.file.Path;
 import org.cactoos.scalar.LengthOf;
 import org.cactoos.text.TextOf;
 import org.hamcrest.core.IsNot;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasContent;
 import org.llorllale.cactoos.matchers.IsTrue;
@@ -45,16 +44,11 @@ import org.llorllale.cactoos.matchers.IsTrue;
  * @since 0.13
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class WriterAsOutputStreamTest {
-    /**
-     * Temporary files and folders generator.
-     */
-    @Rule
-    public final TemporaryFolder folder = new TemporaryFolder();
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.JUnitTestsShouldIncludeAssert"})
+final class WriterAsOutputStreamTest {
 
     @Test
-    public void writesToByteArray() {
+    void writesToByteArray() {
         final String content = "Hello, товарищ! How are you?";
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         new Assertion<>(
@@ -78,9 +72,8 @@ public final class WriterAsOutputStreamTest {
     }
 
     @Test
-    public void writesLargeContentToFile() throws IOException {
-        final Path temp = this.folder.newFile("cactoos-1.txt-1")
-            .toPath();
+    void writesLargeContentToFile(@TempDir final Path wdir) throws IOException {
+        final Path temp = wdir.resolve("writestream1.txt");
         try (OutputStreamWriter writer = new OutputStreamWriter(
             Files.newOutputStream(temp.toAbsolutePath()),
             StandardCharsets.UTF_8
@@ -105,8 +98,8 @@ public final class WriterAsOutputStreamTest {
     }
 
     @Test
-    public void writesToFileAndRemovesIt() throws Exception {
-        final Path temp = this.folder.newFile().toPath();
+    void writesToFileAndRemovesIt(@TempDir final Path wdir) throws Exception {
+        final Path temp = wdir.resolve("writestream2.txt");
         try (OutputStreamWriter writer = new OutputStreamWriter(
             Files.newOutputStream(temp.toAbsolutePath()),
             StandardCharsets.UTF_8

--- a/src/test/java/org/cactoos/io/WriterAsOutputTest.java
+++ b/src/test/java/org/cactoos/io/WriterAsOutputTest.java
@@ -29,9 +29,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.cactoos.text.TextOf;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasContent;
 
@@ -41,17 +40,12 @@ import org.llorllale.cactoos.matchers.HasContent;
  * @since 0.13
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class WriterAsOutputTest {
-    /**
-     * Temporary files and folders generator.
-     */
-    @Rule
-    public final TemporaryFolder folder = new TemporaryFolder();
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class WriterAsOutputTest {
 
     @Test
-    public void writesLargeContentToFile() throws IOException {
-        final Path temp = this.folder.newFile("cactoos-1.txt-1")
-            .toPath();
+    void writesLargeContentToFile(@TempDir final Path wdir) throws IOException {
+        final Path temp = wdir.resolve("cactoos-1.txt-1");
         try (OutputStreamWriter writer = new OutputStreamWriter(
             Files.newOutputStream(temp.toAbsolutePath()),
             StandardCharsets.UTF_8

--- a/src/test/java/org/cactoos/io/WriterToTest.java
+++ b/src/test/java/org/cactoos/io/WriterToTest.java
@@ -23,12 +23,10 @@
  */
 package org.cactoos.io;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import org.cactoos.text.TextOf;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasContent;
 
@@ -38,17 +36,12 @@ import org.llorllale.cactoos.matchers.HasContent;
  * @since 0.13
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class WriterToTest {
-    /**
-     * Temporary files and folders generator.
-     */
-    @Rule
-    public final TemporaryFolder folder = new TemporaryFolder();
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class WriterToTest {
 
     @Test
-    public void writesLargeContentToFile() throws IOException {
-        final Path temp = this.folder.newFile("cactoos-1.txt-1")
-            .toPath();
+    void writesLargeContentToFile(@TempDir final Path wdir) {
+        final Path temp = wdir.resolve("cactoos-1.txt-1");
         new Assertion<>(
             "Can't copy Input to Output and return Input",
             new TeeInput(

--- a/src/test/java/org/cactoos/io/ZipTest.java
+++ b/src/test/java/org/cactoos/io/ZipTest.java
@@ -33,9 +33,8 @@ import java.util.zip.ZipInputStream;
 import org.cactoos.list.ListOf;
 import org.hamcrest.collection.IsIterableContainingInAnyOrder;
 import org.hamcrest.core.IsEqual;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.llorllale.cactoos.matchers.Assertion;
 
 /**
@@ -44,16 +43,11 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @since 0.29
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class ZipTest {
-    /**
-     * Temporary folder.
-     */
-    @Rule
-    public final TemporaryFolder folder = new TemporaryFolder();
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class ZipTest {
 
     @Test
-    public void zip() throws Exception {
-        final Path dir = this.folder.newFolder().toPath();
+    void zip(@TempDir final Path dir) throws Exception {
         dir.resolve("x/y").toFile().mkdirs();
         Files.write(dir.resolve("x/y/test"), "".getBytes());
         try (ZipInputStream input = new ZipInputStream(
@@ -76,13 +70,11 @@ public final class ZipTest {
     }
 
     @Test
-    public void zipsArbitraryFileList() throws Exception {
-        this.folder.newFolder("dir1");
-        this.folder.newFolder("dir2");
-        this.folder.newFile("file0");
+    void zipsArbitraryFileList(@TempDir final Path dir) throws Exception {
+        dir.resolve("file0");
         final ListOf<Path> targets = new ListOf<>(
-            this.folder.newFile("dir1/file1.txt").toPath(),
-            this.folder.newFile("dir2/file2.txt").toPath()
+            dir.resolve("dir1/file1.txt"),
+            dir.resolve("dir2/file2.txt")
         );
         try (ZipInputStream input = new ZipInputStream(new Zip(targets).stream())) {
             ZipEntry entry = input.getNextEntry();

--- a/src/test/java/org/cactoos/iterable/MatchedTest.java
+++ b/src/test/java/org/cactoos/iterable/MatchedTest.java
@@ -29,8 +29,7 @@ import org.cactoos.proc.ForEach;
 import org.cactoos.scalar.LengthOf;
 import org.hamcrest.collection.IsIterableWithSize;
 import org.hamcrest.core.IsEqual;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasValues;
 import org.llorllale.cactoos.matchers.Throws;
@@ -42,10 +41,10 @@ import org.llorllale.cactoos.matchers.Throws;
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class MatchedTest {
+final class MatchedTest {
 
     @Test
-    public void iterator() {
+    void iterator() {
         new Assertion<>(
             "All elements have correlation function as `equal`",
             new Matched<>(
@@ -57,7 +56,7 @@ public final class MatchedTest {
     }
 
     @Test
-    public void noCorrelationWithBiggerSecondIterable() {
+    void noCorrelationWithBiggerSecondIterable() {
         new Assertion<>(
             "All elements have correlation function as 'endsWith'",
             () -> new ListOf<>(
@@ -72,7 +71,7 @@ public final class MatchedTest {
     }
 
     @Test
-    public void noCorrelationWithSmallerSecondIterable() {
+    void noCorrelationWithSmallerSecondIterable() {
         new Assertion<>(
             "All elements have correlation function as `endsWith`",
             () -> new ListOf<>(
@@ -87,7 +86,7 @@ public final class MatchedTest {
     }
 
     @Test
-    public void endsWith() {
+    void endsWith() {
         new Assertion<>(
             "All elements have correlation function as `endsWith`",
             new Matched<>(
@@ -102,7 +101,7 @@ public final class MatchedTest {
     }
 
     @Test
-    public void matchedAsNumbers() {
+    void matchedAsNumbers() {
         new Assertion<>(
             "All elements must be treated as Number",
             new Matched<>(
@@ -116,32 +115,38 @@ public final class MatchedTest {
         ).affirm();
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void noCorrelation() throws Exception {
-        new LengthOf(
-            new Matched<>(
-                (fst, snd) -> fst.endsWith("elem") && snd.endsWith("elem"),
-                new IterableOf<>("1st elem", "2nd"),
-                new IterableOf<>("`A` elem", "`B` elem")
-            )
-        ).value();
-        Assert.fail("There is no 'endsWith'correlation between 2nd elements");
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void nonNullCorrelation() throws Exception {
-        new LengthOf(
-            new Matched<>(
-                (fst, snd) -> fst != null && snd != null,
-                new IterableOf<>("1st elem", "2nd elem", "3rd elem"),
-                new IterableOf<>("`A` elem", null, "'C' elem")
-            )
-        ).value();
-        Assert.fail("There is no 'non-null' correlation between 2nd elements");
+    @Test
+    void noCorrelation() throws Exception {
+        new Assertion<>(
+            "Should fail if there is no correlation",
+            () -> new LengthOf(
+                new Matched<>(
+                    (fst, snd) -> fst.endsWith("elem") && snd.endsWith("elem"),
+                    new IterableOf<>("1st elem", "2nd"),
+                    new IterableOf<>("`A` elem", "`B` elem")
+                )
+            ).value(),
+            new Throws<>(IllegalStateException.class)
+        ).affirm();
     }
 
     @Test
-    public void iterablesOfDifferentTypes() {
+    void nonNullCorrelation() throws Exception {
+        new Assertion<>(
+            "Should fail if parameter is null",
+            () -> new LengthOf(
+                new Matched<>(
+                    (fst, snd) -> fst != null && snd != null,
+                    new IterableOf<>("1st elem", "2nd elem", "3rd elem"),
+                    new IterableOf<>("`A` elem", null, "'C' elem")
+                )
+            ).value(),
+            new Throws<>(IllegalStateException.class)
+        ).affirm();
+    }
+
+    @Test
+    void iterablesOfDifferentTypes() {
         new Assertion<>(
             "All elements must be treated according to their type",
             new Matched<>(
@@ -156,7 +161,7 @@ public final class MatchedTest {
     }
 
     @Test
-    public void shouldNotChangeAfterTraversing() throws Exception {
+    void shouldNotChangeAfterTraversing() throws Exception {
         final Iterable<Integer> matched = new Matched<>(
             Objects::equals,
             new IterableOf<>(1, 2, 3),

--- a/src/test/java/org/cactoos/iterable/ReversedTest.java
+++ b/src/test/java/org/cactoos/iterable/ReversedTest.java
@@ -27,7 +27,7 @@ import org.cactoos.list.ListOf;
 import org.hamcrest.collection.IsEmptyIterable;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNot;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasSize;
 
@@ -36,10 +36,10 @@ import org.llorllale.cactoos.matchers.HasSize;
  * @since 0.9
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class ReversedTest {
+final class ReversedTest {
 
     @Test
-    public void reversesIterable() {
+    void reversesIterable() {
         new Assertion<>(
             "Must reverse an iterable",
             new Reversed<>(
@@ -52,7 +52,7 @@ public final class ReversedTest {
     }
 
     @Test
-    public void iteratesMultipleTimes() {
+    void iteratesMultipleTimes() {
         final Iterable<String> itr = new Reversed<>(
             new IterableOf<>("h", "w", "d")
         );
@@ -70,7 +70,7 @@ public final class ReversedTest {
     }
 
     @Test
-    public void reverseList() {
+    void reverseList() {
         final String last = "last";
         new Assertion<>(
             "Must reverse list",
@@ -84,7 +84,7 @@ public final class ReversedTest {
     }
 
     @Test
-    public void reverseEmptyList() {
+    void reverseEmptyList() {
         new Assertion<>(
             "Must reverse empty list",
             new Reversed<>(
@@ -95,7 +95,7 @@ public final class ReversedTest {
     }
 
     @Test
-    public void size() {
+    void size() {
         new Assertion<>(
             "Size must be the same",
             new Reversed<>(
@@ -108,7 +108,7 @@ public final class ReversedTest {
     }
 
     @Test
-    public void isEmpty() {
+    void isEmpty() {
         new Assertion<>(
             "Must be not empty",
             new Reversed<>(

--- a/src/test/java/org/cactoos/iterator/CycledTest.java
+++ b/src/test/java/org/cactoos/iterator/CycledTest.java
@@ -28,10 +28,10 @@ import java.util.NoSuchElementException;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.NoNulls;
 import org.cactoos.scalar.ItemAt;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasValue;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test Case for {@link Cycled}.
@@ -65,11 +65,12 @@ final class CycledTest {
 
     @Test
     void notCycledEmptyTest() {
-        Assertions.assertThrows(
-            NoSuchElementException.class,
+        new Assertion<>(
+            "Error is expected for empty iterator",
             () -> new Cycled<>(
                 Collections::emptyIterator
-            ).next()
-        );
+            ).next(),
+            new Throws<>(NoSuchElementException.class)
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/iterator/CycledTest.java
+++ b/src/test/java/org/cactoos/iterator/CycledTest.java
@@ -28,7 +28,8 @@ import java.util.NoSuchElementException;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.NoNulls;
 import org.cactoos.scalar.ItemAt;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasValue;
 
@@ -37,10 +38,10 @@ import org.llorllale.cactoos.matchers.HasValue;
  * @since 0.8
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class CycledTest {
+final class CycledTest {
 
     @Test
-    public void repeatIteratorTest() {
+    void repeatIteratorTest() {
         final String expected = "two";
         new Assertion<>(
             "must repeat iterator",
@@ -62,10 +63,13 @@ public final class CycledTest {
         ).affirm();
     }
 
-    @Test(expected = NoSuchElementException.class)
-    public void notCycledEmptyTest() {
-        new Cycled<>(
-            Collections::emptyIterator
-        ).next();
+    @Test
+    void notCycledEmptyTest() {
+        Assertions.assertThrows(
+            NoSuchElementException.class,
+            () -> new Cycled<>(
+                Collections::emptyIterator
+            ).next()
+        );
     }
 }

--- a/src/test/java/org/cactoos/iterator/ImmutableTest.java
+++ b/src/test/java/org/cactoos/iterator/ImmutableTest.java
@@ -30,9 +30,10 @@ import java.util.Random;
 import org.cactoos.text.Randomized;
 import org.cactoos.text.TextOf;
 import org.hamcrest.core.IsEqual;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.IsText;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test Case for {@link Immutable}.
@@ -40,19 +41,26 @@ import org.llorllale.cactoos.matchers.IsText;
  * @since 0.32
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class ImmutableTest {
+final class ImmutableTest {
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void doesNotAllowRemovingOfElements() {
+    @Test
+    void doesNotAllowRemovingOfElements() {
         final List<String> list = new LinkedList<>();
         list.add("one");
         final Iterator<String> immutable = new Immutable<>(list.iterator());
         immutable.next();
-        immutable.remove();
+        new Assertion<>(
+            "Cann't remove from unmutable",
+            () -> {
+                immutable.remove();
+                return 1;
+            },
+            new Throws<>(UnsupportedOperationException.class)
+        ).affirm();
     }
 
     @Test
-    public void decoratesNext() {
+    void decoratesNext() {
         final int value = new Random().nextInt();
         final Iterator<Integer> immutable = new Immutable<>(
             new IteratorOf<>(value)
@@ -65,7 +73,7 @@ public final class ImmutableTest {
     }
 
     @Test
-    public void decoratesHasNext() {
+    void decoratesHasNext() {
         final int value = new Random().nextInt();
         final Iterator<Integer> immutable = new Immutable<>(
             new IteratorOf<>(value)
@@ -84,7 +92,7 @@ public final class ImmutableTest {
     }
 
     @Test
-    public void decoratesToString() throws Exception {
+    void decoratesToString() throws Exception {
         final String string = new Randomized().asString();
         final Iterator<Object> iterator = new Iterator<Object>() {
             public Object next() {

--- a/src/test/java/org/cactoos/iterator/IteratorOfBooleansTest.java
+++ b/src/test/java/org/cactoos/iterator/IteratorOfBooleansTest.java
@@ -25,7 +25,8 @@ package org.cactoos.iterator;
 
 import java.util.NoSuchElementException;
 import org.hamcrest.core.IsEqual;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 
 /**
@@ -34,10 +35,10 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @since 0.32
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class IteratorOfBooleansTest {
+final class IteratorOfBooleansTest {
 
     @Test
-    public void emptyIteratorDoesNotHaveNext() {
+    void emptyIteratorDoesNotHaveNext() {
         new Assertion<>(
             "hasNext is true for empty iterator",
             new IteratorOfBooleans().hasNext(),
@@ -45,13 +46,16 @@ public final class IteratorOfBooleansTest {
         ).affirm();
     }
 
-    @Test(expected = NoSuchElementException.class)
-    public void emptyIteratorThrowsException() {
-        new IteratorOfBooleans().next();
+    @Test
+    void emptyIteratorThrowsException() {
+        Assertions.assertThrows(
+            NoSuchElementException.class,
+            () -> new IteratorOfBooleans().next()
+        );
     }
 
     @Test
-    public void nonEmptyIteratorDoesNotHaveNext() {
+    void nonEmptyIteratorDoesNotHaveNext() {
         final IteratorOfBooleans iterator = new IteratorOfBooleans(true, false);
         iterator.next();
         iterator.next();
@@ -62,10 +66,13 @@ public final class IteratorOfBooleansTest {
         ).affirm();
     }
 
-    @Test(expected = NoSuchElementException.class)
-    public void nonEmptyIteratorThrowsException() {
+    @Test
+    void nonEmptyIteratorThrowsException() {
         final IteratorOfBooleans iterator = new IteratorOfBooleans(true);
         iterator.next();
-        iterator.next();
+        Assertions.assertThrows(
+            NoSuchElementException.class,
+            iterator::next
+        );
     }
 }

--- a/src/test/java/org/cactoos/iterator/IteratorOfBooleansTest.java
+++ b/src/test/java/org/cactoos/iterator/IteratorOfBooleansTest.java
@@ -25,9 +25,9 @@ package org.cactoos.iterator;
 
 import java.util.NoSuchElementException;
 import org.hamcrest.core.IsEqual;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Tests for {@link IteratorOfBooleans}.
@@ -48,10 +48,11 @@ final class IteratorOfBooleansTest {
 
     @Test
     void emptyIteratorThrowsException() {
-        Assertions.assertThrows(
-            NoSuchElementException.class,
-            () -> new IteratorOfBooleans().next()
-        );
+        new Assertion<>(
+            "Exception is expected for empty iterator",
+            () -> new IteratorOfBooleans().next(),
+            new Throws<>(NoSuchElementException.class)
+        ).affirm();
     }
 
     @Test
@@ -70,9 +71,10 @@ final class IteratorOfBooleansTest {
     void nonEmptyIteratorThrowsException() {
         final IteratorOfBooleans iterator = new IteratorOfBooleans(true);
         iterator.next();
-        Assertions.assertThrows(
-            NoSuchElementException.class,
-            iterator::next
-        );
+        new Assertion<>(
+            "Exception is expected after iterating last item",
+            iterator::next,
+            new Throws<>(NoSuchElementException.class)
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/iterator/IteratorOfBytesTest.java
+++ b/src/test/java/org/cactoos/iterator/IteratorOfBytesTest.java
@@ -28,7 +28,8 @@ import java.util.NoSuchElementException;
 import org.cactoos.list.ListOf;
 import org.cactoos.text.TextOf;
 import org.hamcrest.core.IsEqual;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasValues;
 
@@ -40,10 +41,10 @@ import org.llorllale.cactoos.matchers.HasValues;
  * @since 0.34
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class IteratorOfBytesTest {
+final class IteratorOfBytesTest {
 
     @Test
-    public void canBeConstructedFromString() throws Exception {
+    void canBeConstructedFromString() throws Exception {
         final Iterator<Byte> itr = new IteratorOfBytes(
             "F"
         );
@@ -60,7 +61,7 @@ public final class IteratorOfBytesTest {
     }
 
     @Test
-    public void canBeConstructedFromText() throws Exception {
+    void canBeConstructedFromText() throws Exception {
         final Iterator<Byte> itr = new IteratorOfBytes(
             new TextOf("ABC")
         );
@@ -79,7 +80,7 @@ public final class IteratorOfBytesTest {
     }
 
     @Test
-    public void emptyIteratorDoesNotHaveNext() {
+    void emptyIteratorDoesNotHaveNext() {
         new Assertion<>(
             "hasNext is true for empty iterator.",
             new IteratorOfBytes().hasNext(),
@@ -87,13 +88,16 @@ public final class IteratorOfBytesTest {
         ).affirm();
     }
 
-    @Test(expected = NoSuchElementException.class)
-    public void emptyIteratorThrowsException() {
-        new IteratorOfBytes().next();
+    @Test
+    void emptyIteratorThrowsException() {
+        Assertions.assertThrows(
+            NoSuchElementException.class,
+            () -> new IteratorOfBytes().next()
+        );
     }
 
     @Test
-    public void nonEmptyIteratorDoesNotHaveNext() {
+    void nonEmptyIteratorDoesNotHaveNext() {
         new Assertion<>(
             "hasNext is true for fully traversed iterator.",
             this.iteratorWithFetchedElements().hasNext(),
@@ -101,9 +105,12 @@ public final class IteratorOfBytesTest {
         ).affirm();
     }
 
-    @Test(expected = NoSuchElementException.class)
-    public void nonEmptyIteratorThrowsException() {
-        this.iteratorWithFetchedElements().next();
+    @Test
+    void nonEmptyIteratorThrowsException() {
+        Assertions.assertThrows(
+            NoSuchElementException.class,
+            () -> this.iteratorWithFetchedElements().next()
+        );
     }
 
     private IteratorOfBytes iteratorWithFetchedElements() {

--- a/src/test/java/org/cactoos/iterator/IteratorOfBytesTest.java
+++ b/src/test/java/org/cactoos/iterator/IteratorOfBytesTest.java
@@ -28,10 +28,10 @@ import java.util.NoSuchElementException;
 import org.cactoos.list.ListOf;
 import org.cactoos.text.TextOf;
 import org.hamcrest.core.IsEqual;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasValues;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Tests for {@link IteratorOfBytes}.
@@ -41,6 +41,7 @@ import org.llorllale.cactoos.matchers.HasValues;
  * @since 0.34
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class IteratorOfBytesTest {
 
     @Test
@@ -90,10 +91,11 @@ final class IteratorOfBytesTest {
 
     @Test
     void emptyIteratorThrowsException() {
-        Assertions.assertThrows(
-            NoSuchElementException.class,
-            () -> new IteratorOfBytes().next()
-        );
+        new Assertion<>(
+            "Exception is expected on iterating empty bytes.",
+            () -> new IteratorOfBytes().next(),
+            new Throws<>(NoSuchElementException.class)
+        ).affirm();
     }
 
     @Test
@@ -107,10 +109,11 @@ final class IteratorOfBytesTest {
 
     @Test
     void nonEmptyIteratorThrowsException() {
-        Assertions.assertThrows(
-            NoSuchElementException.class,
-            () -> this.iteratorWithFetchedElements().next()
-        );
+        new Assertion<>(
+            "Exception is expected for fully traversed iterator.",
+            () -> this.iteratorWithFetchedElements().next(),
+            new Throws<>(NoSuchElementException.class)
+        ).affirm();
     }
 
     private IteratorOfBytes iteratorWithFetchedElements() {

--- a/src/test/java/org/cactoos/iterator/IteratorOfCharsTest.java
+++ b/src/test/java/org/cactoos/iterator/IteratorOfCharsTest.java
@@ -27,9 +27,10 @@ import java.util.NoSuchElementException;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.text.TextOf;
 import org.hamcrest.core.IsEqual;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasValues;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Tests for {@link IteratorOfChars}.
@@ -37,10 +38,10 @@ import org.llorllale.cactoos.matchers.HasValues;
  * @since 0.32
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class IteratorOfCharsTest {
+final class IteratorOfCharsTest {
 
     @Test
-    public void canBeConstructedFromText() {
+    void canBeConstructedFromText() {
         new Assertion<>(
             "Iterator must contain all characters of the string",
             new IterableOf<>(
@@ -53,7 +54,7 @@ public final class IteratorOfCharsTest {
     }
 
     @Test
-    public void emptyIteratorDoesNotHaveNext() {
+    void emptyIteratorDoesNotHaveNext() {
         new Assertion<>(
             "hasNext is true for empty iterator",
             new IteratorOfChars().hasNext(),
@@ -61,13 +62,17 @@ public final class IteratorOfCharsTest {
         ).affirm();
     }
 
-    @Test(expected = NoSuchElementException.class)
-    public void emptyIteratorThrowsException() {
-        new IteratorOfChars().next();
+    @Test
+    void emptyIteratorThrowsException() {
+        new Assertion<>(
+            "Cann't iterate in empty string",
+            () -> new IteratorOfChars().next(),
+            new Throws<>(NoSuchElementException.class)
+        ).affirm();
     }
 
     @Test
-    public void nonEmptyIteratorDoesNotHaveNext() {
+    void nonEmptyIteratorDoesNotHaveNext() {
         final IteratorOfChars iterator = new IteratorOfChars(
             'a', 'b', 'c'
         );
@@ -81,12 +86,16 @@ public final class IteratorOfCharsTest {
         ).affirm();
     }
 
-    @Test(expected = NoSuchElementException.class)
-    public void nonEmptyIteratorThrowsException() {
+    @Test
+    void nonEmptyIteratorThrowsException() {
         final IteratorOfChars iterator = new IteratorOfChars(
             'a'
         );
         iterator.next();
-        iterator.next();
+        new Assertion<>(
+            "Cann't move to second character",
+            () -> iterator.next(),
+            new Throws<>(NoSuchElementException.class)
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/iterator/IteratorOfCharsTest.java
+++ b/src/test/java/org/cactoos/iterator/IteratorOfCharsTest.java
@@ -65,7 +65,7 @@ final class IteratorOfCharsTest {
     @Test
     void emptyIteratorThrowsException() {
         new Assertion<>(
-            "Cann't iterate in empty string",
+            "Exception is expected on iterating empty string",
             () -> new IteratorOfChars().next(),
             new Throws<>(NoSuchElementException.class)
         ).affirm();

--- a/src/test/java/org/cactoos/iterator/IteratorOfDoublesTest.java
+++ b/src/test/java/org/cactoos/iterator/IteratorOfDoublesTest.java
@@ -25,9 +25,9 @@ package org.cactoos.iterator;
 
 import java.util.NoSuchElementException;
 import org.hamcrest.core.IsEqual;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Tests for {@link IteratorOfDoubles}.
@@ -37,6 +37,7 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @since 0.34
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class IteratorOfDoublesTest {
 
     @Test
@@ -50,10 +51,11 @@ final class IteratorOfDoublesTest {
 
     @Test
     void emptyIteratorThrowsException() {
-        Assertions.assertThrows(
-            NoSuchElementException.class,
-            () -> new IteratorOfDoubles().next()
-        );
+        new Assertion<>(
+            "Exception is expected on iterating empty doubles.",
+            () -> new IteratorOfDoubles().next(),
+            new Throws<>(NoSuchElementException.class)
+        ).affirm();
     }
 
     @Test
@@ -67,10 +69,11 @@ final class IteratorOfDoublesTest {
 
     @Test
     void nonEmptyIteratorThrowsException() {
-        Assertions.assertThrows(
-            NoSuchElementException.class,
-            () -> this.iteratorWithFetchedElements().next()
-        );
+        new Assertion<>(
+            "Exception is expected for fully traversed iterator.",
+            () -> this.iteratorWithFetchedElements().next(),
+            new Throws<>(NoSuchElementException.class)
+        ).affirm();
     }
 
     private IteratorOfDoubles iteratorWithFetchedElements() {

--- a/src/test/java/org/cactoos/iterator/IteratorOfDoublesTest.java
+++ b/src/test/java/org/cactoos/iterator/IteratorOfDoublesTest.java
@@ -25,7 +25,8 @@ package org.cactoos.iterator;
 
 import java.util.NoSuchElementException;
 import org.hamcrest.core.IsEqual;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 
 /**
@@ -36,10 +37,10 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @since 0.34
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class IteratorOfDoublesTest {
+final class IteratorOfDoublesTest {
 
     @Test
-    public void emptyIteratorDoesNotHaveNext() {
+    void emptyIteratorDoesNotHaveNext() {
         new Assertion<>(
             "hasNext is true for empty iterator.",
             new IteratorOfDoubles().hasNext(),
@@ -47,13 +48,16 @@ public final class IteratorOfDoublesTest {
         ).affirm();
     }
 
-    @Test(expected = NoSuchElementException.class)
-    public void emptyIteratorThrowsException() {
-        new IteratorOfDoubles().next();
+    @Test
+    void emptyIteratorThrowsException() {
+        Assertions.assertThrows(
+            NoSuchElementException.class,
+            () -> new IteratorOfDoubles().next()
+        );
     }
 
     @Test
-    public void nonEmptyIteratorDoesNotHaveNext() {
+    void nonEmptyIteratorDoesNotHaveNext() {
         new Assertion<>(
             "hasNext is true for fully traversed iterator.",
             this.iteratorWithFetchedElements().hasNext(),
@@ -61,9 +65,12 @@ public final class IteratorOfDoublesTest {
         ).affirm();
     }
 
-    @Test(expected = NoSuchElementException.class)
-    public void nonEmptyIteratorThrowsException() {
-        this.iteratorWithFetchedElements().next();
+    @Test
+    void nonEmptyIteratorThrowsException() {
+        Assertions.assertThrows(
+            NoSuchElementException.class,
+            () -> this.iteratorWithFetchedElements().next()
+        );
     }
 
     private IteratorOfDoubles iteratorWithFetchedElements() {

--- a/src/test/java/org/cactoos/iterator/IteratorOfFloatsTest.java
+++ b/src/test/java/org/cactoos/iterator/IteratorOfFloatsTest.java
@@ -25,9 +25,9 @@ package org.cactoos.iterator;
 
 import java.util.NoSuchElementException;
 import org.hamcrest.core.IsEqual;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Tests for {@link IteratorOfFloats}.
@@ -35,6 +35,7 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @since 0.32
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class IteratorOfFloatsTest {
 
     @Test
@@ -48,10 +49,11 @@ final class IteratorOfFloatsTest {
 
     @Test
     void emptyIteratorThrowsException() {
-        Assertions.assertThrows(
-            NoSuchElementException.class,
-            () -> new IteratorOfFloats().next()
-        );
+        new Assertion<>(
+            "Exception is expected for empty float iterator",
+            () -> new IteratorOfFloats().next(),
+            new Throws<>(NoSuchElementException.class)
+        ).affirm();
     }
 
     @Test
@@ -70,9 +72,10 @@ final class IteratorOfFloatsTest {
     void nonEmptyIteratorThrowsException() {
         final IteratorOfFloats iterator = new IteratorOfFloats(1.0f);
         iterator.next();
-        Assertions.assertThrows(
-            NoSuchElementException.class,
-            iterator::next
-        );
+        new Assertion<>(
+            "Excpetion is expected for fully traversed iterator.",
+            iterator::next,
+            new Throws<>(NoSuchElementException.class)
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/iterator/IteratorOfFloatsTest.java
+++ b/src/test/java/org/cactoos/iterator/IteratorOfFloatsTest.java
@@ -25,7 +25,8 @@ package org.cactoos.iterator;
 
 import java.util.NoSuchElementException;
 import org.hamcrest.core.IsEqual;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 
 /**
@@ -34,10 +35,10 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @since 0.32
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class IteratorOfFloatsTest {
+final class IteratorOfFloatsTest {
 
     @Test
-    public void emptyIteratorDoesNotHaveNext() {
+    void emptyIteratorDoesNotHaveNext() {
         new Assertion<>(
             "hasNext is true for empty iterator.",
             new IteratorOfFloats().hasNext(),
@@ -45,13 +46,16 @@ public final class IteratorOfFloatsTest {
         ).affirm();
     }
 
-    @Test(expected = NoSuchElementException.class)
-    public void emptyIteratorThrowsException() {
-        new IteratorOfFloats().next();
+    @Test
+    void emptyIteratorThrowsException() {
+        Assertions.assertThrows(
+            NoSuchElementException.class,
+            () -> new IteratorOfFloats().next()
+        );
     }
 
     @Test
-    public void nonEmptyIteratorDoesNotHaveNext() {
+    void nonEmptyIteratorDoesNotHaveNext() {
         final IteratorOfFloats iterator = new IteratorOfFloats(1.0f, 2.0f);
         iterator.next();
         iterator.next();
@@ -62,10 +66,13 @@ public final class IteratorOfFloatsTest {
         ).affirm();
     }
 
-    @Test(expected = NoSuchElementException.class)
-    public void nonEmptyIteratorThrowsException() {
+    @Test
+    void nonEmptyIteratorThrowsException() {
         final IteratorOfFloats iterator = new IteratorOfFloats(1.0f);
         iterator.next();
-        iterator.next();
+        Assertions.assertThrows(
+            NoSuchElementException.class,
+            iterator::next
+        );
     }
 }

--- a/src/test/java/org/cactoos/iterator/IteratorOfIntsTest.java
+++ b/src/test/java/org/cactoos/iterator/IteratorOfIntsTest.java
@@ -25,8 +25,10 @@ package org.cactoos.iterator;
 
 import java.util.NoSuchElementException;
 import org.hamcrest.core.IsEqual;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Tests for {@link IteratorOfInts}.
@@ -34,10 +36,10 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @since 0.32
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class IteratorOfIntsTest {
+final class IteratorOfIntsTest {
 
     @Test
-    public void emptyIteratorDoesNotHaveNext() {
+    void emptyIteratorDoesNotHaveNext() {
         new Assertion<>(
             "hasNext is true for empty iterator.",
             new IteratorOfInts().hasNext(),
@@ -45,13 +47,16 @@ public final class IteratorOfIntsTest {
         ).affirm();
     }
 
-    @Test(expected = NoSuchElementException.class)
-    public void emptyIteratorThrowsException() {
-        new IteratorOfInts().next();
+    @Test
+    void emptyIteratorThrowsException() {
+        Assertions.assertThrows(
+            NoSuchElementException.class,
+            () -> new IteratorOfInts().next()
+        );
     }
 
     @Test
-    public void nonEmptyIteratorDoesNotHaveNext() {
+    void nonEmptyIteratorDoesNotHaveNext() {
         final IteratorOfInts iterator = new IteratorOfInts(1, 2);
         iterator.next();
         iterator.next();
@@ -62,10 +67,14 @@ public final class IteratorOfIntsTest {
         ).affirm();
     }
 
-    @Test(expected = NoSuchElementException.class)
-    public void nonEmptyIteratorThrowsException() {
+    @Test
+    void nonEmptyIteratorThrowsException() {
         final IteratorOfInts iterator = new IteratorOfInts(1);
         iterator.next();
-        iterator.next();
+        new Assertion<>(
+            "",
+            iterator::next,
+            new Throws<>(NoSuchElementException.class)
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/iterator/IteratorOfIntsTest.java
+++ b/src/test/java/org/cactoos/iterator/IteratorOfIntsTest.java
@@ -25,7 +25,6 @@ package org.cactoos.iterator;
 
 import java.util.NoSuchElementException;
 import org.hamcrest.core.IsEqual;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.Throws;
@@ -36,6 +35,7 @@ import org.llorllale.cactoos.matchers.Throws;
  * @since 0.32
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class IteratorOfIntsTest {
 
     @Test
@@ -49,10 +49,11 @@ final class IteratorOfIntsTest {
 
     @Test
     void emptyIteratorThrowsException() {
-        Assertions.assertThrows(
-            NoSuchElementException.class,
-            () -> new IteratorOfInts().next()
-        );
+        new Assertion<>(
+            "Exception is expected on iterating empty ints.",
+            () -> new IteratorOfInts().next(),
+            new Throws<>(NoSuchElementException.class)
+        ).affirm();
     }
 
     @Test
@@ -72,7 +73,7 @@ final class IteratorOfIntsTest {
         final IteratorOfInts iterator = new IteratorOfInts(1);
         iterator.next();
         new Assertion<>(
-            "",
+            "Exception is expected for fully traversed iterator.",
             iterator::next,
             new Throws<>(NoSuchElementException.class)
         ).affirm();

--- a/src/test/java/org/cactoos/iterator/IteratorOfLongsTest.java
+++ b/src/test/java/org/cactoos/iterator/IteratorOfLongsTest.java
@@ -25,9 +25,9 @@ package org.cactoos.iterator;
 
 import java.util.NoSuchElementException;
 import org.hamcrest.core.IsEqual;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Tests for {@link IteratorOfLongs}.
@@ -35,6 +35,7 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @since 0.34
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class IteratorOfLongsTest {
 
     @Test
@@ -48,10 +49,11 @@ final class IteratorOfLongsTest {
 
     @Test
     void emptyIteratorThrowsException() {
-        Assertions.assertThrows(
-            NoSuchElementException.class,
-            () -> new IteratorOfLongs().next()
-        );
+        new Assertion<>(
+            "Exception is expected for empty iterator of longs.",
+            () -> new IteratorOfLongs().next(),
+            new Throws<>(NoSuchElementException.class)
+        ).affirm();
     }
 
     @Test
@@ -70,9 +72,10 @@ final class IteratorOfLongsTest {
     void nonEmptyIteratorThrowsException() {
         final IteratorOfLongs iterator = new IteratorOfLongs(1);
         iterator.next();
-        Assertions.assertThrows(
-            NoSuchElementException.class,
-                iterator::next
-        );
+        new Assertion<>(
+            "Exception is expected for fully traversed iterator.",
+            iterator::next,
+            new Throws<>(NoSuchElementException.class)
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/iterator/IteratorOfLongsTest.java
+++ b/src/test/java/org/cactoos/iterator/IteratorOfLongsTest.java
@@ -25,7 +25,8 @@ package org.cactoos.iterator;
 
 import java.util.NoSuchElementException;
 import org.hamcrest.core.IsEqual;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 
 /**
@@ -34,10 +35,10 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @since 0.34
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class IteratorOfLongsTest {
+final class IteratorOfLongsTest {
 
     @Test
-    public void emptyIteratorDoesNotHaveNext() {
+    void emptyIteratorDoesNotHaveNext() {
         new Assertion<>(
             "hasNext is true for empty iterator.",
             new IteratorOfLongs().hasNext(),
@@ -45,13 +46,16 @@ public final class IteratorOfLongsTest {
         ).affirm();
     }
 
-    @Test(expected = NoSuchElementException.class)
-    public void emptyIteratorThrowsException() {
-        new IteratorOfLongs().next();
+    @Test
+    void emptyIteratorThrowsException() {
+        Assertions.assertThrows(
+            NoSuchElementException.class,
+            () -> new IteratorOfLongs().next()
+        );
     }
 
     @Test
-    public void nonEmptyIteratorDoesNotHaveNext() {
+    void nonEmptyIteratorDoesNotHaveNext() {
         final IteratorOfLongs iterator = new IteratorOfLongs(1, 2);
         iterator.next();
         iterator.next();
@@ -62,10 +66,13 @@ public final class IteratorOfLongsTest {
         ).affirm();
     }
 
-    @Test(expected = NoSuchElementException.class)
-    public void nonEmptyIteratorThrowsException() {
+    @Test
+    void nonEmptyIteratorThrowsException() {
         final IteratorOfLongs iterator = new IteratorOfLongs(1);
         iterator.next();
-        iterator.next();
+        Assertions.assertThrows(
+            NoSuchElementException.class,
+                iterator::next
+        );
     }
 }

--- a/src/test/java/org/cactoos/iterator/IteratorOfShortsTest.java
+++ b/src/test/java/org/cactoos/iterator/IteratorOfShortsTest.java
@@ -25,7 +25,8 @@ package org.cactoos.iterator;
 
 import java.util.NoSuchElementException;
 import org.hamcrest.core.IsEqual;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 
 /**
@@ -35,10 +36,10 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidUsingShortType")
-public final class IteratorOfShortsTest {
+final class IteratorOfShortsTest {
 
     @Test
-    public void emptyIteratorDoesNotHaveNext() {
+    void emptyIteratorDoesNotHaveNext() {
         new Assertion<>(
             "hasNext is true for empty iterator.",
             new IteratorOfShorts().hasNext(),
@@ -46,13 +47,16 @@ public final class IteratorOfShortsTest {
         ).affirm();
     }
 
-    @Test(expected = NoSuchElementException.class)
-    public void emptyIteratorThrowsException() {
-        new IteratorOfShorts().next();
+    @Test
+    void emptyIteratorThrowsException() {
+        Assertions.assertThrows(
+            NoSuchElementException.class,
+            () -> new IteratorOfShorts().next()
+        );
     }
 
     @Test
-    public void nonEmptyIteratorDoesNotHaveNext() {
+    void nonEmptyIteratorDoesNotHaveNext() {
         final IteratorOfShorts iterator = new IteratorOfShorts(
             (short) 1, (short) 2
         );
@@ -65,10 +69,13 @@ public final class IteratorOfShortsTest {
         ).affirm();
     }
 
-    @Test(expected = NoSuchElementException.class)
-    public void nonEmptyIteratorThrowsException() {
+    @Test
+    void nonEmptyIteratorThrowsException() {
         final IteratorOfShorts iterator = new IteratorOfShorts((short) 1);
         iterator.next();
-        iterator.next();
+        Assertions.assertThrows(
+            NoSuchElementException.class,
+            iterator::next
+        );
     }
 }

--- a/src/test/java/org/cactoos/iterator/IteratorOfShortsTest.java
+++ b/src/test/java/org/cactoos/iterator/IteratorOfShortsTest.java
@@ -25,9 +25,9 @@ package org.cactoos.iterator;
 
 import java.util.NoSuchElementException;
 import org.hamcrest.core.IsEqual;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Tests for {@link IteratorOfShorts}.
@@ -49,10 +49,11 @@ final class IteratorOfShortsTest {
 
     @Test
     void emptyIteratorThrowsException() {
-        Assertions.assertThrows(
-            NoSuchElementException.class,
-            () -> new IteratorOfShorts().next()
-        );
+        new Assertion<>(
+            "Exception is expected for empty iterator",
+            () -> new IteratorOfShorts().next(),
+            new Throws<>(NoSuchElementException.class)
+        ).affirm();
     }
 
     @Test
@@ -73,9 +74,10 @@ final class IteratorOfShortsTest {
     void nonEmptyIteratorThrowsException() {
         final IteratorOfShorts iterator = new IteratorOfShorts((short) 1);
         iterator.next();
-        Assertions.assertThrows(
-            NoSuchElementException.class,
-            iterator::next
-        );
+        new Assertion<>(
+            "Exception is not thrown after last item iteration",
+            iterator::next,
+            new Throws<>(NoSuchElementException.class)
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/iterator/PartitionedTest.java
+++ b/src/test/java/org/cactoos/iterator/PartitionedTest.java
@@ -31,7 +31,8 @@ import org.cactoos.list.ListOf;
 import org.cactoos.scalar.LengthOf;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasValue;
 
@@ -41,10 +42,10 @@ import org.llorllale.cactoos.matchers.HasValue;
  * @since 0.29
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class PartitionedTest {
+final class PartitionedTest {
 
     @Test
-    public void emptyPartitioned() throws Exception {
+    void emptyPartitioned() throws Exception {
         new Assertion<>(
             "Can't generate an empty Partitioned.",
             new LengthOf(
@@ -58,7 +59,7 @@ public final class PartitionedTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void partitionedOne() {
+    void partitionedOne() {
         new Assertion<>(
             "Can't generate a Partitioned of partition size 1.",
             new ArrayList<>(
@@ -77,7 +78,7 @@ public final class PartitionedTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void partitionedEqualSize() {
+    void partitionedEqualSize() {
         new Assertion<>(
             "Can't generate a Partitioned of partition size 2.",
             new ArrayList<>(
@@ -93,7 +94,7 @@ public final class PartitionedTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void partitionedLastPartitionSmaller() {
+    void partitionedLastPartitionSmaller() {
         new Assertion<>(
             "Can't generate a Partitioned of size 2 last partition smaller.",
             new ListOf<>(
@@ -108,23 +109,32 @@ public final class PartitionedTest {
         ).affirm();
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void partitionedWithPartitionSizeSmallerOne() {
-        new Partitioned<>(0, new ListOf<>(1).iterator()).next();
+    @Test
+    void partitionedWithPartitionSizeSmallerOne() {
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> new Partitioned<>(0, new ListOf<>(1).iterator()).next()
+        );
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void partitionedListsAreUnmodifiable() {
-        new Partitioned<>(
-            2, new ListOf<>(1, 2).iterator()
-        ).next().clear();
+    @Test
+    void partitionedListsAreUnmodifiable() {
+        Assertions.assertThrows(
+            UnsupportedOperationException.class,
+            () -> new Partitioned<>(
+                2, new ListOf<>(1, 2).iterator()
+            ).next().clear()
+        );
     }
 
-    @Test(expected = NoSuchElementException.class)
-    public void emptyPartitionedNextThrowsException() {
-        new Partitioned<>(
-            2, Collections.emptyIterator()
-        ).next();
+    @Test
+    void emptyPartitionedNextThrowsException() {
+        Assertions.assertThrows(
+            NoSuchElementException.class,
+            () -> new Partitioned<>(
+                2, Collections.emptyIterator()
+            ).next()
+        );
     }
 
 }

--- a/src/test/java/org/cactoos/iterator/PartitionedTest.java
+++ b/src/test/java/org/cactoos/iterator/PartitionedTest.java
@@ -31,10 +31,10 @@ import org.cactoos.list.ListOf;
 import org.cactoos.scalar.LengthOf;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasValue;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link Partitioned}.
@@ -42,6 +42,7 @@ import org.llorllale.cactoos.matchers.HasValue;
  * @since 0.29
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class PartitionedTest {
 
     @Test
@@ -111,30 +112,36 @@ final class PartitionedTest {
 
     @Test
     void partitionedWithPartitionSizeSmallerOne() {
-        Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () -> new Partitioned<>(0, new ListOf<>(1).iterator()).next()
-        );
+        new Assertion<>(
+            "Exception is expected for partition size lower 1",
+            () -> new Partitioned<>(0, new ListOf<>(1).iterator()).next(),
+            new Throws<>(IllegalArgumentException.class)
+        ).affirm();
     }
 
     @Test
     void partitionedListsAreUnmodifiable() {
-        Assertions.assertThrows(
-            UnsupportedOperationException.class,
-            () -> new Partitioned<>(
-                2, new ListOf<>(1, 2).iterator()
-            ).next().clear()
-        );
+        new Assertion<>(
+            "Exception is expected on modification operations",
+            () -> {
+                new Partitioned<>(
+                    2, new ListOf<>(1, 2).iterator()
+                ).next().clear();
+                return 1;
+            },
+            new Throws<>(UnsupportedOperationException.class)
+        ).affirm();
     }
 
     @Test
     void emptyPartitionedNextThrowsException() {
-        Assertions.assertThrows(
-            NoSuchElementException.class,
+        new Assertion<>(
+            "Exception is expected for iteration empty",
             () -> new Partitioned<>(
                 2, Collections.emptyIterator()
-            ).next()
-        );
+            ).next(),
+            new Throws<>(NoSuchElementException.class)
+        ).affirm();
     }
 
 }

--- a/src/test/java/org/cactoos/list/ImmutableListIteratorTest.java
+++ b/src/test/java/org/cactoos/list/ImmutableListIteratorTest.java
@@ -34,7 +34,9 @@ import org.llorllale.cactoos.matchers.Throws;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocTypeCheck (500 lines)
  */
-@SuppressWarnings({"PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals"})
+@SuppressWarnings({"PMD.TooManyMethods",
+    "PMD.AvoidDuplicateLiterals",
+    "PMD.JUnitTestsShouldIncludeAssert"})
 final class ImmutableListIteratorTest {
 
     @Test

--- a/src/test/java/org/cactoos/list/ImmutableTest.java
+++ b/src/test/java/org/cactoos/list/ImmutableTest.java
@@ -40,7 +40,7 @@ import org.llorllale.cactoos.matchers.Throws;
  * @since 1.16
  */
 @SuppressWarnings({"PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals"})
-class ImmutableTest {
+final class ImmutableTest {
 
     @Test
     void innerListIsDecorated() {

--- a/src/test/java/org/cactoos/list/JoinedListIteratorTest.java
+++ b/src/test/java/org/cactoos/list/JoinedListIteratorTest.java
@@ -36,6 +36,7 @@ import org.llorllale.cactoos.matchers.Throws;
  * @since 1.0.0
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class JoinedListIteratorTest {
 
     @Test

--- a/src/test/java/org/cactoos/list/JoinedTest.java
+++ b/src/test/java/org/cactoos/list/JoinedTest.java
@@ -29,10 +29,10 @@ import org.hamcrest.collection.IsIterableContainingInOrder;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsInstanceOf;
 import org.hamcrest.core.IsNot;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.IsTrue;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link Joined}.
@@ -41,7 +41,8 @@ import org.llorllale.cactoos.matchers.IsTrue;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle DiamondOperatorCheck (500 lines)
  */
-@SuppressWarnings("PMD.TooManyMethods")
+@SuppressWarnings({"PMD.TooManyMethods",
+    "PMD.JUnitTestsShouldIncludeAssert"})
 final class JoinedTest {
 
     /**
@@ -401,10 +402,11 @@ final class JoinedTest {
 
     @Test
     void listIteratorSecond() {
-        Assertions.assertThrows(
-            IndexOutOfBoundsException.class,
-            () -> new Joined<Integer>().listIterator(66)
-        );
+        new Assertion<>(
+            "Exception is expected for greater then size index",
+            () -> new Joined<Integer>().listIterator(66),
+            new Throws<>(IndexOutOfBoundsException.class)
+        ).affirm();
     }
 
     @Test

--- a/src/test/java/org/cactoos/list/JoinedTest.java
+++ b/src/test/java/org/cactoos/list/JoinedTest.java
@@ -29,7 +29,8 @@ import org.hamcrest.collection.IsIterableContainingInOrder;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsInstanceOf;
 import org.hamcrest.core.IsNot;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.IsTrue;
 
@@ -41,7 +42,7 @@ import org.llorllale.cactoos.matchers.IsTrue;
  * @checkstyle DiamondOperatorCheck (500 lines)
  */
 @SuppressWarnings("PMD.TooManyMethods")
-public final class JoinedTest {
+final class JoinedTest {
 
     /**
      * Literal ONE value.
@@ -64,7 +65,7 @@ public final class JoinedTest {
     private static final String LITERAL_FOUR = "FOUR";
 
     @Test
-    public void behavesAsCollection() {
+    void behavesAsCollection() {
         new Assertion<>(
             "Can't behave as a list",
             new Joined<String>(
@@ -80,7 +81,7 @@ public final class JoinedTest {
     }
 
     @Test
-    public void size() {
+    void size() {
         new Assertion<>(
             "Must evaluate the size of the joined list",
             new Joined<String>(
@@ -96,7 +97,7 @@ public final class JoinedTest {
     }
 
     @Test
-    public void isEmpty() {
+    void isEmpty() {
         new Assertion<>(
             "Must be evaluated as an empty list",
             new Joined<String>(
@@ -112,7 +113,7 @@ public final class JoinedTest {
     }
 
     @Test
-    public void contains() {
+    void contains() {
         new Assertion<>(
             "Must contain element specified",
             new Joined<String>(
@@ -128,7 +129,7 @@ public final class JoinedTest {
     }
 
     @Test
-    public void iterator() {
+    void iterator() {
         new Assertion<>(
             "Joined Iterator Must return next element equal to the first added",
             new Joined<String>(
@@ -146,7 +147,7 @@ public final class JoinedTest {
     }
 
     @Test
-    public void add() {
+    void add() {
         final List<String> joined = new Joined<String>(
             new ListOf<>(JoinedTest.LITERAL_ONE),
             new ListOf<>(JoinedTest.LITERAL_TWO)
@@ -166,7 +167,7 @@ public final class JoinedTest {
     }
 
     @Test
-    public void remove() {
+    void remove() {
         final List<String> joined = new Joined<String>(
             new ListOf<>(JoinedTest.LITERAL_ONE),
             new ListOf<>(JoinedTest.LITERAL_TWO)
@@ -184,7 +185,7 @@ public final class JoinedTest {
     }
 
     @Test
-    public void containsAll() {
+    void containsAll() {
         new Assertion<>(
             "Must contain all elements",
             new Joined<String>(
@@ -201,7 +202,7 @@ public final class JoinedTest {
     }
 
     @Test
-    public void addAll() {
+    void addAll() {
         final List<String> joined = new Joined<String>(
             new ListOf<>(JoinedTest.LITERAL_ONE),
             new ListOf<>(JoinedTest.LITERAL_TWO)
@@ -227,7 +228,7 @@ public final class JoinedTest {
     }
 
     @Test
-    public void addAllInFront() {
+    void addAllInFront() {
         final List<String> joined = new Joined<String>(
             new ListOf<>(JoinedTest.LITERAL_ONE),
             new ListOf<>(JoinedTest.LITERAL_TWO)
@@ -254,7 +255,7 @@ public final class JoinedTest {
     }
 
     @Test
-    public void removeAll() {
+    void removeAll() {
         final List<String> joined = new Joined<String>(
             new ListOf<>(
                 JoinedTest.LITERAL_ONE,
@@ -280,7 +281,7 @@ public final class JoinedTest {
     }
 
     @Test
-    public void retainAll() {
+    void retainAll() {
         final List<String> joined = new Joined<String>(
             new ListOf<>(JoinedTest.LITERAL_ONE),
             new ListOf<>(
@@ -307,7 +308,7 @@ public final class JoinedTest {
     }
 
     @Test
-    public void clear() {
+    void clear() {
         final List<String> joined = new Joined<String>(
             new ListOf<>(
                 JoinedTest.LITERAL_TWO,
@@ -326,7 +327,7 @@ public final class JoinedTest {
     }
 
     @Test
-    public void get() {
+    void get() {
         new Assertion<>(
             "Must get element",
             new Joined<String>(
@@ -343,7 +344,7 @@ public final class JoinedTest {
     }
 
     @Test
-    public void set() {
+    void set() {
         final List<String> joined = new Joined<String>(
             new ListOf<>(JoinedTest.LITERAL_ONE),
             new ListOf<>(JoinedTest.LITERAL_TWO)
@@ -357,7 +358,7 @@ public final class JoinedTest {
     }
 
     @Test
-    public void addByIndex() {
+    void addByIndex() {
         final List<String> joined = new Joined<String>(
             new ListOf<>(JoinedTest.LITERAL_ONE),
             new ListOf<>(JoinedTest.LITERAL_TWO)
@@ -371,7 +372,7 @@ public final class JoinedTest {
     }
 
     @Test
-    public void removeByIndex() {
+    void removeByIndex() {
         final List<String> joined = new Joined<String>(
             new ListOf<>(JoinedTest.LITERAL_ONE),
             new ListOf<>(JoinedTest.LITERAL_TWO)
@@ -385,7 +386,7 @@ public final class JoinedTest {
     }
 
     @Test
-    public void removeByElement() {
+    void removeByElement() {
         final List<String> joined = new Joined<String>(
             new ListOf<>(JoinedTest.LITERAL_ONE),
             new ListOf<>(JoinedTest.LITERAL_TWO)
@@ -398,13 +399,16 @@ public final class JoinedTest {
         ).affirm();
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
-    public void listIteratorSecond() {
-        new Joined<Integer>().listIterator(66);
+    @Test
+    void listIteratorSecond() {
+        Assertions.assertThrows(
+            IndexOutOfBoundsException.class,
+            () -> new Joined<Integer>().listIterator(66)
+        );
     }
 
     @Test
-    public void subList() {
+    void subList() {
         new Assertion<>(
             "Must be able to to get sub list",
             new Joined<String>(
@@ -421,7 +425,7 @@ public final class JoinedTest {
     }
 
     @Test
-    public void itemAndList() {
+    void itemAndList() {
         new Assertion<>(
             "Must be able to join element with a list",
             new Joined<>(
@@ -439,7 +443,7 @@ public final class JoinedTest {
     }
 
     @Test
-    public void infersCorrectly() {
+    void infersCorrectly() {
         new Assertion<>(
             "Must be able to infer type of elements",
             new Joined<>(

--- a/src/test/java/org/cactoos/list/ListIteratorEnvelopeTest.java
+++ b/src/test/java/org/cactoos/list/ListIteratorEnvelopeTest.java
@@ -34,6 +34,7 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocTypeCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class ListIteratorEnvelopeTest {
     @Test
     void mustReturnPreviousIndex() {

--- a/src/test/java/org/cactoos/list/ListIteratorNoNullsTest.java
+++ b/src/test/java/org/cactoos/list/ListIteratorNoNullsTest.java
@@ -38,6 +38,7 @@ import org.llorllale.cactoos.matchers.Throws;
  * @since 0.35
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class ListIteratorNoNullsTest {
 
     @Test

--- a/src/test/java/org/cactoos/list/ListOfTest.java
+++ b/src/test/java/org/cactoos/list/ListOfTest.java
@@ -29,7 +29,8 @@ import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.Mapped;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.HasSize;
 
 /**
@@ -38,15 +39,13 @@ import org.llorllale.cactoos.matchers.HasSize;
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-@SuppressWarnings(
-    {
-        "PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals"
-    }
-)
-public final class ListOfTest {
+@SuppressWarnings({"PMD.TooManyMethods",
+    "PMD.AvoidDuplicateLiterals",
+    "PMD.JUnitTestsShouldIncludeAssert"})
+final class ListOfTest {
 
     @Test
-    public void behavesAsCollection() throws Exception {
+    void behavesAsCollection() throws Exception {
         MatcherAssert.assertThat(
             "Can't behave as a list",
             new ListOf<>(1, 2),
@@ -55,7 +54,7 @@ public final class ListOfTest {
     }
 
     @Test
-    public void elementAtIndexTest() throws Exception {
+    void elementAtIndexTest() throws Exception {
         final int num = 345;
         MatcherAssert.assertThat(
             "Can't convert an iterable to a list",
@@ -65,7 +64,7 @@ public final class ListOfTest {
     }
 
     @Test
-    public void sizeTest() throws Exception {
+    void sizeTest() throws Exception {
         final int size = 42;
         MatcherAssert.assertThat(
             "Can't build a list with a certain size",
@@ -77,7 +76,7 @@ public final class ListOfTest {
     }
 
     @Test
-    public void emptyTest() throws Exception {
+    void emptyTest() throws Exception {
         MatcherAssert.assertThat(
             "Can't convert an empty iterable to an empty list",
             new ListOf<>(
@@ -87,18 +86,24 @@ public final class ListOfTest {
         );
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
-    public void lowBoundTest() throws Exception {
-        new ListOf<>(Collections.nCopies(10, 0)).get(-1);
-    }
-
-    @Test(expected = IndexOutOfBoundsException.class)
-    public void highBoundTest() throws Exception {
-        new ListOf<>(Collections.nCopies(10, 0)).get(11);
+    @Test
+    void lowBoundTest() {
+        Assertions.assertThrows(
+            IndexOutOfBoundsException.class,
+            () -> new ListOf<>(Collections.nCopies(10, 0)).get(-1)
+        );
     }
 
     @Test
-    public void makesListFromMappedIterable() throws Exception {
+    void highBoundTest() {
+        Assertions.assertThrows(
+            IndexOutOfBoundsException.class,
+            () -> new ListOf<>(Collections.nCopies(10, 0)).get(11)
+        );
+    }
+
+    @Test
+    void makesListFromMappedIterable() throws Exception {
         final List<Integer> list = new ListOf<>(
             new Mapped<>(
                 i -> i + 1,
@@ -118,7 +123,7 @@ public final class ListOfTest {
     }
 
     @Test
-    public void equalsComparesContentBothListEnvelopes() {
+    void equalsComparesContentBothListEnvelopes() {
         MatcherAssert.assertThat(
             "Can't compare using equals.",
             new ListOf<>(1, 2),
@@ -127,7 +132,7 @@ public final class ListOfTest {
     }
 
     @Test
-    public void equalsComparesContentListEnvelopeWithNormalList() {
+    void equalsComparesContentListEnvelopeWithNormalList() {
         MatcherAssert.assertThat(
             "Can't compare using equals.",
             new ListOf<>(1, 2),
@@ -136,7 +141,7 @@ public final class ListOfTest {
     }
 
     @Test
-    public void equalsComparesEmptyLists() {
+    void equalsComparesEmptyLists() {
         MatcherAssert.assertThat(
             "Can't compare using equals.",
             new ListOf<>(),
@@ -145,7 +150,7 @@ public final class ListOfTest {
     }
 
     @Test
-    public void toStringUsesListContent() {
+    void toStringUsesListContent() {
         MatcherAssert.assertThat(
             "Can't print content using toString.",
             new ListOf<>(1, 2).toString(),
@@ -154,7 +159,7 @@ public final class ListOfTest {
     }
 
     @Test
-    public void hashCodesListContent() {
+    void hashCodesListContent() {
         MatcherAssert.assertThat(
             "Can't create hashcode.",
             new ListOf<>(1, 2).hashCode(),

--- a/src/test/java/org/cactoos/list/ListOfTest.java
+++ b/src/test/java/org/cactoos/list/ListOfTest.java
@@ -29,9 +29,10 @@ import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.Mapped;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasSize;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link ListOf}.
@@ -88,18 +89,20 @@ final class ListOfTest {
 
     @Test
     void lowBoundTest() {
-        Assertions.assertThrows(
-            IndexOutOfBoundsException.class,
-            () -> new ListOf<>(Collections.nCopies(10, 0)).get(-1)
-        );
+        new Assertion<>(
+            "Exception is expected for negative index",
+            () -> new ListOf<>(Collections.nCopies(10, 0)).get(-1),
+            new Throws<>(IndexOutOfBoundsException.class)
+        ).affirm();
     }
 
     @Test
     void highBoundTest() {
-        Assertions.assertThrows(
-            IndexOutOfBoundsException.class,
-            () -> new ListOf<>(Collections.nCopies(10, 0)).get(11)
-        );
+        new Assertion<>(
+            "Exception is expected for index larger then size",
+            () -> new ListOf<>(Collections.nCopies(10, 0)).get(11),
+            new Throws<>(IndexOutOfBoundsException.class)
+        ).affirm();
     }
 
     @Test

--- a/src/test/java/org/cactoos/list/SyncedTest.java
+++ b/src/test/java/org/cactoos/list/SyncedTest.java
@@ -33,7 +33,8 @@ import org.llorllale.cactoos.matchers.RunsInThreads;
  * @since 0.24
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-@SuppressWarnings("PMD.TooManyMethods")
+@SuppressWarnings({"PMD.TooManyMethods",
+    "PMD.JUnitTestsShouldIncludeAssert"})
 final class SyncedTest {
 
     @Test

--- a/src/test/java/org/cactoos/map/GroupedTest.java
+++ b/src/test/java/org/cactoos/map/GroupedTest.java
@@ -37,6 +37,7 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @since 0.30
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class GroupedTest {
 
     @Test

--- a/src/test/java/org/cactoos/map/MapEntryTest.java
+++ b/src/test/java/org/cactoos/map/MapEntryTest.java
@@ -25,8 +25,9 @@ package org.cactoos.map;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link MapEntry}.
@@ -61,10 +62,11 @@ final class MapEntryTest {
 
     @Test
     void cantSetValue() {
-        Assertions.assertThrows(
-            UnsupportedOperationException.class,
-            () -> new MapEntry<>("one", "two").setValue("three")
-        );
+        new Assertion<>(
+            "Exception is expected on change operations",
+            () -> new MapEntry<>("one", "two").setValue("three"),
+            new Throws<>(UnsupportedOperationException.class)
+        ).affirm();
     }
 
     @Test

--- a/src/test/java/org/cactoos/map/MapEntryTest.java
+++ b/src/test/java/org/cactoos/map/MapEntryTest.java
@@ -25,7 +25,8 @@ package org.cactoos.map;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link MapEntry}.
@@ -33,10 +34,11 @@ import org.junit.Test;
  * @since 0.9
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class MapEntryTest {
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class MapEntryTest {
 
     @Test
-    public void getKey() {
+    void getKey() {
         final String key = "hello";
         final String value = "world";
         MatcherAssert.assertThat(
@@ -47,7 +49,7 @@ public final class MapEntryTest {
     }
 
     @Test
-    public void getValue() {
+    void getValue() {
         final String key = "foo";
         final String value = "bar";
         MatcherAssert.assertThat(
@@ -57,13 +59,16 @@ public final class MapEntryTest {
         );
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void cantSetValue() {
-        new MapEntry<>("one", "two").setValue("three");
+    @Test
+    void cantSetValue() {
+        Assertions.assertThrows(
+            UnsupportedOperationException.class,
+            () -> new MapEntry<>("one", "two").setValue("three")
+        );
     }
 
     @Test
-    public void equalsTo() {
+    void equalsTo() {
         final String key = "eo";
         final String value = "book";
         MatcherAssert.assertThat(
@@ -74,7 +79,7 @@ public final class MapEntryTest {
     }
 
     @Test
-    public void compareHash() {
+    void compareHash() {
         MatcherAssert.assertThat(
             "the hash code are not equals",
             new MapEntry<>("elegant", "objects").hashCode(),
@@ -83,7 +88,7 @@ public final class MapEntryTest {
     }
 
     @Test
-    public void toStringMethod() {
+    void toStringMethod() {
         MatcherAssert.assertThat(
             "ToString method returns unexpected value",
             new MapEntry<>("somekey", "somevalue").toString(),

--- a/src/test/java/org/cactoos/map/MapEnvelopeTest.java
+++ b/src/test/java/org/cactoos/map/MapEnvelopeTest.java
@@ -29,7 +29,7 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.collection.IsMapWithSize;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNot;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 
 /**
@@ -39,11 +39,12 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle DiamondOperatorCheck (500 lines)
  */
-@SuppressWarnings("PMD.TooManyMethods")
-public final class MapEnvelopeTest {
+@SuppressWarnings({"PMD.TooManyMethods",
+    "PMD.JUnitTestsShouldIncludeAssert"})
+final class MapEnvelopeTest {
 
     @Test
-    public void mapIsEmptyTrue() {
+    void mapIsEmptyTrue() {
         MatcherAssert.assertThat(
             "#isEmpty() returns false for empty map",
             new NoNulls<>(
@@ -54,7 +55,7 @@ public final class MapEnvelopeTest {
     }
 
     @Test
-    public void mapIsEmptyFalse() {
+    void mapIsEmptyFalse() {
         MatcherAssert.assertThat(
             "#isEmpty() returns true for not empty map",
             new NoNulls<>(
@@ -67,7 +68,7 @@ public final class MapEnvelopeTest {
     }
 
     @Test
-    public void mapContainsKeyTrue() {
+    void mapContainsKeyTrue() {
         MatcherAssert.assertThat(
             "contains key returns false with exist key",
             new NoNulls<>(
@@ -80,7 +81,7 @@ public final class MapEnvelopeTest {
     }
 
     @Test
-    public void mapContainsKeyFalse() {
+    void mapContainsKeyFalse() {
         MatcherAssert.assertThat(
             "contains key returns true with absent key",
             new NoNulls<>(
@@ -93,7 +94,7 @@ public final class MapEnvelopeTest {
     }
 
     @Test
-    public void mapContainsValueTrue() {
+    void mapContainsValueTrue() {
         MatcherAssert.assertThat(
             "contains value returns false with exist value",
             new NoNulls<>(
@@ -106,7 +107,7 @@ public final class MapEnvelopeTest {
     }
 
     @Test
-    public void mapContainsValueFalse() {
+    void mapContainsValueFalse() {
         MatcherAssert.assertThat(
             "contains value returns true with absent value",
             new NoNulls<>(
@@ -119,7 +120,7 @@ public final class MapEnvelopeTest {
     }
 
     @Test
-    public void mapEqualsToItself() {
+    void mapEqualsToItself() {
         final MapOf<String, String> map =
             new MapOf<String, String>(new MapEntry<>("key", "value"));
         MatcherAssert.assertThat(
@@ -130,7 +131,7 @@ public final class MapEnvelopeTest {
     }
 
     @Test
-    public void mapNotEqualsToAnotherClass() {
+    void mapNotEqualsToAnotherClass() {
         final MapOf<String, String> map =
             new MapOf<String, String>(new MapEntry<>("key1", "value1"));
         MatcherAssert.assertThat(
@@ -143,7 +144,7 @@ public final class MapEnvelopeTest {
     }
 
     @Test
-    public void mapEqualsToMapWithSameEntries() {
+    void mapEqualsToMapWithSameEntries() {
         final String key = "key2";
         final String value = "value2";
         final MapEntry<String, String> input = new MapEntry<>(key, value);
@@ -156,7 +157,7 @@ public final class MapEnvelopeTest {
     }
 
     @Test
-    public void equalsDoesNotFailOnNulls() {
+    void equalsDoesNotFailOnNulls() {
         final MapEntry<String, String> first =
             new MapEntry<>("key3", "value3");
         final MapEntry<String, String> second =
@@ -169,7 +170,7 @@ public final class MapEnvelopeTest {
     }
 
     @Test
-    public void mapNotEqualsToOtherWithDifferentKeys() {
+    void mapNotEqualsToOtherWithDifferentKeys() {
         final String value = "value5";
         MatcherAssert.assertThat(
             "Map equals to another map with different keys",
@@ -185,7 +186,7 @@ public final class MapEnvelopeTest {
     }
 
     @Test
-    public void mapNotEqualsToOtherWithDifferentValues() {
+    void mapNotEqualsToOtherWithDifferentValues() {
         final String key = "key7";
         MatcherAssert.assertThat(
             "Map equals to another map with different values",
@@ -201,7 +202,7 @@ public final class MapEnvelopeTest {
     }
 
     @Test
-    public void hashCodeDependsOnItems() {
+    void hashCodeDependsOnItems() {
         final String key = "key9";
         final String value = "value9";
         final MapEntry<String, String> input = new MapEntry<>(key, value);
@@ -214,7 +215,7 @@ public final class MapEnvelopeTest {
     }
 
     @Test
-    public void hashCodeDoesNotFailOnNulls() {
+    void hashCodeDoesNotFailOnNulls() {
         final MapEntry<String, String> first =
             new MapEntry<>("key10", "value10");
         final MapEntry<String, String> second =
@@ -224,7 +225,7 @@ public final class MapEnvelopeTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void emptyMapEnvelopeShouldBeEqualToEmptyDerivedMap() {
+    void emptyMapEnvelopeShouldBeEqualToEmptyDerivedMap() {
         final MapEnvelope<Integer, String> base = new MapOf<>();
         final DerivedMapEnvelope<Integer, String> derived =
             new DerivedMapEnvelope<>(new HashMap<>());
@@ -237,7 +238,7 @@ public final class MapEnvelopeTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void mapEnvelopeShouldCompareDerivedClasses() {
+    void mapEnvelopeShouldCompareDerivedClasses() {
         final int key = 1;
         final String value = "one";
         final MapEntry<Integer, String> entry = new MapEntry<>(key, value);
@@ -254,7 +255,7 @@ public final class MapEnvelopeTest {
     }
 
     @Test
-    public void putIsDelegated() {
+    void putIsDelegated() {
         final Map<Integer, Integer> map = new DerivedMapEnvelope<>(
             new HashMap<>()
         );
@@ -271,7 +272,7 @@ public final class MapEnvelopeTest {
     }
 
     @Test
-    public void clearIsDelegated() {
+    void clearIsDelegated() {
         final Map<Integer, Integer> map = new DerivedMapEnvelope<>(
             new MapOf<Integer, Integer>(
                 new MapEntry<>(0, 1)
@@ -286,7 +287,7 @@ public final class MapEnvelopeTest {
     }
 
     @Test
-    public void removeIsDelegated() {
+    void removeIsDelegated() {
         final Map<Integer, Integer> map = new DerivedMapEnvelope<>(
             new MapOf<Integer, Integer>(
                 new MapEntry<>(0, 1)

--- a/src/test/java/org/cactoos/map/MapOfTest.java
+++ b/src/test/java/org/cactoos/map/MapOfTest.java
@@ -44,7 +44,8 @@ import org.llorllale.cactoos.matchers.HasEntry;
  * @since 0.4
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-@SuppressWarnings("PMD.TooManyMethods")
+@SuppressWarnings({"PMD.TooManyMethods",
+    "PMD.JUnitTestsShouldIncludeAssert"})
 final class MapOfTest {
 
     @Test

--- a/src/test/java/org/cactoos/map/MergedTest.java
+++ b/src/test/java/org/cactoos/map/MergedTest.java
@@ -26,9 +26,9 @@ package org.cactoos.map;
 import org.cactoos.iterable.IterableOf;
 import org.hamcrest.core.AllOf;
 import org.hamcrest.core.IsEqual;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link Merged}.
@@ -118,13 +118,14 @@ final class MergedTest {
 
     @Test
     void throwsNullPointerForNullMap() {
-        Assertions.assertThrows(
-            NullPointerException.class,
+        new Assertion<>(
+            "Exception is expected for merge with null",
             () -> new Merged<Integer, Integer>(
                 new MapOf<Integer, Integer>(),
                 null
-            ).size()
-        );
+            ).size(),
+            new Throws<>(NullPointerException.class)
+        ).affirm();
     }
 
     @Test

--- a/src/test/java/org/cactoos/map/MergedTest.java
+++ b/src/test/java/org/cactoos/map/MergedTest.java
@@ -26,7 +26,8 @@ package org.cactoos.map;
 import org.cactoos.iterable.IterableOf;
 import org.hamcrest.core.AllOf;
 import org.hamcrest.core.IsEqual;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 
 /**
@@ -35,11 +36,12 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @since 1.0
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class MergedTest {
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class MergedTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void behavesAsMap() {
+    void behavesAsMap() {
         new Assertion<>(
             "Must behave as a map",
             new Merged<>(
@@ -60,7 +62,7 @@ public final class MergedTest {
     }
 
     @Test
-    public void createsMapFromMaps() {
+    void createsMapFromMaps() {
         new Assertion<>(
             "Must merge a few maps",
             new Merged<Integer, Integer>(
@@ -81,7 +83,7 @@ public final class MergedTest {
     }
 
     @Test
-    public void overridesValues() {
+    void overridesValues() {
         new Assertion<>(
             "Must override values",
             new Merged<Integer, Integer>(
@@ -101,7 +103,7 @@ public final class MergedTest {
     }
 
     @Test
-    public void mergesEmptyMaps() {
+    void mergesEmptyMaps() {
         new Assertion<>(
             "Must merge empty maps",
             new Merged<Integer, Integer>(
@@ -114,16 +116,19 @@ public final class MergedTest {
         ).affirm();
     }
 
-    @Test(expected = NullPointerException.class)
-    public void throwsNullPointerForNullMap() {
-        new Merged<Integer, Integer>(
-            new MapOf<Integer, Integer>(),
-            null
-        ).size();
+    @Test
+    void throwsNullPointerForNullMap() {
+        Assertions.assertThrows(
+            NullPointerException.class,
+            () -> new Merged<Integer, Integer>(
+                new MapOf<Integer, Integer>(),
+                null
+            ).size()
+        );
     }
 
     @Test
-    public void behavesAsMapWithWildCards() {
+    void behavesAsMapWithWildCards() {
         new Assertion<>(
             "Must behave as a map with common type",
             new Merged<Number, Number>(

--- a/src/test/java/org/cactoos/map/NoNullsTest.java
+++ b/src/test/java/org/cactoos/map/NoNullsTest.java
@@ -30,8 +30,8 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.AllOf;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsIterableContaining;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.IsEntry;
 import org.llorllale.cactoos.matchers.Throws;
@@ -42,17 +42,14 @@ import org.llorllale.cactoos.matchers.Throws;
  * @since 0.30
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-@SuppressWarnings(
-    {
-        "PMD.TooManyMethods",
-        "PMD.NonStaticInitializer",
-        "serial"
-    }
-)
-public final class NoNullsTest {
+@SuppressWarnings({"PMD.TooManyMethods",
+    "PMD.NonStaticInitializer",
+    "serial",
+    "PMD.JUnitTestsShouldIncludeAssert"})
+final class NoNullsTest {
 
     @Test
-    public void getSize() {
+    void getSize() {
         MatcherAssert.assertThat(
             "Can't calculate size",
             new NoNulls<>(
@@ -66,7 +63,7 @@ public final class NoNullsTest {
     }
 
     @Test
-    public void isEmptyTrue() {
+    void isEmptyTrue() {
         MatcherAssert.assertThat(
             "Can't get is empty true",
             new NoNulls<>(
@@ -77,7 +74,7 @@ public final class NoNullsTest {
     }
 
     @Test
-    public void isEmptyFalse() {
+    void isEmptyFalse() {
         MatcherAssert.assertThat(
             "Can't get is empty false",
             new NoNulls<>(
@@ -90,7 +87,7 @@ public final class NoNullsTest {
     }
 
     @Test
-    public void containsKeyTrue() {
+    void containsKeyTrue() {
         MatcherAssert.assertThat(
             "Can't get #containsKey() true",
             new NoNulls<>(
@@ -103,7 +100,7 @@ public final class NoNullsTest {
     }
 
     @Test
-    public void containsKeyFalse() {
+    void containsKeyFalse() {
         MatcherAssert.assertThat(
             "Can't get #containsKey() false",
             new NoNulls<>(
@@ -115,21 +112,21 @@ public final class NoNullsTest {
         );
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void containsKeyException() {
-        MatcherAssert.assertThat(
+    @Test
+    void containsKeyException() {
+        new Assertion<>(
             "Could no throw an IllegalStateException for null key",
-            new NoNulls<>(
+            () -> new NoNulls<>(
                 new MapOf<Integer, Integer>(
                     new MapEntry<>(0, -1)
                 )
             ).containsKey(null),
-            new IsEqual<>(true)
-        );
+            new Throws<>(IllegalStateException.class)
+        ).affirm();
     }
 
     @Test
-    public void containsValueFalse() {
+    void containsValueFalse() {
         MatcherAssert.assertThat(
             "Can't get #containsValue() false",
             new NoNulls<>(
@@ -142,7 +139,7 @@ public final class NoNullsTest {
     }
 
     @Test
-    public void containsValueTrue() {
+    void containsValueTrue() {
         MatcherAssert.assertThat(
             "Can't get #containsValue() true",
             new NoNulls<>(
@@ -154,21 +151,21 @@ public final class NoNullsTest {
         );
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void containsValueException() {
-        MatcherAssert.assertThat(
+    @Test
+    void containsValueException() {
+        new Assertion<>(
             "Can't get #containsValue() exception",
-            new NoNulls<>(
+            () -> new NoNulls<>(
                 new MapOf<Integer, Integer>(
                     new MapEntry<>(0, -1)
                 )
             ).containsValue(null),
-            new IsEqual<>(true)
-        );
+            new Throws<>(IllegalStateException.class)
+        ).affirm();
     }
 
     @Test
-    public void getValue() {
+    void getValue() {
         MatcherAssert.assertThat(
             "Can't call #get()",
             new NoNulls<>(
@@ -180,34 +177,34 @@ public final class NoNullsTest {
         );
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void getValueByNullKey() {
-        MatcherAssert.assertThat(
+    @Test
+    void getValueByNullKey() {
+        new Assertion<>(
             "Can't call #get() with key null",
-            new NoNulls<>(
+            () -> new NoNulls<>(
                 new MapOf<Integer, Integer>(
                     new MapEntry<>(0, -1)
                 )
             ).get(null),
-            new IsEqual<>(-1)
-        );
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void getValueByNullValue() {
-        MatcherAssert.assertThat(
-            "Can't call #get() with null value",
-            new NoNulls<>(
-                new MapOf<Integer, Integer>(
-                    new MapEntry<>(0, null)
-                )
-            ).get(0),
-            new IsEqual<>(-1)
+            new Throws<>(IllegalStateException.class)
         );
     }
 
     @Test
-    public void put() {
+    void getValueByNullValue() {
+        new Assertion<>(
+            "Can't call #get() with null value",
+            () -> new NoNulls<>(
+                new MapOf<Integer, Integer>(
+                    new MapEntry<>(0, null)
+                )
+            ).get(0),
+            new Throws<>(IllegalStateException.class)
+        );
+    }
+
+    @Test
+    void put() {
         MatcherAssert.assertThat(
             "Can't call #put()",
             new NoNulls<Integer, Integer>(
@@ -221,39 +218,39 @@ public final class NoNullsTest {
         );
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void putWithNullKey() {
-        MatcherAssert.assertThat(
+    @Test
+    void putWithNullKey() {
+        new Assertion<>(
             "Can't call #put() with Null key",
-            new NoNulls<Integer, Integer>(
+            () -> new NoNulls<Integer, Integer>(
                 new HashMap<Integer, Integer>() {
                     {
                         put(0, 0);
                     }
                 }
             ),
-            new PutUpdatesValues<Integer, Integer>(null, 1)
-        );
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void putWithNullValue() {
-        MatcherAssert.assertThat(
-            "Can't call #put() with Null value",
-            new NoNulls<Integer, Integer>(
-                new HashMap<Integer, Integer>() {
-                    {
-                        put(0, 0);
-                    }
-                }
-            ),
-            new PutUpdatesValues<Integer, Integer>(0, null)
+            new Throws<>(IllegalStateException.class)
         );
     }
 
     @Test
-    @Ignore
-    public void putWithNoMapping() {
+    void putWithNullValue() {
+        new Assertion<>(
+            "Can't call #put() with Null value",
+            () -> new NoNulls<Integer, Integer>(
+                new HashMap<Integer, Integer>() {
+                    {
+                        put(0, 0);
+                    }
+                }
+            ),
+            new Throws<>(IllegalStateException.class)
+        );
+    }
+
+    @Test
+    @Disabled
+    void putWithNoMapping() {
         MatcherAssert.assertThat(
             "Can't call #put() with no mapping",
             new NoNulls<Integer, Integer>(
@@ -268,7 +265,7 @@ public final class NoNullsTest {
     }
 
     @Test
-    public void remove() {
+    void remove() {
         MatcherAssert.assertThat(
             "Can't call #remove()",
             new NoNulls<Integer, Integer>(
@@ -282,24 +279,24 @@ public final class NoNullsTest {
         );
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void removeWithNullKey() {
-        MatcherAssert.assertThat(
+    @Test
+    void removeWithNullKey() {
+        new Assertion<>(
             "Can't call #remove() with Null key",
-            new NoNulls<Integer, Integer>(
+            () -> new NoNulls<Integer, Integer>(
                 new HashMap<Integer, Integer>() {
                     {
                         put(0, 0);
                     }
                 }
             ),
-            new RemoveDeletesValues<Integer, Integer>(null, 0)
+            new Throws<>(IllegalStateException.class)
         );
     }
 
     @Test
-    @Ignore
-    public void removeWithNoMapping() {
+    @Disabled
+    void removeWithNoMapping() {
         MatcherAssert.assertThat(
             "Can't call #remove() with no mapping",
             new NoNulls<Integer, Integer>(
@@ -314,7 +311,7 @@ public final class NoNullsTest {
     }
 
     @Test
-    public void putAll() {
+    void putAll() {
         MatcherAssert.assertThat(
             "Can't call #putAll()",
             new NoNulls<Integer, Integer>(
@@ -329,7 +326,7 @@ public final class NoNullsTest {
     }
 
     @Test
-    public void clear() {
+    void clear() {
         MatcherAssert.assertThat(
             "Can't call #clear()",
             new NoNulls<Integer, Integer>(
@@ -347,7 +344,7 @@ public final class NoNullsTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void entrySet() {
+    void entrySet() {
         new Assertion<Set<Map.Entry<Integer, Integer>>>(
             "Must call #entrySet()",
             new NoNulls<Integer, Integer>(
@@ -366,7 +363,7 @@ public final class NoNullsTest {
     }
 
     @Test
-    public void putThrowsErrorIfValueNull() {
+    void putThrowsErrorIfValueNull() {
         new Assertion<>(
             "Should throws an error if value is null",
             () -> new NoNulls<Integer, Integer>(
@@ -380,7 +377,7 @@ public final class NoNullsTest {
     }
 
     @Test
-    public void putThrowsErrorIfPreviousValueNull() {
+    void putThrowsErrorIfPreviousValueNull() {
         new Assertion<>(
             "Should throws an error if previous value is null",
             () -> new NoNulls<>(

--- a/src/test/java/org/cactoos/map/SyncedTest.java
+++ b/src/test/java/org/cactoos/map/SyncedTest.java
@@ -33,6 +33,7 @@ import org.llorllale.cactoos.matchers.RunsInThreads;
  * @since 0.24
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class SyncedTest {
 
     @Test

--- a/src/test/java/org/cactoos/number/AvgOfTest.java
+++ b/src/test/java/org/cactoos/number/AvgOfTest.java
@@ -26,9 +26,10 @@ package org.cactoos.number;
 import java.util.Collections;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.AllOf;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.IsNumber;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link AvgOf}.
@@ -37,10 +38,10 @@ import org.llorllale.cactoos.matchers.IsNumber;
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 @SuppressWarnings("PMD.TooManyMethods")
-public final class AvgOfTest {
+final class AvgOfTest {
 
     @Test
-    public void withEmptyCollection() {
+    void withEmptyCollection() {
         new Assertion<>(
             "Average of elements in empty collection must be zero",
             new AvgOf(Collections.emptyList()).longValue(),
@@ -49,7 +50,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withIntCollectionIntValue() {
+    void withIntCollectionIntValue() {
         new Assertion<>(
             "Average of values in int collection must be int value",
             new AvgOf(
@@ -60,7 +61,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withIntCollectionIntValueMaxValues() {
+    void withIntCollectionIntValueMaxValues() {
         new Assertion<>(
             "Average of values in MAX int collection must be MAX int value",
             new AvgOf(
@@ -71,7 +72,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withIntCollectionLongValue() {
+    void withIntCollectionLongValue() {
         new Assertion<>(
             "Average of values in int collection must be long value",
             new AvgOf(
@@ -82,7 +83,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withIntCollectionDoubleValue() {
+    void withIntCollectionDoubleValue() {
         new Assertion<>(
             "Average of values in int collection must be double value",
             new AvgOf(
@@ -93,7 +94,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withIntCollectionFloatValue() {
+    void withIntCollectionFloatValue() {
         new Assertion<>(
             "Average of values in int collection must be float value",
             new AvgOf(
@@ -104,7 +105,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withLongCollectionIntValue() {
+    void withLongCollectionIntValue() {
         new Assertion<>(
             "Average of values in long collection must be int value",
             new AvgOf(
@@ -115,7 +116,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withLongCollectionLongValue() {
+    void withLongCollectionLongValue() {
         new Assertion<>(
             "Average of values in long collection must be long value",
             new AvgOf(
@@ -126,7 +127,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withLongCollectionMaxValue() {
+    void withLongCollectionMaxValue() {
         new Assertion<>(
             "Average of values in MAX long collection must be MAX long value",
             new AvgOf(
@@ -137,7 +138,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withLongCollectionDoubleValue() {
+    void withLongCollectionDoubleValue() {
         new Assertion<>(
             "Average of values in long collection must be double value",
             new AvgOf(
@@ -148,7 +149,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withLongCollectionFloatValue() {
+    void withLongCollectionFloatValue() {
         new Assertion<>(
             "Average of values in long collection must be float value",
             new AvgOf(
@@ -159,7 +160,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withDoubleCollectionIntValue() {
+    void withDoubleCollectionIntValue() {
         new Assertion<>(
             "Average of values in double collection must be int value",
             new AvgOf(
@@ -170,7 +171,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withDoubleCollectionLongValue() {
+    void withDoubleCollectionLongValue() {
         new Assertion<>(
             "Average of values in double collection must be long value",
             new AvgOf(
@@ -181,7 +182,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withDoubleCollectionDoubleValue() {
+    void withDoubleCollectionDoubleValue() {
         new Assertion<>(
             "Average of values in double collection must be double value",
             new AvgOf(
@@ -192,7 +193,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withDoubleCollectionMaxValue() {
+    void withDoubleCollectionMaxValue() {
         new Assertion<>(
             "Average of values in MAX double collection must be MAX double value",
             new AvgOf(
@@ -203,7 +204,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withDoubleCollectionMinValue() {
+    void withDoubleCollectionMinValue() {
         new Assertion<>(
             "Average of values in MIN double collection must be MIN double value",
             new AvgOf(
@@ -213,29 +214,41 @@ public final class AvgOfTest {
         ).affirm();
     }
 
-    @Test(expected = NumberFormatException.class)
-    public void withDoubleCollectionPositiveInfinity() {
-        new AvgOf(
-            Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY
-        ).doubleValue();
-    }
-
-    @Test(expected = NumberFormatException.class)
-    public void withDoubleCollectionNegativeInfinity() {
-        new AvgOf(
-            Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY
-        ).doubleValue();
-    }
-
-    @Test(expected = NumberFormatException.class)
-    public void withDoubleCollectionNaN() {
-        new AvgOf(
-            Double.NaN, Double.NaN
-        ).doubleValue();
+    @Test
+    void withDoubleCollectionPositiveInfinity() {
+        new Assertion<>(
+            "Cann't calculate avg from infinity",
+            () -> new AvgOf(
+                Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY
+            ).doubleValue(),
+            new Throws<>(NumberFormatException.class)
+        ).affirm();
     }
 
     @Test
-    public void withDoubleCollectionNegativeNumbersDoubleValue() {
+    void withDoubleCollectionNegativeInfinity() {
+        new Assertion<>(
+            "Cann't calculate avg from infinity",
+            () -> new AvgOf(
+                Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY
+            ).doubleValue(),
+            new Throws<>(NumberFormatException.class)
+        ).affirm();
+    }
+
+    @Test
+    void withDoubleCollectionNaN() {
+        new Assertion<>(
+            "Cann't calculate avg from NaN",
+            () -> new AvgOf(
+                Double.NaN, Double.NaN
+            ).doubleValue(),
+        new Throws<>(NumberFormatException.class)
+        ).affirm();
+    }
+
+    @Test
+    void withDoubleCollectionNegativeNumbersDoubleValue() {
         new Assertion<>(
             "Average of values in negative double collection must be negative double value",
             new AvgOf(
@@ -246,7 +259,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withDecimalCollectionPrecisionProblem() {
+    void withDecimalCollectionPrecisionProblem() {
         new Assertion<>(
             "Average of decimal values must have precision problem",
             new AvgOf(
@@ -257,7 +270,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withDecimalCollectionPrecisionProblemExtraDecimalRange() {
+    void withDecimalCollectionPrecisionProblemExtraDecimalRange() {
         new Assertion<>(
             "Average of decimal values with extra decimal range must have precision problem",
             new AvgOf(
@@ -268,7 +281,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withFloatCollectionIntValue() {
+    void withFloatCollectionIntValue() {
         new Assertion<>(
             "Average of float values in float collection must be int value",
             new AvgOf(
@@ -279,7 +292,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withFloatCollectionLongValue() {
+    void withFloatCollectionLongValue() {
         new Assertion<>(
             "Average of values in float collection must be long value",
             new AvgOf(
@@ -290,7 +303,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withFloatCollectionDoubleValue() {
+    void withFloatCollectionDoubleValue() {
         new Assertion<>(
             "Average of values in float collection must be double value",
             new AvgOf(
@@ -301,7 +314,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withFloatCollectionFloatValue() {
+    void withFloatCollectionFloatValue() {
         new Assertion<>(
             "Average of values in float collection must be float value",
             new AvgOf(
@@ -312,7 +325,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withFloatCollectionMaxValue() {
+    void withFloatCollectionMaxValue() {
         new Assertion<>(
             "Average of values in MAX float collection must be MAX float value",
             new AvgOf(
@@ -323,7 +336,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void withFloatCollectionMinValue() {
+    void withFloatCollectionMinValue() {
         new Assertion<>(
             "Average of values in MIN float collection must be MIN float value",
             new AvgOf(
@@ -334,7 +347,7 @@ public final class AvgOfTest {
     }
 
     @Test
-    public void canBeCalledTwice() {
+    void canBeCalledTwice() {
         new Assertion<Number>(
             "Average of values can be called twice",
             new AvgOf(

--- a/src/test/java/org/cactoos/number/MultiplicationOfTest.java
+++ b/src/test/java/org/cactoos/number/MultiplicationOfTest.java
@@ -26,7 +26,7 @@ package org.cactoos.number;
 import java.util.NoSuchElementException;
 import org.cactoos.iterable.IterableOf;
 import org.hamcrest.core.IsEqual;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.Throws;
 
@@ -36,13 +36,13 @@ import org.llorllale.cactoos.matchers.Throws;
  * @since 0.49.2
  */
 @SuppressWarnings("PMD.TooManyMethods")
-public final class MultiplicationOfTest {
+final class MultiplicationOfTest {
 
     /**
      * Ensures that multiplication of int numbers return proper value.
      */
     @Test
-    public void withListOfNumbersInt() {
+    void withListOfNumbersInt() {
         new Assertion<>(
             "Multiplication of int must return the appropriate value",
             new MultiplicationOf(2, 3).intValue(),
@@ -54,7 +54,7 @@ public final class MultiplicationOfTest {
      * Ensures that multiplication of double numbers return proper value.
      */
     @Test
-    public void withListOfNumbersDouble() {
+    void withListOfNumbersDouble() {
         new Assertion<>(
             "Multiplication of double numbers must return proper value",
             new MultiplicationOf(2.0d, 2.5d, 3.0d).doubleValue(),
@@ -66,7 +66,7 @@ public final class MultiplicationOfTest {
      * Ensures that multiplication of float numbers return proper value.
      */
     @Test
-    public void withListOfNumbersFloat() {
+    void withListOfNumbersFloat() {
         new Assertion<>(
             "Multiplication of float numbers must return proper value",
             new MultiplicationOf(3.0f, 3.0f, 3.0f).floatValue(),
@@ -78,7 +78,7 @@ public final class MultiplicationOfTest {
      * Ensures that multiplication of long numbers return proper value.
      */
     @Test
-    public void withListOfNumbersLong() {
+    void withListOfNumbersLong() {
         new Assertion<>(
             "Multiplication of long numbers must return proper value",
             new MultiplicationOf(2L, 3L, 2L).longValue(),
@@ -90,7 +90,7 @@ public final class MultiplicationOfTest {
      * Ensures that multiplication of int numbers iterable return proper value.
      */
     @Test
-    public void withIterableInt() {
+    void withIterableInt() {
         new Assertion<>(
             "Multiplication of int numbers must return proper value",
             new MultiplicationOf(
@@ -104,7 +104,7 @@ public final class MultiplicationOfTest {
      * Ensures that multiplication of long numbers iterable return proper value.
      */
     @Test
-    public void withIterableLong() {
+    void withIterableLong() {
         new Assertion<>(
             "Multiplication of long numbers iterable must return proper value",
             new MultiplicationOf(
@@ -119,7 +119,7 @@ public final class MultiplicationOfTest {
      * return proper value.
      */
     @Test
-    public void withIterableFloat() {
+    void withIterableFloat() {
         new Assertion<>(
             "Multiplication floating numbers must be iterable",
             new MultiplicationOf(
@@ -134,7 +134,7 @@ public final class MultiplicationOfTest {
      * return proper value.
      */
     @Test
-    public void withIterableDouble() {
+    void withIterableDouble() {
         new Assertion<>(
             "Multiplication double numbers must be iterable",
             new MultiplicationOf(
@@ -148,7 +148,7 @@ public final class MultiplicationOfTest {
      * Ensures that empty iterable will not be multiplied.
      */
     @Test
-    public void rejectsEmptyIterable() {
+    void rejectsEmptyIterable() {
         new Assertion<>(
             "Must fail with empty iterable",
             () -> new MultiplicationOf(new IterableOf<>()).doubleValue(),

--- a/src/test/java/org/cactoos/proc/BiProcNoNullsTest.java
+++ b/src/test/java/org/cactoos/proc/BiProcNoNullsTest.java
@@ -25,42 +25,64 @@ package org.cactoos.proc;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import org.hamcrest.core.IsEqual;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link BiProcNoNulls}.
  * @since 0.11
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class BiProcNoNullsTest {
+final class BiProcNoNullsTest {
 
-    @Test(expected = IllegalArgumentException.class)
-    public void failForNullProc() throws Exception {
-        new BiProcNoNulls<>(null).exec(new Object(), new Object());
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void failForNullFirstArg() throws Exception {
-        new BiProcNoNulls<>(
-            (first, second) -> { }
-        ).exec(null, new Object());
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void failForNullSecondArg() throws Exception {
-        new BiProcNoNulls<>(
-            (first, second) -> { }
-        ).exec(new Object(), null);
+    @Test
+    void failForNullProc() {
+        new Assertion<>(
+            "Fails in case of null proc",
+            () -> {
+                new BiProcNoNulls<>(null).exec(
+                    new Object(), new Object()
+                );
+                return 1;
+            },
+            new Throws<>(IllegalArgumentException.class)
+        ).affirm();
     }
 
     @Test
-    public void okForNoNulls() throws Exception {
+    void failForNullFirstArg() {
+        new Assertion<>(
+            "Fails in case of null first arg",
+            () -> {
+                new BiProcNoNulls<>(
+                    (first, second) -> { }
+                ).exec(null, new Object());
+                return 1;
+            },
+            new Throws<>(IllegalArgumentException.class)
+        ).affirm();
+    }
+
+    @Test
+    void failForNullSecondArg() {
+        new Assertion<>(
+            "Fails in case of null second arg",
+            () -> {
+                new BiProcNoNulls<>(
+                    (first, second) -> { }
+                ).exec(new Object(), null);
+                return 1;
+            },
+            new Throws<>(IllegalArgumentException.class)
+        );
+    }
+
+    @Test
+    void okForNoNulls() throws Exception {
         final AtomicInteger counter = new AtomicInteger();
         new BiProcNoNulls<>(
-            (AtomicInteger ctr, Object second) -> {
-                ctr.incrementAndGet();
-            }
+            (AtomicInteger ctr, Object second) -> ctr.incrementAndGet()
         ).exec(counter, new Object());
         new Assertion<>(
             "Can't invoke the \"BiProc.exec\" method",

--- a/src/test/java/org/cactoos/proc/CheckedBiProcTest.java
+++ b/src/test/java/org/cactoos/proc/CheckedBiProcTest.java
@@ -28,8 +28,9 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link CheckedBiProc}.
@@ -37,30 +38,45 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @since 0.32
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class CheckedBiProcTest {
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class CheckedBiProcTest {
 
-    @Test(expected = IllegalStateException.class)
-    public void runtimeExceptionIsNotWrapped() throws Exception {
-        new CheckedBiProc<>(
-            (first, second) -> {
-                throw new IllegalStateException("runtime1");
+    @Test
+    void runtimeExceptionIsNotWrapped() {
+        new Assertion<>(
+            "Runtime exception is wraped",
+            () -> {
+                new CheckedBiProc<>(
+                    (first, second) -> {
+                        throw new IllegalStateException("runtime1");
+                    },
+                    IOException::new
+                ).exec(true, true);
+                return 1;
             },
-            IOException::new
-        ).exec(true, true);
-    }
-
-    @Test(expected = IOException.class)
-    public void checkedExceptionIsWrapped() throws Exception {
-        new CheckedBiProc<>(
-            (first, second) -> {
-                throw new EOFException("runtime2");
-            },
-            IOException::new
-        ).exec(true, true);
+            new Throws<>(IllegalStateException.class)
+        ).affirm();
     }
 
     @Test
-    public void extraWrappingIgnored() {
+    void checkedExceptionIsWrapped() {
+        new Assertion<>(
+            "",
+            () -> {
+                new CheckedBiProc<>(
+                    (first, second) -> {
+                        throw new EOFException("runtime2");
+                    },
+                    IOException::new
+                ).exec(true, true);
+                return 1;
+            },
+            new Throws<>(IOException.class)
+        );
+    }
+
+    @Test
+    void extraWrappingIgnored() {
         try {
             new CheckedBiProc<>(
                 (first, second) -> {
@@ -78,7 +94,7 @@ public final class CheckedBiProcTest {
     }
 
     @Test
-    public void noExceptionThrown() throws Exception {
+    void noExceptionThrown() throws Exception {
         final AtomicInteger counter = new AtomicInteger();
         new CheckedBiProc<>(
             (first, second) -> counter.incrementAndGet(),

--- a/src/test/java/org/cactoos/proc/CheckedProcTest.java
+++ b/src/test/java/org/cactoos/proc/CheckedProcTest.java
@@ -28,8 +28,9 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link CheckedProc}.
@@ -37,30 +38,44 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @since 0.32
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class CheckedProcTest {
+final class CheckedProcTest {
 
-    @Test(expected = IllegalStateException.class)
-    public void runtimeExceptionIsNotWrapped() throws Exception {
-        new CheckedProc<>(
-            input -> {
-                throw new IllegalStateException("runtime1");
+    @Test
+    void runtimeExceptionIsNotWrapped() {
+        new Assertion<>(
+            "Runtime exception is wrapped",
+            () -> {
+                new CheckedProc<>(
+                    input -> {
+                        throw new IllegalStateException("runtime1");
+                    },
+                    IOException::new
+                ).exec(true);
+                return 1;
             },
-            IOException::new
-        ).exec(true);
-    }
-
-    @Test(expected = IOException.class)
-    public void checkedExceptionIsWrapped() throws Exception {
-        new CheckedProc<>(
-            input -> {
-                throw new EOFException("runtime2");
-            },
-            IOException::new
-        ).exec(true);
+            new Throws<>(IllegalStateException.class)
+        ).affirm();
     }
 
     @Test
-    public void extraWrappingIgnored() {
+    void checkedExceptionIsWrapped() {
+        new Assertion<>(
+            "Checked exception is not wrapped",
+            () -> {
+                new CheckedProc<>(
+                    input -> {
+                        throw new EOFException("runtime2");
+                    },
+                    IOException::new
+                ).exec(true);
+                return 1;
+            },
+            new Throws<>(IOException.class)
+        ).affirm();
+    }
+
+    @Test
+    void extraWrappingIgnored() {
         try {
             new CheckedProc<>(
                 input -> {
@@ -78,7 +93,7 @@ public final class CheckedProcTest {
     }
 
     @Test
-    public void noExceptionThrown() throws Exception {
+    void noExceptionThrown() throws Exception {
         final AtomicInteger counter = new AtomicInteger();
         new CheckedProc<>(
             input -> counter.incrementAndGet(),

--- a/src/test/java/org/cactoos/proc/ForEachInThreadsTest.java
+++ b/src/test/java/org/cactoos/proc/ForEachInThreadsTest.java
@@ -37,7 +37,7 @@ import org.llorllale.cactoos.matchers.Assertion;
  * @since 1.0
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public class ForEachInThreadsTest {
+final class ForEachInThreadsTest {
 
     @Test
     @SuppressWarnings("unchecked")

--- a/src/test/java/org/cactoos/proc/ProcNoNullsTest.java
+++ b/src/test/java/org/cactoos/proc/ProcNoNullsTest.java
@@ -25,28 +25,44 @@ package org.cactoos.proc;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import org.hamcrest.core.IsEqual;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link ProcNoNulls}.
  * @since 0.11
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class ProcNoNullsTest {
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class ProcNoNullsTest {
 
-    @Test(expected = IllegalArgumentException.class)
-    public void failForNullProc() throws Exception {
-        new ProcNoNulls<>(null).exec(new Object());
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void failForNullInput() throws Exception {
-        new ProcNoNulls<>(input -> { }).exec(null);
+    @Test
+    void failForNullProc() {
+        new Assertion<>(
+            "Doesn't fail for null proc",
+            () -> {
+                new ProcNoNulls<>(null).exec(new Object());
+                return 1;
+            },
+            new Throws<>(IllegalArgumentException.class)
+        ).affirm();
     }
 
     @Test
-    public void okForNoNulls() throws Exception {
+    void failForNullInput() {
+        new Assertion<>(
+            "Doesn't fail for null input",
+            () -> {
+                new ProcNoNulls<>(input -> { }).exec(null);
+                return 1;
+            },
+            new Throws<>(IllegalArgumentException.class)
+        ).affirm();
+    }
+
+    @Test
+    void okForNoNulls() throws Exception {
         final AtomicInteger counter = new AtomicInteger();
         new ProcNoNulls<>(AtomicInteger::incrementAndGet)
             .exec(counter);

--- a/src/test/java/org/cactoos/proc/UncheckedProcTest.java
+++ b/src/test/java/org/cactoos/proc/UncheckedProcTest.java
@@ -25,7 +25,9 @@ package org.cactoos.proc;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link UncheckedProc}.
@@ -33,24 +35,39 @@ import org.junit.Test;
  * @since 0.2
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class UncheckedProcTest {
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+final class UncheckedProcTest {
 
-    @Test(expected = UncheckedIOException.class)
-    public void rethrowsCheckedToUncheckedException() {
-        new UncheckedProc<>(
-            input -> {
-                throw new IOException("intended");
-            }
-        ).exec(1);
+    @Test
+    void rethrowsCheckedToUncheckedException() {
+        new Assertion<>(
+            "Checked exception was not rethrown as unchecked",
+            () -> {
+                new UncheckedProc<>(
+                    input -> {
+                        throw new IOException("intended");
+                    }
+                ).exec(1);
+                return 1;
+            },
+            new Throws<>(UncheckedIOException.class)
+        ).affirm();
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void runtimeExceptionGoesOut() {
-        new UncheckedProc<>(
-            i -> {
-                throw new IllegalStateException("intended to fail");
-            }
-        ).exec(1);
+    @Test
+    void runtimeExceptionGoesOut() {
+        new Assertion<>(
+            "Runtime exception was not rethrown",
+            () -> {
+                new UncheckedProc<>(
+                    i -> {
+                        throw new IllegalStateException("intended to fail");
+                    }
+                ).exec(1);
+                return 1;
+            },
+            new Throws<>(IllegalStateException.class)
+        ).affirm();
     }
 
 }

--- a/src/test/java/org/cactoos/scalar/BinaryTest.java
+++ b/src/test/java/org/cactoos/scalar/BinaryTest.java
@@ -25,7 +25,7 @@ package org.cactoos.scalar;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import org.hamcrest.core.IsEqual;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasValue;
 import org.llorllale.cactoos.matchers.Throws;
@@ -35,10 +35,10 @@ import org.llorllale.cactoos.matchers.Throws;
  * @since 1.0
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class BinaryTest {
+final class BinaryTest {
 
     @Test
-    public void conditionTrue() {
+    void conditionTrue() {
         final AtomicInteger counter = new AtomicInteger(0);
         final Binary binary = new Binary(
             new True(),
@@ -58,7 +58,7 @@ public final class BinaryTest {
     }
 
     @Test
-    public void conditionFalse() {
+    void conditionFalse() {
         final AtomicInteger counter = new AtomicInteger(0);
         final Binary binary = new Binary(
             new False(),
@@ -78,7 +78,7 @@ public final class BinaryTest {
     }
 
     @Test
-    public void throwsException() {
+    void throwsException() {
         final String msg = "Custom exception message";
         final Binary binary = new Binary(
             new True(),

--- a/src/test/java/org/cactoos/scalar/CheckedTest.java
+++ b/src/test/java/org/cactoos/scalar/CheckedTest.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import java.nio.channels.AcceptPendingException;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.Throws;
 
@@ -37,10 +37,10 @@ import org.llorllale.cactoos.matchers.Throws;
  * @since 0.30
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class CheckedTest {
+final class CheckedTest {
 
     @Test
-    public void runtimeExceptionGoesOut() throws Exception {
+    void runtimeExceptionGoesOut() throws Exception {
         new Assertion<>(
             "Must throw runtime exception",
             () -> new Checked<>(
@@ -54,7 +54,7 @@ public final class CheckedTest {
     }
 
     @Test
-    public void usesGenericVarianceOnExceptionTypes() throws Exception {
+    void usesGenericVarianceOnExceptionTypes() throws Exception {
         new Assertion<>(
             "Must use generic variance on exception types",
             () -> new Checked<String, IllegalStateException>(
@@ -70,7 +70,7 @@ public final class CheckedTest {
     }
 
     @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-    public void usesContravarianceOnResultType() throws Exception {
+    void usesContravarianceOnResultType() throws Exception {
         new Assertion<>(
             "Must use contravariance on result",
             new Checked<CharSequence, IOException>(
@@ -82,7 +82,7 @@ public final class CheckedTest {
     }
 
     @Test
-    public void throwsIoException() throws Exception {
+    void throwsIoException() throws Exception {
         new Assertion<>(
             "Must throw io exception",
             () -> new Checked<>(
@@ -96,7 +96,7 @@ public final class CheckedTest {
     }
 
     @Test
-    public void ioExceptionGoesOut() throws Exception {
+    void ioExceptionGoesOut() throws Exception {
         try {
             new Checked<>(
                 () -> {
@@ -114,7 +114,7 @@ public final class CheckedTest {
     }
 
     @Test
-    public void fileNotFoundExceptionGoesOut() throws Exception {
+    void fileNotFoundExceptionGoesOut() throws Exception {
         try {
             new Checked<>(
                 () -> {
@@ -132,7 +132,7 @@ public final class CheckedTest {
     }
 
     @Test
-    public void throwsIoExceptionWithModifiedMessage() throws Exception {
+    void throwsIoExceptionWithModifiedMessage() throws Exception {
         final String message = "error msg";
         new Assertion<>(
             "Must throw io exception with modified message",

--- a/src/test/java/org/cactoos/scalar/HighestOfTest.java
+++ b/src/test/java/org/cactoos/scalar/HighestOfTest.java
@@ -31,7 +31,8 @@ import org.cactoos.number.SumOf;
 import org.cactoos.time.DateOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasValue;
 
@@ -42,15 +43,18 @@ import org.llorllale.cactoos.matchers.HasValue;
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class HighestOfTest {
+final class HighestOfTest {
 
-    @Test(expected = NoSuchElementException.class)
-    public void failsForEmptyIterable() throws Exception {
-        new HighestOf<>(() -> Collections.emptyIterator()).value();
+    @Test
+    void failsForEmptyIterable() {
+        Assertions.assertThrows(
+            NoSuchElementException.class,
+            () -> new HighestOf<>(() -> Collections.emptyIterator()).value()
+        );
     }
 
     @Test
-    public void singleAtSingleIterable() throws Exception {
+    void singleAtSingleIterable() throws Exception {
         MatcherAssert.assertThat(
             "Can't find the highest among one by scalars",
             new HighestOf<Integer>(() -> 10).value(),
@@ -64,7 +68,7 @@ public final class HighestOfTest {
     }
 
     @Test
-    public void highestIntegerAtIterable() throws Exception {
+    void highestIntegerAtIterable() throws Exception {
         MatcherAssert.assertThat(
             "Can't find the highest integer among many by scalars",
             new HighestOf<Integer>(
@@ -93,7 +97,7 @@ public final class HighestOfTest {
     }
 
     @Test
-    public void highestLongAtIterable() throws Exception {
+    void highestLongAtIterable() throws Exception {
         MatcherAssert.assertThat(
             "Can't find the highest long among many by scalars",
             new HighestOf<Long>(
@@ -122,7 +126,7 @@ public final class HighestOfTest {
     }
 
     @Test
-    public void highestDoubleAtIterable() throws Exception {
+    void highestDoubleAtIterable() throws Exception {
         MatcherAssert.assertThat(
             "Can't find the highest double among many by scalars",
             new HighestOf<Double>(
@@ -171,7 +175,7 @@ public final class HighestOfTest {
     }
 
     @Test
-    public void highestStringAtIterable() throws Exception {
+    void highestStringAtIterable() throws Exception {
         MatcherAssert.assertThat(
             "Can't find the highest string among many by scalars",
             new HighestOf<String>(() -> "Apple", () -> "Orange").value(),
@@ -185,7 +189,7 @@ public final class HighestOfTest {
     }
 
     @Test
-    public void highestCharAtIterable() throws Exception {
+    void highestCharAtIterable() throws Exception {
         MatcherAssert.assertThat(
             "Can't find the highest char among many by scalars",
             new HighestOf<Character>(() -> 'A', () -> 'B').value(),
@@ -199,7 +203,7 @@ public final class HighestOfTest {
     }
 
     @Test
-    public void highestSumAtIterable() throws Exception {
+    void highestSumAtIterable() throws Exception {
         new Assertion<>(
             "Must find the highest double sum among many",
             new HighestOf<>(
@@ -212,7 +216,7 @@ public final class HighestOfTest {
     }
 
     @Test
-    public void highestDateAtIterable() throws Exception {
+    void highestDateAtIterable() throws Exception {
         MatcherAssert.assertThat(
             "Can't find the highest date among many",
             new HighestOf<Date>(
@@ -227,7 +231,7 @@ public final class HighestOfTest {
     }
 
     @Test
-    public void highestBooleanAtIterable() throws Exception {
+    void highestBooleanAtIterable() throws Exception {
         MatcherAssert.assertThat(
             "Can't find the highest boolean among many",
             new HighestOf<Boolean>(

--- a/src/test/java/org/cactoos/scalar/HighestOfTest.java
+++ b/src/test/java/org/cactoos/scalar/HighestOfTest.java
@@ -31,10 +31,10 @@ import org.cactoos.number.SumOf;
 import org.cactoos.time.DateOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasValue;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link HighestOf}.
@@ -42,15 +42,17 @@ import org.llorllale.cactoos.matchers.HasValue;
  * @since 0.29
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals",
+    "PMD.JUnitTestsShouldIncludeAssert"})
 final class HighestOfTest {
 
     @Test
     void failsForEmptyIterable() {
-        Assertions.assertThrows(
-            NoSuchElementException.class,
-            () -> new HighestOf<>(() -> Collections.emptyIterator()).value()
-        );
+        new Assertion<>(
+            "Exception is expected for iterating empty collection",
+            () -> new HighestOf<>(() -> Collections.emptyIterator()).value(),
+            new Throws<>(NoSuchElementException.class)
+        ).affirm();
     }
 
     @Test

--- a/src/test/java/org/cactoos/scalar/LowestOfTest.java
+++ b/src/test/java/org/cactoos/scalar/LowestOfTest.java
@@ -31,9 +31,10 @@ import org.cactoos.number.SumOf;
 import org.cactoos.time.DateOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasValue;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link LowestOf}.
@@ -42,15 +43,19 @@ import org.llorllale.cactoos.matchers.HasValue;
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class LowestOfTest {
+final class LowestOfTest {
 
-    @Test(expected = NoSuchElementException.class)
-    public void failsForEmptyIterable() throws Exception {
-        new LowestOf<>(() -> Collections.emptyIterator()).value();
+    @Test
+    void failsForEmptyIterable() {
+        new Assertion<>(
+            "Cann't iterate in empty collection",
+            () -> new LowestOf<>(() -> Collections.emptyIterator()).value(),
+            new Throws<>(NoSuchElementException.class)
+        );
     }
 
     @Test
-    public void singleAtSingleIterable() throws Exception {
+    void singleAtSingleIterable() throws Exception {
         MatcherAssert.assertThat(
             "Can't find the lowest among one by scalars",
             new LowestOf<Integer>(() -> 10).value(),
@@ -64,7 +69,7 @@ public final class LowestOfTest {
     }
 
     @Test
-    public void lowestIntegerAtIterable() throws Exception {
+    void lowestIntegerAtIterable() throws Exception {
         MatcherAssert.assertThat(
             "Can't find the lowest integer among many by scalars",
             new LowestOf<Integer>(
@@ -98,7 +103,7 @@ public final class LowestOfTest {
     }
 
     @Test
-    public void lowestLongAtIterable() throws Exception {
+    void lowestLongAtIterable() throws Exception {
         MatcherAssert.assertThat(
             "Can't find the lowest long among many by scalars",
             new LowestOf<Long>(
@@ -132,7 +137,7 @@ public final class LowestOfTest {
     }
 
     @Test
-    public void lowestDoubleAtIterable() throws Exception {
+    void lowestDoubleAtIterable() throws Exception {
         MatcherAssert.assertThat(
             "Can't find the lowest double among many by scalars",
             new LowestOf<Double>(
@@ -191,7 +196,7 @@ public final class LowestOfTest {
     }
 
     @Test
-    public void lowestStringAtIterable() throws Exception {
+    void lowestStringAtIterable() throws Exception {
         MatcherAssert.assertThat(
             "Can't find the lowest string among many by scalars",
             new LowestOf<String>(
@@ -209,7 +214,7 @@ public final class LowestOfTest {
     }
 
     @Test
-    public void lowestCharAtIterable() throws Exception {
+    void lowestCharAtIterable() throws Exception {
         MatcherAssert.assertThat(
             "Can't find the lowest char among many by scalars",
             new LowestOf<Character>(() -> 'B', () -> 'U', () -> 'G').value(),
@@ -223,7 +228,7 @@ public final class LowestOfTest {
     }
 
     @Test
-    public void lowestSumAtIterable() throws Exception {
+    void lowestSumAtIterable() throws Exception {
         new Assertion<>(
             "Must find the lowest double sum among many",
             new LowestOf<>(
@@ -236,7 +241,7 @@ public final class LowestOfTest {
     }
 
     @Test
-    public void lowestDateAtIterable() throws Exception {
+    void lowestDateAtIterable() throws Exception {
         MatcherAssert.assertThat(
             "Can't find the lowest date among many",
             new LowestOf<Date>(
@@ -251,7 +256,7 @@ public final class LowestOfTest {
     }
 
     @Test
-    public void lowestBooleanAtIterable() throws Exception {
+    void lowestBooleanAtIterable() throws Exception {
         MatcherAssert.assertThat(
             "Can't find the lowest boolean among many",
             new LowestOf<Boolean>(

--- a/src/test/java/org/cactoos/scalar/ReducedTest.java
+++ b/src/test/java/org/cactoos/scalar/ReducedTest.java
@@ -27,27 +27,29 @@ import java.util.Collections;
 import java.util.NoSuchElementException;
 import org.cactoos.Scalar;
 import org.cactoos.iterable.IterableOf;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasValue;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link Reduced}.
  * @since 0.30
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class ReducedTest {
 
     @Test
     void failsForEmptyIterable() {
-        Assertions.assertThrows(
-            NoSuchElementException.class,
+        new Assertion<>(
+            "Exception is expected for empty iterable",
             () -> new Reduced<>(
                 (first, last) -> first,
                 Collections.emptyList()
-            ).value()
-        );
+            ).value(),
+            new Throws<>(NoSuchElementException.class)
+        ).affirm();
     }
 
     @Test

--- a/src/test/java/org/cactoos/scalar/ReducedTest.java
+++ b/src/test/java/org/cactoos/scalar/ReducedTest.java
@@ -27,7 +27,8 @@ import java.util.Collections;
 import java.util.NoSuchElementException;
 import org.cactoos.Scalar;
 import org.cactoos.iterable.IterableOf;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasValue;
 
@@ -36,18 +37,21 @@ import org.llorllale.cactoos.matchers.HasValue;
  * @since 0.30
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class ReducedTest {
+final class ReducedTest {
 
-    @Test(expected = NoSuchElementException.class)
-    public void failsForEmptyIterable() throws Exception {
-        new Reduced<>(
-            (first, last) -> first,
-            Collections.emptyList()
-        ).value();
+    @Test
+    void failsForEmptyIterable() {
+        Assertions.assertThrows(
+            NoSuchElementException.class,
+            () -> new Reduced<>(
+                (first, last) -> first,
+                Collections.emptyList()
+            ).value()
+        );
     }
 
     @Test
-    public void singleAtSingleIterable() {
+    void singleAtSingleIterable() {
         final Integer single = 10;
         new Assertion<>(
             "Must find the single",
@@ -60,7 +64,7 @@ public final class ReducedTest {
     }
 
     @Test
-    public void firstAtIterable() {
+    void firstAtIterable() {
         final String one = "Apple";
         final String two = "Banana";
         final String three = "Orange";
@@ -79,7 +83,7 @@ public final class ReducedTest {
     }
 
     @Test
-    public void lastAtIterable() {
+    void lastAtIterable() {
         final Character one = 'A';
         final Character two = 'B';
         final Character three = 'O';
@@ -98,7 +102,7 @@ public final class ReducedTest {
     }
 
     @Test
-    public void lastAtIterableOfValues() {
+    void lastAtIterableOfValues() {
         final Character one = 'A';
         final Character two = 'B';
         final Character three = 'O';
@@ -113,7 +117,7 @@ public final class ReducedTest {
     }
 
     @Test
-    public void constructedFromVarargs() {
+    void constructedFromVarargs() {
         final String one = "One";
         final String two = "Two";
         final String three = "Three";

--- a/src/test/java/org/cactoos/scalar/RetryTest.java
+++ b/src/test/java/org/cactoos/scalar/RetryTest.java
@@ -44,7 +44,7 @@ import org.llorllale.cactoos.matchers.HasValue;
 final class RetryTest {
 
     @Test
-    void runsScalarMultipleTimes() throws Exception {
+    void runsScalarMultipleTimes() {
         new Assertion<>(
             "must retry in case of failure",
             new Retry<>(
@@ -61,7 +61,7 @@ final class RetryTest {
     }
 
     @Test
-    void runsScalarTwiceWithDefaults() throws Exception {
+    void runsScalarTwiceWithDefaults() {
         final AtomicInteger tries = new AtomicInteger(0);
         new Assertion<>(
             "Should run twice with defaults",
@@ -78,8 +78,7 @@ final class RetryTest {
     }
 
     @Test
-    void runsScalarMultipleTimesIgnoringNegativeDuration()
-        throws Exception {
+    void runsScalarMultipleTimesIgnoringNegativeDuration() {
         final int times = 2;
         final AtomicInteger tries = new AtomicInteger(0);
         new Assertion<>(
@@ -116,12 +115,14 @@ final class RetryTest {
             Integer.MAX_VALUE,
             Duration.ofMillis(wait)
         ).value();
-        for (int position = 0; position < executions.size() - 1; position += 1) {
-            final int actual = position;
+        for (int position = 0; position < times - 1; position += 1) {
             new Assertion<>(
-                "Should wait the given time between attempts",
-                executions.get(actual).plusMillis(wait),
-                Matchers.lessThanOrEqualTo(executions.get(actual + 1))
+                String.format(
+                    "Should wait the given time between attempts on attempt %d",
+                    position
+                ),
+                executions.get(position).plusMillis(wait),
+                Matchers.lessThanOrEqualTo(executions.get(position + 1))
             ).affirm();
         }
     }

--- a/src/test/java/org/cactoos/scalar/ScalarWithFallbackTest.java
+++ b/src/test/java/org/cactoos/scalar/ScalarWithFallbackTest.java
@@ -28,7 +28,8 @@ import java.util.IllegalFormatException;
 import java.util.IllegalFormatWidthException;
 import org.cactoos.Fallback;
 import org.cactoos.iterable.IterableOf;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasValue;
 
@@ -39,10 +40,10 @@ import org.llorllale.cactoos.matchers.HasValue;
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 @SuppressWarnings("unchecked")
-public final class ScalarWithFallbackTest {
+final class ScalarWithFallbackTest {
 
     @Test
-    public void usesMainFunc() throws Exception {
+    void usesMainFunc() throws Exception {
         final String message = "Main function's result #1";
         new Assertion<>(
             "Must use the main function if no exception",
@@ -60,7 +61,7 @@ public final class ScalarWithFallbackTest {
     }
 
     @Test
-    public void usesMainFuncFromExceptionAndFallback() throws Exception {
+    void usesMainFuncFromExceptionAndFallback() throws Exception {
         final String message = "Main function's result #1 (exp & flbck)";
         new Assertion<>(
             "Using the main function if no exception (exp & flbck)",
@@ -76,7 +77,7 @@ public final class ScalarWithFallbackTest {
     }
 
     @Test
-    public void usesMainFuncFromIterableExceptionAndFallback() throws Exception {
+    void usesMainFuncFromIterableExceptionAndFallback() throws Exception {
         final String message = "Main function's result #1 (exp iterable & flbck)";
         new Assertion<>(
             "Using the main function if no exception (exp iterable & flbck)",
@@ -92,7 +93,7 @@ public final class ScalarWithFallbackTest {
     }
 
     @Test
-    public void usesFallback() throws Exception {
+    void usesFallback() throws Exception {
         final String message = "Fallback from IOException";
         new Assertion<>(
             "Must use a single fallback in case of exception",
@@ -115,7 +116,7 @@ public final class ScalarWithFallbackTest {
     }
 
     @Test
-    public void usesFallbackFromExceptionAndFallback() throws Exception {
+    void usesFallbackFromExceptionAndFallback() throws Exception {
         final String message = "Fallback from IOException (exp & flbck)";
         new Assertion<>(
             "Using a single fallback in case of exception (exp & flbck)",
@@ -133,7 +134,7 @@ public final class ScalarWithFallbackTest {
     }
 
     @Test
-    public void usesFallbackFromIterableExceptionAndFallback() throws Exception {
+    void usesFallbackFromIterableExceptionAndFallback() throws Exception {
         final String message = "Fallback from IOException (exp iterable & flbck)";
         new Assertion<>(
             "Using a single fallback in case of exception (exp iterable & flbck)",
@@ -151,7 +152,7 @@ public final class ScalarWithFallbackTest {
     }
 
     @Test
-    public void usesFallbackOfInterruptedException() throws Exception {
+    void usesFallbackOfInterruptedException() throws Exception {
         final String message = "Fallback from InterruptedException";
         new Assertion<>(
             "Must use a fallback from Interrupted in case of exception",
@@ -173,7 +174,7 @@ public final class ScalarWithFallbackTest {
     }
 
     @Test
-    public void usesTheClosestFallback() throws Exception {
+    void usesTheClosestFallback() throws Exception {
         final String expected = "Fallback from IllegalFormatException";
         new Assertion<>(
             "Must find the closest fallback",
@@ -196,13 +197,16 @@ public final class ScalarWithFallbackTest {
         ).affirm();
     }
 
-    @Test(expected = Exception.class)
-    public void noFallbackIsProvided() throws Exception {
-        new ScalarWithFallback<>(
-            () -> {
-                throw new IllegalFormatWidthException(1);
-            },
-            new IterableOf<>()
-        ).value();
+    @Test
+    void noFallbackIsProvided() {
+        Assertions.assertThrows(
+            Exception.class,
+            () -> new ScalarWithFallback<>(
+                () -> {
+                    throw new IllegalFormatWidthException(1);
+                },
+                new IterableOf<>()
+            ).value()
+        );
     }
 }

--- a/src/test/java/org/cactoos/scalar/ScalarWithFallbackTest.java
+++ b/src/test/java/org/cactoos/scalar/ScalarWithFallbackTest.java
@@ -28,10 +28,10 @@ import java.util.IllegalFormatException;
 import java.util.IllegalFormatWidthException;
 import org.cactoos.Fallback;
 import org.cactoos.iterable.IterableOf;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasValue;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link ScalarWithFallback}.
@@ -39,7 +39,8 @@ import org.llorllale.cactoos.matchers.HasValue;
  * @since 0.31
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked",
+    "PMD.JUnitTestsShouldIncludeAssert"})
 final class ScalarWithFallbackTest {
 
     @Test
@@ -199,14 +200,15 @@ final class ScalarWithFallbackTest {
 
     @Test
     void noFallbackIsProvided() {
-        Assertions.assertThrows(
-            Exception.class,
+        new Assertion<>(
+            "Exception is expected if there is no fallback",
             () -> new ScalarWithFallback<>(
                 () -> {
                     throw new IllegalFormatWidthException(1);
                 },
                 new IterableOf<>()
-            ).value()
-        );
+            ).value(),
+            new Throws<>(Exception.class)
+        ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/scalar/StrictTest.java
+++ b/src/test/java/org/cactoos/scalar/StrictTest.java
@@ -38,7 +38,7 @@ import org.llorllale.cactoos.matchers.Throws;
 final class StrictTest {
 
     @Test
-    public void throwsExceptionOnFailure() {
+    void throwsExceptionOnFailure() {
         new Assertion<>(
             "Must throw the provided exception on rule failure",
             new Strict<>(
@@ -51,7 +51,7 @@ final class StrictTest {
     }
 
     @Test
-    public void returnsIncapsulatedValue() throws Exception {
+    void returnsIncapsulatedValue() throws Exception {
         new Assertion<>(
             "Must return the original value on rule match",
             new Strict<>(

--- a/src/test/java/org/cactoos/scalar/StrictTest.java
+++ b/src/test/java/org/cactoos/scalar/StrictTest.java
@@ -25,7 +25,7 @@ package org.cactoos.scalar;
 
 import org.cactoos.func.FuncOf;
 import org.hamcrest.core.IsEqual;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.Throws;
 
@@ -34,7 +34,7 @@ import org.llorllale.cactoos.matchers.Throws;
  *
  * @since 0.56
  */
-public final class StrictTest {
+final class StrictTest {
 
     @Test
     public void throwsExceptionOnFailure() {

--- a/src/test/java/org/cactoos/scalar/StrictTest.java
+++ b/src/test/java/org/cactoos/scalar/StrictTest.java
@@ -34,6 +34,7 @@ import org.llorllale.cactoos.matchers.Throws;
  *
  * @since 0.56
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class StrictTest {
 
     @Test

--- a/src/test/java/org/cactoos/scalar/ThrowsOnFalseTest.java
+++ b/src/test/java/org/cactoos/scalar/ThrowsOnFalseTest.java
@@ -25,7 +25,7 @@
 package org.cactoos.scalar;
 
 import org.hamcrest.core.IsEqual;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.Throws;
 
@@ -34,10 +34,10 @@ import org.llorllale.cactoos.matchers.Throws;
  *
  * @since 0.56.0
  */
-public final class ThrowsOnFalseTest {
+final class ThrowsOnFalseTest {
 
     @Test
-    public void throwsOnFalse() throws Exception {
+    void throwsOnFalse() throws Exception {
         final String message = "test message";
         new Assertion<>(
             "Throws an exception",
@@ -49,7 +49,7 @@ public final class ThrowsOnFalseTest {
     }
 
     @Test
-    public void throwsSuppliedExceptionOnFalse() throws Exception {
+    void throwsSuppliedExceptionOnFalse() throws Exception {
         final String message = "illegal state";
         new Assertion<>(
             "Throws supplied exception",
@@ -62,7 +62,7 @@ public final class ThrowsOnFalseTest {
     }
 
     @Test
-    public void returnsTrueOnTrue() throws Exception {
+    void returnsTrueOnTrue() throws Exception {
         new Assertion<>(
             "Must return true on true statement",
             new ThrowsOnFalse(() -> true, "test").value(),

--- a/src/test/java/org/cactoos/scalar/UncheckedTest.java
+++ b/src/test/java/org/cactoos/scalar/UncheckedTest.java
@@ -25,8 +25,10 @@ package org.cactoos.scalar;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.IsTrue;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link Unchecked}.
@@ -34,18 +36,44 @@ import org.junit.jupiter.api.Test;
  * @since 0.3
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class UncheckedTest {
 
     @Test
     void rethrowsCheckedToUncheckedException() {
-        Assertions.assertThrows(
-            UncheckedIOException.class,
+        new Assertion<>(
+            "Checked exception should be rethrown as unchecked",
             () -> new Unchecked<>(
                 () -> {
                     throw new IOException("intended");
                 }
-            ).value()
-        );
+            ).value(),
+            new Throws<>(UncheckedIOException.class)
+        ).affirm();
+    }
+
+    @Test
+    void rethrowsUncheckedException() {
+        new Assertion<>(
+            "Unchecked exception should be rethrown as is",
+            () -> new Unchecked<>(
+                () -> {
+                    throw new IllegalStateException("");
+                }
+            ).value(),
+            new Throws<>(IllegalStateException.class)
+        ).affirm();
+    }
+
+    @Test
+    void returnUncheckedValue() {
+        new Assertion<>(
+            "Must return value without exceptions",
+            new Unchecked<>(
+                () -> true
+            ).value(),
+            new IsTrue()
+        ).affirm();
     }
 
 }

--- a/src/test/java/org/cactoos/scalar/UncheckedTest.java
+++ b/src/test/java/org/cactoos/scalar/UncheckedTest.java
@@ -25,7 +25,8 @@ package org.cactoos.scalar;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Unchecked}.
@@ -33,15 +34,18 @@ import org.junit.Test;
  * @since 0.3
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class UncheckedTest {
+final class UncheckedTest {
 
-    @Test(expected = UncheckedIOException.class)
-    public void rethrowsCheckedToUncheckedException() {
-        new Unchecked<>(
-            () -> {
-                throw new IOException("intended");
-            }
-        ).value();
+    @Test
+    void rethrowsCheckedToUncheckedException() {
+        Assertions.assertThrows(
+            UncheckedIOException.class,
+            () -> new Unchecked<>(
+                () -> {
+                    throw new IOException("intended");
+                }
+            ).value()
+        );
     }
 
 }

--- a/src/test/java/org/cactoos/set/SetOfTest.java
+++ b/src/test/java/org/cactoos/set/SetOfTest.java
@@ -37,7 +37,8 @@ import org.llorllale.cactoos.matchers.HasValues;
  * Test case for {@link SetOf}.
  * @since 0.49.2
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals",
+    "PMD.JUnitTestsShouldIncludeAssert"})
 final class SetOfTest {
 
     @Test

--- a/src/test/java/org/cactoos/set/SortedTest.java
+++ b/src/test/java/org/cactoos/set/SortedTest.java
@@ -41,12 +41,9 @@ import org.llorllale.cactoos.matchers.IsText;
  * @since 1.0.0
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-@SuppressWarnings(
-    {
-        "PMD.AvoidDuplicateLiterals",
-        "PMD.TooManyMethods"
-    }
-)
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals",
+    "PMD.TooManyMethods",
+    "PMD.JUnitTestsShouldIncludeAssert"})
 final class SortedTest {
 
     @Test

--- a/src/test/java/org/cactoos/text/ComparableTextTest.java
+++ b/src/test/java/org/cactoos/text/ComparableTextTest.java
@@ -26,7 +26,7 @@ package org.cactoos.text;
 import org.cactoos.Text;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNot;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.IsText;
 
@@ -36,10 +36,10 @@ import org.llorllale.cactoos.matchers.IsText;
  * @since 0.27
  * @checkstyle JavadocMethodCheck (100 lines)
  */
-public final class ComparableTextTest {
+final class ComparableTextTest {
 
     @Test
-    public void comparesWithASubtext() {
+    void comparesWithASubtext() {
         new Assertion<>(
             "Can't compare sub texts",
             new ComparableText(
@@ -56,7 +56,7 @@ public final class ComparableTextTest {
     }
 
     @Test
-    public void comparesToUncheckedText() {
+    void comparesToUncheckedText() {
         final String txt = "foobar";
         new Assertion<>(
             "These UncheckedText are not equal",
@@ -72,7 +72,7 @@ public final class ComparableTextTest {
     }
 
     @Test
-    public void equalsToItself() {
+    void equalsToItself() {
         final Text text = new TextOf("text");
         new Assertion<>(
             "Does not equal to itself",
@@ -82,7 +82,7 @@ public final class ComparableTextTest {
     }
 
     @Test
-    public void equalsAndHashCodeOfComparableOfTheSameText() {
+    void equalsAndHashCodeOfComparableOfTheSameText() {
         final Text text = new TextOf("my text");
         final Text actual = new ComparableText(text);
         final Text expected = new ComparableText(text);
@@ -101,7 +101,7 @@ public final class ComparableTextTest {
     }
 
     @Test
-    public void equalsOfDifferentText() {
+    void equalsOfDifferentText() {
         final Text text = new ComparableText(
             new TextOf("my value")
         );

--- a/src/test/java/org/cactoos/text/FormattedTextTest.java
+++ b/src/test/java/org/cactoos/text/FormattedTextTest.java
@@ -28,10 +28,10 @@ import java.util.IllegalFormatConversionException;
 import java.util.Locale;
 import java.util.UnknownFormatConversionException;
 import org.cactoos.list.ListOf;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasString;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link FormattedText}.
@@ -39,6 +39,7 @@ import org.llorllale.cactoos.matchers.HasString;
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 final class FormattedTextTest {
 
     @Test
@@ -67,13 +68,14 @@ final class FormattedTextTest {
 
     @Test
     void failsForInvalidPattern() {
-        Assertions.assertThrows(
-            UnknownFormatConversionException.class,
+        new Assertion<>(
+            "Exception is expected for invalid format",
             () -> new FormattedText(
                 new TextOf("%%. Formatted %$"),
                 new ListOf<>(1, "invalid")
-            ).asString()
-        );
+            ).asString(),
+            new Throws<>(UnknownFormatConversionException.class)
+        ).affirm();
     }
 
     @Test
@@ -89,15 +91,16 @@ final class FormattedTextTest {
     }
 
     @Test
-    void ensuresThatFormatterFails() throws Exception {
-        Assertions.assertThrows(
-            IllegalFormatConversionException.class,
+    void ensuresThatFormatterFails() {
+        new Assertion<>(
+            "Exception is expected for wrong format",
             () -> new FormattedText(
                 new TextOf("Local time: %d"),
                 Locale.ROOT,
                 Calendar.getInstance()
-            ).asString()
-        );
+            ).asString(),
+            new Throws<>(IllegalFormatConversionException.class)
+        ).affirm();
     }
 
     @Test

--- a/src/test/java/org/cactoos/text/FormattedTextTest.java
+++ b/src/test/java/org/cactoos/text/FormattedTextTest.java
@@ -28,7 +28,8 @@ import java.util.IllegalFormatConversionException;
 import java.util.Locale;
 import java.util.UnknownFormatConversionException;
 import org.cactoos.list.ListOf;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.HasString;
 
@@ -38,10 +39,10 @@ import org.llorllale.cactoos.matchers.HasString;
  * @since 0.1
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class FormattedTextTest {
+final class FormattedTextTest {
 
     @Test
-    public void formatsText() {
+    void formatsText() {
         new Assertion<>(
             "Can't format a text",
             new FormattedText(
@@ -52,7 +53,7 @@ public final class FormattedTextTest {
     }
 
     @Test
-    public void formatsTextWithObjects() {
+    void formatsTextWithObjects() {
         new Assertion<>(
             "Can't format a text with objects",
             new FormattedText(
@@ -64,16 +65,19 @@ public final class FormattedTextTest {
         ).affirm();
     }
 
-    @Test(expected = UnknownFormatConversionException.class)
-    public void failsForInvalidPattern() throws Exception {
-        new FormattedText(
-            new TextOf("%%. Formatted %$"),
-            new ListOf<>(1, "invalid")
-        ).asString();
+    @Test
+    void failsForInvalidPattern() {
+        Assertions.assertThrows(
+            UnknownFormatConversionException.class,
+            () -> new FormattedText(
+                new TextOf("%%. Formatted %$"),
+                new ListOf<>(1, "invalid")
+            ).asString()
+        );
     }
 
     @Test
-    public void formatsTextWithCollection() {
+    void formatsTextWithCollection() {
         new Assertion<>(
             "Can't format a text with a collection",
             new FormattedText(
@@ -84,17 +88,20 @@ public final class FormattedTextTest {
         ).affirm();
     }
 
-    @Test(expected = IllegalFormatConversionException.class)
-    public void ensuresThatFormatterFails() throws Exception {
-        new FormattedText(
-            new TextOf("Local time: %d"),
-            Locale.ROOT,
-            Calendar.getInstance()
-        ).asString();
+    @Test
+    void ensuresThatFormatterFails() throws Exception {
+        Assertions.assertThrows(
+            IllegalFormatConversionException.class,
+            () -> new FormattedText(
+                new TextOf("Local time: %d"),
+                Locale.ROOT,
+                Calendar.getInstance()
+            ).asString()
+        );
     }
 
     @Test
-    public void formatsWithLocale() {
+    void formatsWithLocale() {
         new Assertion<>(
             "Can't format a text with Locale",
             new FormattedText(
@@ -105,7 +112,7 @@ public final class FormattedTextTest {
     }
 
     @Test
-    public void formatsWithText() {
+    void formatsWithText() {
         new Assertion<>(
             "Can't format a string with text",
             new FormattedText(

--- a/src/test/java/org/cactoos/text/StartsWithTest.java
+++ b/src/test/java/org/cactoos/text/StartsWithTest.java
@@ -34,7 +34,7 @@ import org.llorllale.cactoos.matchers.IsTrue;
  * @since 0.44
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public class StartsWithTest {
+final class StartsWithTest {
 
     @Test
     void emptyStartsWithEmpty() throws Exception {

--- a/src/test/java/org/cactoos/text/StrictTest.java
+++ b/src/test/java/org/cactoos/text/StrictTest.java
@@ -36,7 +36,8 @@ import org.llorllale.cactoos.matchers.Throws;
  *
  * @since 1.0
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals",
+    "PMD.JUnitTestsShouldIncludeAssert"})
 final class StrictTest {
 
     /**

--- a/src/test/java/org/cactoos/time/DateOfTest.java
+++ b/src/test/java/org/cactoos/time/DateOfTest.java
@@ -37,10 +37,10 @@ import org.llorllale.cactoos.matchers.HasValue;
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public class DateOfTest {
+final class DateOfTest {
 
     @Test
-    public final void testParsingIsoFormattedStringToDate() {
+    void testParsingIsoFormattedStringToDate() {
         new Assertion<>(
             "must parse a Date with default/ISO format.",
             new DateOf("2017-12-13T14:15:16.000000017Z"),
@@ -55,7 +55,7 @@ public class DateOfTest {
     }
 
     @Test
-    public final void testParsingCustomFormattedStringToDate() {
+    void testParsingCustomFormattedStringToDate() {
         new Assertion<>(
             "must parse a Date with custom format.",
             new DateOf(
@@ -73,7 +73,7 @@ public class DateOfTest {
     }
 
     @Test
-    public final void testParsingCustomFormattedStringWithoutTimeToDate() {
+    void testParsingCustomFormattedStringWithoutTimeToDate() {
         new Assertion<>(
             "must parse a Date with custom format.",
             new DateOf(
@@ -91,7 +91,7 @@ public class DateOfTest {
     }
 
     @Test
-    public final void testParsingCustomFormatterStringToDate() {
+    void testParsingCustomFormatterStringToDate() {
         new Assertion<>(
             "must parse a Date with custom format.",
             new DateOf(

--- a/src/test/java/org/cactoos/time/LocalDateTimeOfTest.java
+++ b/src/test/java/org/cactoos/time/LocalDateTimeOfTest.java
@@ -35,10 +35,10 @@ import org.llorllale.cactoos.matchers.HasValue;
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public class LocalDateTimeOfTest {
+final class LocalDateTimeOfTest {
 
     @Test
-    public final void testParsingIsoFormattedStringToLocalDateTime() {
+    void testParsingIsoFormattedStringToLocalDateTime() {
         new Assertion<>(
             "Can't parse a LocalDateTime with default/ISO format.",
             new LocalDateTimeOf("2017-12-13T14:15:16.000000017+01:00"),
@@ -47,7 +47,7 @@ public class LocalDateTimeOfTest {
     }
 
     @Test
-    public final void testParsingFormattedStringWithFormatToLocalDateTime() {
+    void testParsingFormattedStringWithFormatToLocalDateTime() {
         new Assertion<>(
             "Can't parse a LocalDateTime with custom format.",
             new LocalDateTimeOf(
@@ -59,7 +59,7 @@ public class LocalDateTimeOfTest {
     }
 
     @Test
-    public final void testParsingFormattedStringWithFormatterToLocalDateTime() {
+    void testParsingFormattedStringWithFormatterToLocalDateTime() {
         new Assertion<>(
             "Can't parse a LocalDateTime with custom formatter.",
             new LocalDateTimeOf(

--- a/src/test/java/org/cactoos/time/OffsetDateTimeOfTest.java
+++ b/src/test/java/org/cactoos/time/OffsetDateTimeOfTest.java
@@ -36,10 +36,10 @@ import org.llorllale.cactoos.matchers.HasValue;
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public class OffsetDateTimeOfTest {
+final class OffsetDateTimeOfTest {
 
     @Test
-    public final void testParsingIsoFormattedStringToOffsetDateTime() {
+    void testParsingIsoFormattedStringToOffsetDateTime() {
         new Assertion<>(
             "Can't parse a OffsetDateTime with default/ISO format.",
             new OffsetDateTimeOf("2017-12-13T14:15:16.000000017+01:00"),
@@ -52,7 +52,7 @@ public class OffsetDateTimeOfTest {
     }
 
     @Test
-    public final void testParsingFormattedStringWithOffsetToOffsetDateTime() {
+    void testParsingFormattedStringWithOffsetToOffsetDateTime() {
         new Assertion<>(
             "Can't parse a OffsetDateTime with custom format.",
             new OffsetDateTimeOf(

--- a/src/test/java/org/cactoos/time/ZonedDateTimeOfTest.java
+++ b/src/test/java/org/cactoos/time/ZonedDateTimeOfTest.java
@@ -38,10 +38,10 @@ import org.llorllale.cactoos.matchers.HasValue;
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public class ZonedDateTimeOfTest {
+final class ZonedDateTimeOfTest {
 
     @Test
-    public final void testParsingIsoFormattedStringToZonedDateTime() {
+    void testParsingIsoFormattedStringToZonedDateTime() {
         new Assertion<>(
             "Can't parse a ZonedDateTime with default/ISO format.",
             new ZonedDateTimeOf("2017-12-13T14:15:16.000000017+01:00"),
@@ -55,7 +55,7 @@ public class ZonedDateTimeOfTest {
     }
 
     @Test
-    public final void testParsingFormattedStringWithZoneToZonedDateTime() {
+    void testParsingFormattedStringWithZoneToZonedDateTime() {
         new Assertion<>(
             "Can't parse a ZonedDateTime with custom format and zone.",
             new ZonedDateTimeOf(
@@ -73,7 +73,7 @@ public class ZonedDateTimeOfTest {
     }
 
     @Test
-    public final void testParsingFormattedStringWithFormatterToZonedDateTime() {
+    void testParsingFormattedStringWithFormatterToZonedDateTime() {
         new Assertion<>(
             "Can't parse a ZonedDateTime with custom format and zone.",
             new ZonedDateTimeOf(

--- a/src/test/resources/forbidden-apis.txt
+++ b/src/test/resources/forbidden-apis.txt
@@ -1,7 +1,6 @@
 @defaultMessage Do not use static methods, please use cactoos-matchers Assertion instead
 org.hamcrest.Matchers
 org.junit.jupiter.api.Assertions
-org.junit.Assert
 org.hamcrest.MatcherAssert
 
 @defaultMessage Please avoid using static methods.


### PR DESCRIPTION
- JUnit 4 is deleted (and from deprecated api, as it fails on missing dependency)
- Assertions usage is change to cactoos Assertion
- Some fix to close streams (failed on windows)
- update actions versions


Fix https://github.com/yegor256/cactoos/issues/1586