### PR TITLE
Improve JoinedListIterator code coverage

### DIFF
--- a/src/test/java/org/cactoos/list/JoinedListIteratorTest.java
+++ b/src/test/java/org/cactoos/list/JoinedListIteratorTest.java
@@ -123,4 +123,48 @@ final class JoinedListIteratorTest {
             new IsEqual<>(new IterableOf<>(1, 2, 3, 0))
         ).affirm();
     }
+
+    @Test
+    void nextIndexTest() {
+        final ListIterator<Integer> joined = new JoinedListIterator<>(
+            new ListOf<>(1).listIterator(),
+            new ListOf<>(2).listIterator(),
+            new ListOf<>(3).listIterator()
+        );
+        new Assertion<>(
+            "Must return index of the next element",
+            joined.nextIndex(),
+            new IsEqual<>(0)
+        ).affirm();
+        joined.next();
+        new Assertion<>(
+            "Must return index of the next element",
+            joined.nextIndex(),
+            new IsEqual<>(1)
+        ).affirm();
+    }
+
+    @Test
+    void previousIndexDoesntExistTest() {
+        new Assertion<>(
+            "Must return -1 if there is no previous item",
+            new JoinedListIterator<>(
+                new ListOf<>(1).listIterator(),
+                new ListOf<>(2).listIterator(),
+                new ListOf<>(3).listIterator()
+            ).previousIndex(),
+            new IsEqual<>(-1)
+        ).affirm();
+    }
+
+    @Test
+    void nextThrowsIfThereIsNoNext() {
+        new Assertion<>(
+            "Must throw error if there is no next element",
+            () -> new JoinedListIterator<>().next(),
+            new Throws<>(
+                NoSuchElementException.class
+            )
+        ).affirm();
+    }
 }


### PR DESCRIPTION
Added tests for the `JoinedListIterator` class.

One of the tests I wanted to add was the following:

```java
@Test  
void previousIndexTest() {  
	final ListIterator<Integer> joined = new JoinedListIterator<>(  
		new ListOf<>(1).listIterator(),  
		new ListOf<>(2).listIterator(),  
		new ListOf<>(3).listIterator()  
	);  
	joined.next();  
	new Assertion<>(  
		"Must return index of the previous element",  
		joined.previousIndex(),  
		new IsEqual<>(0)  
	).affirm();  
	joined.next();
	new Assertion<>(  
		"Must return index of the previous element",  
		joined.previousIndex(),  
		new IsEqual<>(1)  
	).affirm();  
}
```

Surprisingly, the test failed. Currently, the `previousIndex()` method returns `-1` for the first call and `0` for the second call, which contradicts the expected behavior. My suspision is that the implementation of `previousIndex` is incorrect.

```java
@Override  
public int previousIndex() {  
	int previousidx = -1;  
	if (this.hasPrevious()) {  
		previousidx = this.cursor.get() - 1;
	}  
	return previousidx;  
}
```

The line `previousidx = this.cursor.get() - 1` should likely be `previousidx = this.cursor.get()`.

If my suspicion is confirmed, I will fix the implementation of  `previousIndex()` and add the mentioned test to ensure the corrected behavior is validated.