### PR TITLE
 Adding an OOP analogue for StringUtils.splitPreserveAllTokens ISSUE #1722

### DIFF
--- a/src/main/java/org/cactoos/TriFunc.java
+++ b/src/main/java/org/cactoos/TriFunc.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2024 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos;
+
+/**
+ * Function that accepts two arguments.
+ *
+ * <p>If you don't want to have any checked exceptions being thrown
+ * out of your {@link BiFunc}, you can use
+ * {@link org.cactoos.func.UncheckedBiFunc} decorator. Also
+ * you may try {@link org.cactoos.func.IoCheckedBiFunc}.</p>
+ *
+ * <p>There is no thread-safety guarantee.
+ *
+ * @param <X> Type of input
+ * @param <Y> Type of input
+ * @param <Z> Type of input
+ * @param <W> Type of output
+ */
+@FunctionalInterface
+public interface TriFunc<X, Y, Z, W> {
+
+    /**
+     * Apply it.
+     * @param first The first argument
+     * @param second The second argument
+     * @param third The third argument
+     * @return The result
+     * @throws Exception If fails
+     */
+    W apply(X first, Y second, Z third) throws Exception;
+}

--- a/src/main/java/org/cactoos/func/BiFuncSplitPreserve.java
+++ b/src/main/java/org/cactoos/func/BiFuncSplitPreserve.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2024 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package org.cactoos.func;
 
 import org.cactoos.BiFunc;

--- a/src/main/java/org/cactoos/func/BiFuncSplitPreserve.java
+++ b/src/main/java/org/cactoos/func/BiFuncSplitPreserve.java
@@ -1,0 +1,25 @@
+package org.cactoos.func;
+
+import org.cactoos.BiFunc;
+import org.cactoos.list.ListOf;
+
+import java.util.Collection;
+
+public class BiFuncSplitPreserve implements BiFunc<String, String, Collection<String>> {
+    @Override
+    public Collection<String> apply(String str, String regex) throws Exception {
+        ListOf<String> ret = new ListOf<>();
+        int start = 0;
+        int pos = str.indexOf(regex);
+        while (pos >= start) {
+            ret.add(str.substring(start, pos));
+            start = pos + regex.length();
+            pos = str.indexOf(regex, start);
+        }
+        if (start < str.length())
+            ret.add(str.substring(start));
+        else if (start == str.length())
+            ret.add("");
+        return ret;
+    }
+}

--- a/src/main/java/org/cactoos/func/BiFuncSplitPreserve.java
+++ b/src/main/java/org/cactoos/func/BiFuncSplitPreserve.java
@@ -31,7 +31,7 @@ import java.util.Collection;
 
 public class BiFuncSplitPreserve implements BiFunc<String, String, Collection<String>> {
     @Override
-    public Collection<String> apply(String str, String regex) throws Exception {
+    public Collection<String> apply(final String str, final String regex) throws Exception {
         ListOf<String> ret = new ListOf<>();
         int start = 0;
         int pos = str.indexOf(regex);

--- a/src/main/java/org/cactoos/func/TriFuncSplitPreserve.java
+++ b/src/main/java/org/cactoos/func/TriFuncSplitPreserve.java
@@ -29,7 +29,17 @@ import org.cactoos.TriFunc;
 import org.cactoos.list.ListOf;
 
 /**
- * Used for avoiding static method calls.
+ * A String splitter preserving all tokens.
+ * Unlike regular Split, stores empty "" tokens
+ * created by adjacent regex separators.
+ *
+ * <p>
+ *     Examples:
+ *     1) text - " hello there", regex - " "
+ *     result: ["", "hello", "there", ""]
+ *     2) text - "aaa", regex - "a"
+ *     result: ["", "", "", ""]
+ * </p>
  *
  * @since 0.0
  */
@@ -46,14 +56,14 @@ public final class TriFuncSplitPreserve
         int start = 0;
         int pos = str.indexOf(regex);
         while (pos >= start) {
-            if (lmt > 0 && ret.size() == lmt) {
+            if (lmt > 0 && ret.size() == lmt || regex.isEmpty()) {
                 break;
             }
             ret.add(str.substring(start, pos));
             start = pos + regex.length();
             pos = str.indexOf(regex, start);
         }
-        if (lmt <= 0 || ret.size() < lmt) {
+        if (lmt <= 0 || ret.size() < lmt || regex.isEmpty()) {
             if (start < str.length()) {
                 ret.add(str.substring(start));
             } else if (start == str.length()) {

--- a/src/main/java/org/cactoos/func/TriFuncSplitPreserve.java
+++ b/src/main/java/org/cactoos/func/TriFuncSplitPreserve.java
@@ -35,7 +35,7 @@ import org.cactoos.list.ListOf;
  *
  * <p>
  *     Examples:
- *     1) text - " hello there", regex - " "
+ *     1) text - " hello there ", regex - " "
  *     result: ["", "hello", "there", ""]
  *     2) text - "aaa", regex - "a"
  *     result: ["", "", "", ""]

--- a/src/main/java/org/cactoos/func/TriFuncSplitPreserve.java
+++ b/src/main/java/org/cactoos/func/TriFuncSplitPreserve.java
@@ -24,26 +24,40 @@
 
 package org.cactoos.func;
 
-import org.cactoos.BiFunc;
+import org.cactoos.TriFunc;
 import org.cactoos.list.ListOf;
-
 import java.util.Collection;
 
-public class BiFuncSplitPreserve implements BiFunc<String, String, Collection<String>> {
+/**
+ * Used for avoiding static method calls.
+ */
+public final class TriFuncSplitPreserve
+        implements TriFunc
+    <String, String, Integer, Collection<String>> {
     @Override
-    public Collection<String> apply(final String str, final String regex) throws Exception {
-        ListOf<String> ret = new ListOf<>();
+    public Collection<String> apply(
+        final String str,
+        final String regex,
+        final Integer lmt
+    ) {
+        final ListOf<String> ret = new ListOf<>();
         int start = 0;
         int pos = str.indexOf(regex);
         while (pos >= start) {
+            if (lmt > 0 && ret.size() == lmt) {
+                break;
+            }
             ret.add(str.substring(start, pos));
             start = pos + regex.length();
             pos = str.indexOf(regex, start);
         }
-        if (start < str.length())
-            ret.add(str.substring(start));
-        else if (start == str.length())
-            ret.add("");
+        if (lmt <= 0 || ret.size() < lmt) {
+            if (start < str.length()) {
+                ret.add(str.substring(start));
+            } else if (start == str.length()) {
+                ret.add("");
+            }
+        }
         return ret;
     }
 }

--- a/src/main/java/org/cactoos/text/SplitPreserveAllTokens.java
+++ b/src/main/java/org/cactoos/text/SplitPreserveAllTokens.java
@@ -1,0 +1,181 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2024 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cactoos.text;
+
+import org.cactoos.Text;
+import org.cactoos.func.BiFuncSplitPreserve;
+import org.cactoos.iterable.IterableEnvelope;
+import org.cactoos.iterable.IterableOf;
+import org.cactoos.iterable.Mapped;
+import org.cactoos.iterator.IteratorOf;
+
+/**
+ * Splits the Text into an array, including empty
+ * tokens created by adjacent separators.
+ *
+ * @see String#split(String)
+ * @see String#split(String, int)
+ * @since 0.9
+ */
+public final class SplitPreserveAllTokens extends IterableEnvelope<Text> {
+    /**
+     * Ctor.
+     *
+     * @param text The text
+     * @see String#split(String)
+     */
+    public SplitPreserveAllTokens(final CharSequence text) {
+        this(new TextOf(text), new TextOf(" "));
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param text The text
+     * @see String#split(String)
+     */
+    public SplitPreserveAllTokens(final Text text) {
+        this(text, new TextOf(" "));
+    }
+    /**
+     * Ctor.
+     *
+     * @param text The text
+     * @param lmt The limit
+     * @see String#split(String, int)
+     */
+    public SplitPreserveAllTokens(final CharSequence text, final int lmt) {
+        this(new TextOf(text), new TextOf(" "), lmt);
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param text The text
+     * @param lmt The limit
+     * @see String#split(String, int)
+     */
+    public SplitPreserveAllTokens(final Text text, final int lmt) {
+        this(text, new TextOf(" "), lmt);
+    }
+    /**
+     * Ctor.
+     *
+     * @param text The text
+     * @param rgx The regex
+     * @see String#split(String)
+     */
+    public SplitPreserveAllTokens(final CharSequence text, final CharSequence rgx) {
+        this(new TextOf(text), new TextOf(rgx));
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param text The text
+     * @param rgx The regex
+     * @param lmt The limit
+     * @see String#split(String, int)
+     */
+    public SplitPreserveAllTokens(final CharSequence text, final CharSequence rgx, final int lmt) {
+        this(new TextOf(text), new TextOf(rgx), lmt);
+    }
+
+    /**
+     * Ctor.
+     * @param text The text
+     * @param rgx The regex
+     * @see String#split(String)
+     */
+    public SplitPreserveAllTokens(final CharSequence text, final Text rgx) {
+        this(new TextOf(text), rgx);
+    }
+
+    /**
+     * Ctor.
+     * @param text The text
+     * @param rgx The regex
+     * @param lmt The limit
+     * @see String#split(String, int)
+     */
+    public SplitPreserveAllTokens(final CharSequence text, final Text rgx, final int lmt) {
+        this(new TextOf(text), rgx, lmt);
+    }
+
+    /**
+     * Ctor.
+     * @param text The text
+     * @param rgx The regex
+     * @see String#split(String)
+     */
+    public SplitPreserveAllTokens(final Text text, final CharSequence rgx) {
+        this(text, new TextOf(rgx));
+    }
+
+    /**
+     * Ctor.
+     * @param text The text
+     * @param rgx The regex
+     * @param lmt The limit
+     * @see String#split(String, int)
+     */
+    public SplitPreserveAllTokens(final Text text, final CharSequence rgx, final int lmt) {
+        this(text, new TextOf(rgx), lmt);
+    }
+
+    /**
+     * Ctor.
+     * @param text The text
+     * @param rgx The regex
+     * @see String#split(String)
+     */
+    public SplitPreserveAllTokens(final Text text, final Text rgx) {
+        this(text, rgx, 0);
+    }
+
+    /**
+     * Ctor.
+     * @param text The text
+     * @param rgx The regex
+     * @param lmt The limit
+     * @see String#split(String, int)
+     */
+    public SplitPreserveAllTokens(
+            final Text text, final Text rgx, final int lmt
+    ) {
+        super(
+                new Mapped<>(
+                        TextOf::new,
+                        new IterableOf<>(
+                                () -> new IteratorOf<>(
+                                        new BiFuncSplitPreserve()
+                                                .apply(text.toString(),
+                                                        rgx.toString())
+                                                .toArray(new String[0]))
+                        )
+                )
+        );
+    }
+
+}

--- a/src/main/java/org/cactoos/text/SplitPreserveAllTokens.java
+++ b/src/main/java/org/cactoos/text/SplitPreserveAllTokens.java
@@ -45,6 +45,7 @@ public final class SplitPreserveAllTokens extends IterableEnvelope<Text> {
      * @param text The text
      * @see String#split(String)
      */
+
     public SplitPreserveAllTokens(final CharSequence text) {
         this(new TextOf(text), new TextOf(" "));
     }
@@ -58,6 +59,7 @@ public final class SplitPreserveAllTokens extends IterableEnvelope<Text> {
     public SplitPreserveAllTokens(final Text text) {
         this(text, new TextOf(" "));
     }
+
     /**
      * Ctor.
      *
@@ -65,6 +67,7 @@ public final class SplitPreserveAllTokens extends IterableEnvelope<Text> {
      * @param lmt The limit
      * @see String#split(String, int)
      */
+
     public SplitPreserveAllTokens(final CharSequence text, final int lmt) {
         this(new TextOf(text), new TextOf(" "), lmt);
     }
@@ -76,9 +79,11 @@ public final class SplitPreserveAllTokens extends IterableEnvelope<Text> {
      * @param lmt The limit
      * @see String#split(String, int)
      */
+
     public SplitPreserveAllTokens(final Text text, final int lmt) {
         this(text, new TextOf(" "), lmt);
     }
+
     /**
      * Ctor.
      *
@@ -86,6 +91,7 @@ public final class SplitPreserveAllTokens extends IterableEnvelope<Text> {
      * @param rgx The regex
      * @see String#split(String)
      */
+
     public SplitPreserveAllTokens(final CharSequence text, final CharSequence rgx) {
         this(new TextOf(text), new TextOf(rgx));
     }
@@ -98,6 +104,7 @@ public final class SplitPreserveAllTokens extends IterableEnvelope<Text> {
      * @param lmt The limit
      * @see String#split(String, int)
      */
+
     public SplitPreserveAllTokens(final CharSequence text, final CharSequence rgx, final int lmt) {
         this(new TextOf(text), new TextOf(rgx), lmt);
     }
@@ -108,6 +115,7 @@ public final class SplitPreserveAllTokens extends IterableEnvelope<Text> {
      * @param rgx The regex
      * @see String#split(String)
      */
+
     public SplitPreserveAllTokens(final CharSequence text, final Text rgx) {
         this(new TextOf(text), rgx);
     }
@@ -119,6 +127,7 @@ public final class SplitPreserveAllTokens extends IterableEnvelope<Text> {
      * @param lmt The limit
      * @see String#split(String, int)
      */
+
     public SplitPreserveAllTokens(final CharSequence text, final Text rgx, final int lmt) {
         this(new TextOf(text), rgx, lmt);
     }
@@ -129,6 +138,7 @@ public final class SplitPreserveAllTokens extends IterableEnvelope<Text> {
      * @param rgx The regex
      * @see String#split(String)
      */
+
     public SplitPreserveAllTokens(final Text text, final CharSequence rgx) {
         this(text, new TextOf(rgx));
     }
@@ -140,6 +150,7 @@ public final class SplitPreserveAllTokens extends IterableEnvelope<Text> {
      * @param lmt The limit
      * @see String#split(String, int)
      */
+
     public SplitPreserveAllTokens(final Text text, final CharSequence rgx, final int lmt) {
         this(text, new TextOf(rgx), lmt);
     }
@@ -150,6 +161,7 @@ public final class SplitPreserveAllTokens extends IterableEnvelope<Text> {
      * @param rgx The regex
      * @see String#split(String)
      */
+
     public SplitPreserveAllTokens(final Text text, final Text rgx) {
         this(text, rgx, 0);
     }
@@ -161,6 +173,7 @@ public final class SplitPreserveAllTokens extends IterableEnvelope<Text> {
      * @param lmt The limit
      * @see String#split(String, int)
      */
+
     public SplitPreserveAllTokens(
             final Text text, final Text rgx, final int lmt
     ) {

--- a/src/main/java/org/cactoos/text/SplitPreserveAllTokens.java
+++ b/src/main/java/org/cactoos/text/SplitPreserveAllTokens.java
@@ -24,7 +24,7 @@
 package org.cactoos.text;
 
 import org.cactoos.Text;
-import org.cactoos.func.BiFuncSplitPreserve;
+import org.cactoos.func.TriFuncSplitPreserve;
 import org.cactoos.iterable.IterableEnvelope;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.Mapped;
@@ -34,8 +34,6 @@ import org.cactoos.iterator.IteratorOf;
  * Splits the Text into an array, including empty
  * tokens created by adjacent separators.
  *
- * @see String#split(String)
- * @see String#split(String, int)
  * @since 0.9
  */
 public final class SplitPreserveAllTokens extends IterableEnvelope<Text> {
@@ -43,9 +41,7 @@ public final class SplitPreserveAllTokens extends IterableEnvelope<Text> {
      * Ctor.
      *
      * @param text The text
-     * @see String#split(String)
      */
-
     public SplitPreserveAllTokens(final CharSequence text) {
         this(new TextOf(text), new TextOf(" "));
     }
@@ -54,7 +50,6 @@ public final class SplitPreserveAllTokens extends IterableEnvelope<Text> {
      * Ctor.
      *
      * @param text The text
-     * @see String#split(String)
      */
     public SplitPreserveAllTokens(final Text text) {
         this(text, new TextOf(" "));
@@ -65,9 +60,7 @@ public final class SplitPreserveAllTokens extends IterableEnvelope<Text> {
      *
      * @param text The text
      * @param lmt The limit
-     * @see String#split(String, int)
      */
-
     public SplitPreserveAllTokens(final CharSequence text, final int lmt) {
         this(new TextOf(text), new TextOf(" "), lmt);
     }
@@ -77,9 +70,7 @@ public final class SplitPreserveAllTokens extends IterableEnvelope<Text> {
      *
      * @param text The text
      * @param lmt The limit
-     * @see String#split(String, int)
      */
-
     public SplitPreserveAllTokens(final Text text, final int lmt) {
         this(text, new TextOf(" "), lmt);
     }
@@ -89,9 +80,7 @@ public final class SplitPreserveAllTokens extends IterableEnvelope<Text> {
      *
      * @param text The text
      * @param rgx The regex
-     * @see String#split(String)
      */
-
     public SplitPreserveAllTokens(final CharSequence text, final CharSequence rgx) {
         this(new TextOf(text), new TextOf(rgx));
     }
@@ -102,93 +91,89 @@ public final class SplitPreserveAllTokens extends IterableEnvelope<Text> {
      * @param text The text
      * @param rgx The regex
      * @param lmt The limit
-     * @see String#split(String, int)
      */
-
     public SplitPreserveAllTokens(final CharSequence text, final CharSequence rgx, final int lmt) {
         this(new TextOf(text), new TextOf(rgx), lmt);
     }
 
     /**
      * Ctor.
+     *
      * @param text The text
      * @param rgx The regex
-     * @see String#split(String)
      */
-
     public SplitPreserveAllTokens(final CharSequence text, final Text rgx) {
         this(new TextOf(text), rgx);
     }
 
     /**
      * Ctor.
+     *
      * @param text The text
      * @param rgx The regex
      * @param lmt The limit
-     * @see String#split(String, int)
      */
-
     public SplitPreserveAllTokens(final CharSequence text, final Text rgx, final int lmt) {
         this(new TextOf(text), rgx, lmt);
     }
 
     /**
      * Ctor.
+     *
      * @param text The text
      * @param rgx The regex
-     * @see String#split(String)
      */
-
     public SplitPreserveAllTokens(final Text text, final CharSequence rgx) {
         this(text, new TextOf(rgx));
     }
 
     /**
      * Ctor.
+     *
      * @param text The text
      * @param rgx The regex
      * @param lmt The limit
-     * @see String#split(String, int)
      */
-
     public SplitPreserveAllTokens(final Text text, final CharSequence rgx, final int lmt) {
         this(text, new TextOf(rgx), lmt);
     }
 
     /**
      * Ctor.
+     *
      * @param text The text
      * @param rgx The regex
-     * @see String#split(String)
      */
-
     public SplitPreserveAllTokens(final Text text, final Text rgx) {
         this(text, rgx, 0);
     }
 
     /**
      * Ctor.
+     *
      * @param text The text
      * @param rgx The regex
      * @param lmt The limit
-     * @see String#split(String, int)
      */
-
     public SplitPreserveAllTokens(
-            final Text text, final Text rgx, final int lmt
+        final Text text,
+        final Text rgx,
+        final int lmt
     ) {
         super(
-                new Mapped<>(
-                        TextOf::new,
-                        new IterableOf<>(
-                                () -> new IteratorOf<>(
-                                        new BiFuncSplitPreserve()
-                                                .apply(text.toString(),
-                                                        rgx.toString())
-                                                .toArray(new String[0]))
-                        )
+            new Mapped<>(
+                TextOf::new,
+                new IterableOf<>(
+                    () -> new IteratorOf<>(
+                        new TriFuncSplitPreserve()
+                            .apply(
+                                text.toString(),
+                                rgx.toString(),
+                                lmt
+                            ).toArray(new String[0])
+                    )
                 )
+            )
         );
     }
-
 }

--- a/src/test/java/org/cactoos/text/SplitPreserveTest.java
+++ b/src/test/java/org/cactoos/text/SplitPreserveTest.java
@@ -42,7 +42,7 @@ import org.llorllale.cactoos.matchers.Assertion;
 final class SplitPreserveTest {
     @Test
     void checkingSplit() {
-        String txt = "   ";
+        String txt = "aaa";
         final String msg = "Adjacent separators must create an empty element";
         ArrayList<Text> array = new ArrayList<>(4);
         array.add(new TextOf(""));
@@ -54,7 +54,7 @@ final class SplitPreserveTest {
             this.getLength(
                 new Split(
                     new TextOf(txt),
-                    new TextOf(" ")
+                    new TextOf("a")
                 ).iterator()
             ),
             IsNot.not(
@@ -103,7 +103,7 @@ final class SplitPreserveTest {
 
     @Test
     void checkingSplitPreserveTokens() {
-        String txt = "   ";
+        String txt = "aaa";
         final String msg = "Adjacent separators must create an empty element";
         ArrayList<Text> array = new ArrayList<>(4);
         array.add(new TextOf(""));
@@ -115,7 +115,7 @@ final class SplitPreserveTest {
             this.getLength(
                 new SplitPreserveAllTokens(
                     new TextOf(txt),
-                    new TextOf(" ")
+                    new TextOf("a")
                 ).iterator()
             ),
             Matchers.equalTo(

--- a/src/test/java/org/cactoos/text/SplitPreserveTest.java
+++ b/src/test/java/org/cactoos/text/SplitPreserveTest.java
@@ -30,85 +30,138 @@ import org.hamcrest.Matchers;
 import org.hamcrest.core.IsNot;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
-
 import java.util.ArrayList;
 import java.util.Iterator;
 
-public class SplitPreserveTest {
+final class SplitPreserveTest {
     @Test
-    void checkingSplit() throws Exception {
+    void checkingSplit() {
         String txt = "   ";
-        ArrayList<Text> array = new ArrayList<>();
+        final String msg = "Adjacent separators must create an empty element";
+        ArrayList<Text> array = new ArrayList<>(4);
         array.add(new TextOf(""));
         array.add(new TextOf(""));
         array.add(new TextOf(""));
         array.add(new TextOf(""));
         new Assertion<>(
-                "Adjacent separators must create an empty element",
-                getLength(new Split(new TextOf(txt), new TextOf(" ")).iterator()),
-                IsNot.not(Matchers.equalTo(getLength(new IterableOf<Text>(array.iterator()).iterator())))
+            msg,
+            this.getLength(
+                new Split(
+                    new TextOf(txt),
+                    new TextOf(" ")
+                ).iterator()
+            ),
+            IsNot.not(
+                Matchers.equalTo(
+                    this.getLength(
+                        new IterableOf<Text>(
+                            array.iterator()
+                        ).iterator()
+                    )
+                )
+            )
         ).affirm();
-
         txt = " how ";
-        array = new ArrayList<>();
+        array = new ArrayList<>(3);
         array.add(new TextOf(""));
         array.add(new TextOf("how"));
         array.add(new TextOf(""));
-
         new Assertion<>(
-                "Adjacent separators must create an empty element",
-                getLength(new Split(new TextOf(txt), new TextOf(" ")).iterator()),
-                IsNot.not(Matchers.equalTo(getLength(new IterableOf<Text>(array.iterator()).iterator())))
+            msg,
+            this.getLength(
+                new Split(
+                    new TextOf(txt),
+                    new TextOf(" ")
+                ).iterator()
+            ),
+            IsNot.not(
+                Matchers.equalTo(
+                    this.getLength(
+                        new IterableOf<Text>(
+                            array.iterator()
+                        ).iterator()
+                    )
+                )
+            )
         ).affirm();
     }
 
-    int getLength(Iterator<Text> iter) {
+    int getLength(final Iterator<Text> iter) {
         int count = 0;
         while (iter.hasNext()) {
             iter.next();
-            count++;
+            count += 1;
         }
         return count;
     }
 
     @Test
-    void checkingSplitPreserveTokens() throws Exception {
+    void checkingSplitPreserveTokens() {
         String txt = "   ";
-        ArrayList<Text> array = new ArrayList<>();
+        final String msg = "Adjacent separators must create an empty element";
+        ArrayList<Text> array = new ArrayList<>(4);
         array.add(new TextOf(""));
         array.add(new TextOf(""));
         array.add(new TextOf(""));
         array.add(new TextOf(""));
-
         new Assertion<>(
-                "Adjacent separators must create an empty element",
-                getLength(new SplitPreserveAllTokens(new TextOf(txt), new TextOf(" ")).iterator()),
-                Matchers.equalTo(getLength(new IterableOf<Text>(array.iterator()).iterator()))
+            msg,
+            this.getLength(
+                new SplitPreserveAllTokens(
+                    new TextOf(txt),
+                    new TextOf(" ")
+                ).iterator()
+            ),
+            Matchers.equalTo(
+                this.getLength(
+                    new IterableOf<Text>(
+                        array.iterator()
+                    ).iterator()
+                )
+            )
         ).affirm();
-
         txt = "lol\\  / dude";
-        array = new ArrayList<>();
+        array = new ArrayList<>(4);
         array.add(new TextOf("lol\\"));
         array.add(new TextOf(""));
         array.add(new TextOf("/"));
         array.add(new TextOf("dude"));
-
         new Assertion<>(
-                "Adjacent separators must create an empty element",
-                getLength(new SplitPreserveAllTokens(new TextOf(txt), new TextOf(" ")).iterator()),
-                Matchers.equalTo(getLength(new IterableOf<Text>(array.iterator()).iterator()))
+            msg,
+            this.getLength(
+                new SplitPreserveAllTokens(
+                    new TextOf(txt),
+                    new TextOf(" ")
+                ).iterator()
+            ),
+            Matchers.equalTo(
+                this.getLength(
+                    new IterableOf<Text>(
+                        array.iterator()
+                    ).iterator()
+                )
+            )
         ).affirm();
-
         txt = " how ";
-        array = new ArrayList<>();
+        array = new ArrayList<>(3);
         array.add(new TextOf(""));
         array.add(new TextOf("how"));
         array.add(new TextOf(""));
-
         new Assertion<>(
-                "Adjacent separators must create an empty element",
-                getLength(new SplitPreserveAllTokens(new TextOf(txt), new TextOf(" ")).iterator()),
-                Matchers.equalTo(getLength(new IterableOf<Text>(array.iterator()).iterator()))
+            msg,
+            this.getLength(
+                new SplitPreserveAllTokens(
+                    new TextOf(txt),
+                    new TextOf(" ")
+                ).iterator()
+            ),
+            Matchers.equalTo(
+                this.getLength(
+                    new IterableOf<Text>(
+                        array.iterator()
+                    ).iterator()
+                )
+            )
         ).affirm();
     }
 }

--- a/src/test/java/org/cactoos/text/SplitPreserveTest.java
+++ b/src/test/java/org/cactoos/text/SplitPreserveTest.java
@@ -1,0 +1,90 @@
+package org.cactoos.text;
+
+import org.cactoos.Text;
+import org.cactoos.iterable.IterableOf;
+import org.hamcrest.Matchers;
+import org.hamcrest.core.IsNot;
+import org.junit.jupiter.api.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+
+public class SplitPreserveTest {
+    @Test
+    void checkingSplit() throws Exception {
+        String txt = "   ";
+        ArrayList<Text> array = new ArrayList<>();
+        array.add(new TextOf(""));
+        array.add(new TextOf(""));
+        array.add(new TextOf(""));
+        array.add(new TextOf(""));
+        new Assertion<>(
+                "Adjacent separators must create an empty element",
+                getLength(new Split(new TextOf(txt), new TextOf(" ")).iterator()),
+                IsNot.not(Matchers.equalTo(getLength(new IterableOf<Text>(array.iterator()).iterator())))
+        ).affirm();
+
+        txt = " how ";
+        array = new ArrayList<>();
+        array.add(new TextOf(""));
+        array.add(new TextOf("how"));
+        array.add(new TextOf(""));
+
+        new Assertion<>(
+                "Adjacent separators must create an empty element",
+                getLength(new Split(new TextOf(txt), new TextOf(" ")).iterator()),
+                IsNot.not(Matchers.equalTo(getLength(new IterableOf<Text>(array.iterator()).iterator())))
+        ).affirm();
+    }
+
+    int getLength(Iterator<Text> iter) {
+        int count = 0;
+        while (iter.hasNext()) {
+            iter.next();
+            count++;
+        }
+        return count;
+    }
+
+    @Test
+    void checkingSplitPreserveTokens() throws Exception {
+        String txt = "   ";
+        ArrayList<Text> array = new ArrayList<>();
+        array.add(new TextOf(""));
+        array.add(new TextOf(""));
+        array.add(new TextOf(""));
+        array.add(new TextOf(""));
+
+        new Assertion<>(
+                "Adjacent separators must create an empty element",
+                getLength(new SplitPreserveAllTokens(new TextOf(txt), new TextOf(" ")).iterator()),
+                Matchers.equalTo(getLength(new IterableOf<Text>(array.iterator()).iterator()))
+        ).affirm();
+
+        txt = "lol\\  / dude";
+        array = new ArrayList<>();
+        array.add(new TextOf("lol\\"));
+        array.add(new TextOf(""));
+        array.add(new TextOf("/"));
+        array.add(new TextOf("dude"));
+
+        new Assertion<>(
+                "Adjacent separators must create an empty element",
+                getLength(new SplitPreserveAllTokens(new TextOf(txt), new TextOf(" ")).iterator()),
+                Matchers.equalTo(getLength(new IterableOf<Text>(array.iterator()).iterator()))
+        ).affirm();
+
+        txt = " how ";
+        array = new ArrayList<>();
+        array.add(new TextOf(""));
+        array.add(new TextOf("how"));
+        array.add(new TextOf(""));
+
+        new Assertion<>(
+                "Adjacent separators must create an empty element",
+                getLength(new SplitPreserveAllTokens(new TextOf(txt), new TextOf(" ")).iterator()),
+                Matchers.equalTo(getLength(new IterableOf<Text>(array.iterator()).iterator()))
+        ).affirm();
+    }
+}

--- a/src/test/java/org/cactoos/text/SplitPreserveTest.java
+++ b/src/test/java/org/cactoos/text/SplitPreserveTest.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2024 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package org.cactoos.text;
 
 import org.cactoos.Text;


### PR DESCRIPTION
Rationale of some decisions made:
1) Functional Interface allows use of custom String splitter function avoiding the static method calls
2) A new class created as modifying already existing Split class would not be shorter : if we add some checking for flags would create just as many constructors as with 2 distinct classes
3) Tests only compare lengths of obtained Collections