### PR TITLE
Fix previousIndex method in JoinedListIterator

### DIFF
--- a/src/main/java/org/cactoos/list/JoinedListIterator.java
+++ b/src/main/java/org/cactoos/list/JoinedListIterator.java
@@ -143,7 +143,7 @@ public final class JoinedListIterator<T> implements ListIterator<T> {
     public int previousIndex() {
         int previousidx = -1;
         if (this.hasPrevious()) {
-            previousidx = this.cursor.get() - 1;
+            previousidx = this.cursor.get();
         }
         return previousidx;
     }

--- a/src/test/java/org/cactoos/list/JoinedListIteratorTest.java
+++ b/src/test/java/org/cactoos/list/JoinedListIteratorTest.java
@@ -167,4 +167,25 @@ final class JoinedListIteratorTest {
             )
         ).affirm();
     }
+
+    @Test
+    void previousIndexTest() {
+        final ListIterator<Integer> joined = new JoinedListIterator<>(
+            new ListOf<>(1).listIterator(),
+            new ListOf<>(2).listIterator(),
+            new ListOf<>(3).listIterator()
+        );
+        joined.next();
+        new Assertion<>(
+            "Must return index of the previous element",
+            joined.previousIndex(),
+            new IsEqual<>(0)
+        ).affirm();
+        joined.next();
+        new Assertion<>(
+            "Must return index of the previous element",
+            joined.previousIndex(),
+            new IsEqual<>(1)
+        ).affirm();
+    }
 }


### PR DESCRIPTION
Fixed an off by one error mentioned in #1762. Added test to ensure correct behavior.