### PR TITLE
Implementation of an analogue for ExceptionUtils.getRootCause

### DIFF
--- a/src/main/java/org/cactoos/exception/RootCause.java
+++ b/src/main/java/org/cactoos/exception/RootCause.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2024 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.exception;
+
+import java.util.Iterator;
+import org.cactoos.Scalar;
+import org.cactoos.iterator.IteratorOfStackTrace;
+import org.cactoos.iterator.TailOf;
+
+/**
+ * Return root cause exception.
+ *
+ * <p>There is no thread-safety guarantee.
+ *
+ * @since 0.56
+ */
+public final class RootCause implements Scalar<Throwable> {
+
+    /**
+     * Iterator for exceptions.
+     */
+    private final Scalar<Iterator<Throwable>> itr;
+
+    /**
+     * Ctor.
+     * @param exc The exception to iterate.
+     */
+    public RootCause(final Throwable exc) {
+        this(new IteratorOfStackTrace(exc));
+    }
+
+    /**
+     * Ctor.
+     * @param iter The exception Iterator.
+     */
+    public RootCause(final Iterator<Throwable> iter) {
+        this(() -> new TailOf<>(1, iter));
+    }
+
+    /**
+     * Ctor.
+     * @param itr Decorated iterator.
+     */
+    public RootCause(final Scalar<Iterator<Throwable>> itr) {
+        this.itr = itr;
+    }
+
+    @Override
+    public Throwable value() throws Exception {
+        return this.itr.value().next();
+    }
+}

--- a/src/main/java/org/cactoos/exception/package-info.java
+++ b/src/main/java/org/cactoos/exception/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2024 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Exceptions.
+ *
+ * @since 0.56
+ */
+package org.cactoos.exception;

--- a/src/main/java/org/cactoos/iterable/IterableOfStackTrace.java
+++ b/src/main/java/org/cactoos/iterable/IterableOfStackTrace.java
@@ -1,0 +1,44 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2024 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.iterable;
+
+import org.cactoos.iterator.IteratorOfStackTrace;
+
+/**
+ * Iterable of exception.
+ *
+ * <p>There is no thread-safety guarantee.
+ *
+ * @since 0.56
+ */
+public final class IterableOfStackTrace extends IterableEnvelope<Throwable> {
+
+    /**
+     * Ctor.
+     * @param exc The exception to iterate.
+     */
+    public IterableOfStackTrace(final Throwable exc) {
+        super(new IterableOf<>(() -> new IteratorOfStackTrace(exc)));
+    }
+}

--- a/src/main/java/org/cactoos/iterator/IteratorOfStackTrace.java
+++ b/src/main/java/org/cactoos/iterator/IteratorOfStackTrace.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2024 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.iterator;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * {@link Iterator} that returns an exception from the exception stack trace.
+ *
+ * <p>There is no thread-safety guarantee.</p>
+ *
+ * @since 0.56
+ */
+public final class IteratorOfStackTrace implements Iterator<Throwable> {
+
+    /**
+     * The exception to iterate.
+     */
+    private Throwable exception;
+
+    /**
+     * Ctor.
+     * @param exc The exception to iterate.
+     */
+    public IteratorOfStackTrace(final Throwable exc) {
+        this.exception = exc;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return this.exception.getCause() != null;
+    }
+
+    @Override
+    public Throwable next() {
+        if (this.hasNext()) {
+            this.exception = this.exception.getCause();
+            return this.exception;
+        }
+        throw new NoSuchElementException("The iterator doesn't have item");
+    }
+}

--- a/src/test/java/org/cactoos/exception/RootCauseTest.java
+++ b/src/test/java/org/cactoos/exception/RootCauseTest.java
@@ -1,0 +1,47 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2024 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.exception;
+
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+
+/**
+ * Test Case for {@link RootCause}.
+ *
+ * @since 0.56
+ */
+final class RootCauseTest {
+
+    @Test
+    void rootCauseTest() throws Exception {
+        final Throwable inner = new Throwable();
+        final RootCause exc = new RootCause(new Throwable(new Throwable(inner)));
+        new Assertion<>(
+            "Should return inner exception.",
+            exc.value(),
+            new IsEqual<>(inner)
+        ).affirm();
+    }
+}

--- a/src/test/java/org/cactoos/exception/package-info.java
+++ b/src/test/java/org/cactoos/exception/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2024 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Exception, test.
+ *
+ * @since 0.56
+ */
+package org.cactoos.exception;

--- a/src/test/java/org/cactoos/iterable/IterableOfStackTraceTest.java
+++ b/src/test/java/org/cactoos/iterable/IterableOfStackTraceTest.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2024 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.iterable;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+
+/**
+ * Test Case for {@link IterableOfStackTrace}.
+ * @since 0.56
+ */
+final class IterableOfStackTraceTest {
+
+    @Test
+    void exceptionIterableTest() {
+        final Throwable expected = new Throwable();
+        new Assertion<>(
+            "Must get the expected exception.",
+            new IterableOfStackTrace(new Throwable(expected)),
+            Matchers.hasItem(expected)
+        ).affirm();
+    }
+}

--- a/src/test/java/org/cactoos/iterator/IteratorOfStackTraceTest.java
+++ b/src/test/java/org/cactoos/iterator/IteratorOfStackTraceTest.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2024 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.iterator;
+
+import java.util.NoSuchElementException;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.IsTrue;
+import org.llorllale.cactoos.matchers.Throws;
+
+/**
+ * Test Case for {@link StackTraceIterator}.
+ *
+ * @since 0.56
+ */
+final class IteratorOfStackTraceTest {
+    @Test
+    void iteratorOfStackTraceTest() {
+        final Throwable inner = new Throwable();
+        final IteratorOfStackTrace iter =  new IteratorOfStackTrace(new Throwable(inner));
+        new Assertion<>(
+            "First call 'hasNext' should return true.",
+            iter.hasNext(),
+            new IsTrue()
+        ).affirm();
+        new Assertion<>(
+            "First call 'next' should return inner exception.",
+            iter.next(),
+            new IsEqual<>(inner)
+        ).affirm();
+        new Assertion<>(
+            "Second call 'hasNext' should return false.",
+            iter.hasNext(),
+            new IsEqual<>(false)
+        ).affirm();
+        new Assertion<>(
+            "Third call 'next' should throw NSEE.",
+            () -> iter.next(),
+            new Throws<Throwable>(NoSuchElementException.class)
+        ).affirm();
+    }
+}


### PR DESCRIPTION
@yegor256 Please review.
Implementation of 
https://github.com/yegor256/cactoos/issues/1715
Missing analog for ExceptionUtils:

The most useful thing to get rootCause Exception.
https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/exception/ExceptionUtils.html