### PR TITLE
Add Union class for set operations

### DIFF
--- a/src/main/java/org/cactoos/set/Union.java
+++ b/src/main/java/org/cactoos/set/Union.java
@@ -15,7 +15,7 @@ import org.cactoos.scalar.Unchecked;
  * <p>There is no thread-safety guarantee.</p>
  *
  * @param <T> Type of item
- * @since 1.0
+ * @since 0.58.0
  */
 public final class Union<T> extends SetEnvelope<T> {
 
@@ -23,7 +23,6 @@ public final class Union<T> extends SetEnvelope<T> {
      * Ctor.
      * @param first First set
      * @param second Second set
-     * @since 1.0
      */
     public Union(final Iterable<T> first, final Iterable<T> second) {
         super(
@@ -38,7 +37,6 @@ public final class Union<T> extends SetEnvelope<T> {
      * Ctor.
      * @param first First iterator
      * @param second Second iterator
-     * @since 1.0
      */
     public Union(final Iterator<T> first, final Iterator<T> second) {
         this(
@@ -51,7 +49,6 @@ public final class Union<T> extends SetEnvelope<T> {
      * Ctor.
      * @param first First iterable supplier
      * @param second Second iterable supplier
-     * @since 1.0
      */
     public Union(
         final Scalar<Iterable<T>> first,
@@ -67,7 +64,6 @@ public final class Union<T> extends SetEnvelope<T> {
      * Ctor.
      * @param first First set
      * @param second Second set
-     * @since 1.0
      */
     public Union(final SetOf<T> first, final SetOf<T> second) {
         super(computeUnion(first, second));
@@ -79,7 +75,6 @@ public final class Union<T> extends SetEnvelope<T> {
      * @param second The second set
      * @param <E> Type of elements
      * @return The union set (elements in either first or second)
-     * @since 1.0
      */
     private static <E> SetOf<E> computeUnion(
         final SetOf<E> first,

--- a/src/main/java/org/cactoos/set/Union.java
+++ b/src/main/java/org/cactoos/set/Union.java
@@ -15,7 +15,7 @@ import org.cactoos.scalar.Unchecked;
  * <p>There is no thread-safety guarantee.</p>
  *
  * @param <T> Type of item
- * @since 0.49
+ * @since 1.0
  */
 public final class Union<T> extends SetEnvelope<T> {
 
@@ -23,7 +23,7 @@ public final class Union<T> extends SetEnvelope<T> {
      * Ctor.
      * @param first First set
      * @param second Second set
-     * @since 0.49
+     * @since 1.0
      */
     public Union(final Iterable<T> first, final Iterable<T> second) {
         super(
@@ -38,7 +38,7 @@ public final class Union<T> extends SetEnvelope<T> {
      * Ctor.
      * @param first First iterator
      * @param second Second iterator
-     * @since 0.49
+     * @since 1.0
      */
     public Union(final Iterator<T> first, final Iterator<T> second) {
         this(
@@ -51,7 +51,7 @@ public final class Union<T> extends SetEnvelope<T> {
      * Ctor.
      * @param first First iterable supplier
      * @param second Second iterable supplier
-     * @since 0.49
+     * @since 1.0
      */
     public Union(
         final Scalar<Iterable<T>> first,
@@ -67,7 +67,7 @@ public final class Union<T> extends SetEnvelope<T> {
      * Ctor.
      * @param first First set
      * @param second Second set
-     * @since 0.49
+     * @since 1.0
      */
     public Union(final SetOf<T> first, final SetOf<T> second) {
         super(computeUnion(first, second));
@@ -79,7 +79,7 @@ public final class Union<T> extends SetEnvelope<T> {
      * @param second The second set
      * @param <E> Type of elements
      * @return The union set (elements in either first or second)
-     * @since 0.49
+     * @since 1.0
      */
     private static <E> SetOf<E> computeUnion(
         final SetOf<E> first,

--- a/src/main/java/org/cactoos/set/Union.java
+++ b/src/main/java/org/cactoos/set/Union.java
@@ -1,0 +1,92 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2017-2025 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package org.cactoos.set;
+
+import java.util.Iterator;
+import org.cactoos.Scalar;
+import org.cactoos.iterable.IterableOf;
+import org.cactoos.scalar.Unchecked;
+
+/**
+ * Set union.
+ *
+ * <p>There is no thread-safety guarantee.</p>
+ *
+ * @param <T> Type of item
+ * @since 0.49
+ */
+public final class Union<T> extends SetEnvelope<T> {
+
+    /**
+     * Ctor.
+     * @param first First set
+     * @param second Second set
+     * @since 0.49
+     */
+    public Union(final Iterable<T> first, final Iterable<T> second) {
+        super(
+            computeUnion(
+                new SetOf<>(first),
+                new SetOf<>(second)
+            )
+        );
+    }
+
+    /**
+     * Ctor.
+     * @param first First iterator
+     * @param second Second iterator
+     * @since 0.49
+     */
+    public Union(final Iterator<T> first, final Iterator<T> second) {
+        this(
+            new IterableOf<>(first),
+            new IterableOf<>(second)
+        );
+    }
+
+    /**
+     * Ctor.
+     * @param first First iterable supplier
+     * @param second Second iterable supplier
+     * @since 0.49
+     */
+    public Union(
+        final Scalar<Iterable<T>> first,
+        final Scalar<Iterable<T>> second
+    ) {
+        this(
+            new Unchecked<>(first).value(),
+            new Unchecked<>(second).value()
+        );
+    }
+
+    /**
+     * Ctor.
+     * @param first First set
+     * @param second Second set
+     * @since 0.49
+     */
+    public Union(final SetOf<T> first, final SetOf<T> second) {
+        super(computeUnion(first, second));
+    }
+
+    /**
+     * Compute the union of two sets.
+     * @param first The first set
+     * @param second The second set
+     * @param <E> Type of elements
+     * @return The union set (elements in either first or second)
+     * @since 0.49
+     */
+    private static <E> SetOf<E> computeUnion(
+        final SetOf<E> first,
+        final SetOf<E> second
+    ) {
+        final SetOf<E> result = new SetOf<>(first);
+        result.addAll(second);
+        return result;
+    }
+}

--- a/src/test/java/org/cactoos/set/UnionTest.java
+++ b/src/test/java/org/cactoos/set/UnionTest.java
@@ -15,13 +15,12 @@ import org.llorllale.cactoos.matchers.HasValues;
 /**
  * Test case for {@link Union}.
  *
- * @since 1.0
+ * @since 0.58.0
  */
 final class UnionTest {
 
     /**
      * Tests that set union can be computed correctly.
-     * @since 1.0
      */
     @Test
     void computesSetUnion() {
@@ -37,7 +36,6 @@ final class UnionTest {
 
     /**
      * Tests that set union with empty second set returns the first set.
-     * @since 1.0
      */
     @Test
     void computesSetUnionWithEmptySecondSet() {
@@ -53,7 +51,6 @@ final class UnionTest {
 
     /**
      * Tests that set union with empty first set returns the second set.
-     * @since 1.0
      */
     @Test
     void computesSetUnionWithEmptyFirstSet() {
@@ -69,7 +66,6 @@ final class UnionTest {
 
     /**
      * Tests that set union works with java.util.Set.
-     * @since 1.0
      */
     @Test
     void computesSetUnionWithJavaUtilSets() {
@@ -90,7 +86,6 @@ final class UnionTest {
 
     /**
      * Tests that set union works with iterables.
-     * @since 1.0
      */
     @Test
     void computesSetUnionWithIterables() {
@@ -106,7 +101,6 @@ final class UnionTest {
 
     /**
      * Tests that set union works with iterators.
-     * @since 1.0
      */
     @Test
     void computesSetUnionWithIterators() {
@@ -122,7 +116,6 @@ final class UnionTest {
 
     /**
      * Tests that set union with identical sets works correctly.
-     * @since 1.0
      */
     @Test
     void computesSetUnionWithIdenticalSets() {

--- a/src/test/java/org/cactoos/set/UnionTest.java
+++ b/src/test/java/org/cactoos/set/UnionTest.java
@@ -15,13 +15,13 @@ import org.llorllale.cactoos.matchers.HasValues;
 /**
  * Test case for {@link Union}.
  *
- * @since 0.49
+ * @since 1.0
  */
 final class UnionTest {
 
     /**
      * Tests that set union can be computed correctly.
-     * @since 0.49
+     * @since 1.0
      */
     @Test
     void computesSetUnion() {
@@ -37,7 +37,7 @@ final class UnionTest {
 
     /**
      * Tests that set union with empty second set returns the first set.
-     * @since 0.49
+     * @since 1.0
      */
     @Test
     void computesSetUnionWithEmptySecondSet() {
@@ -53,7 +53,7 @@ final class UnionTest {
 
     /**
      * Tests that set union with empty first set returns the second set.
-     * @since 0.49
+     * @since 1.0
      */
     @Test
     void computesSetUnionWithEmptyFirstSet() {
@@ -69,7 +69,7 @@ final class UnionTest {
 
     /**
      * Tests that set union works with java.util.Set.
-     * @since 0.49
+     * @since 1.0
      */
     @Test
     void computesSetUnionWithJavaUtilSets() {
@@ -90,7 +90,7 @@ final class UnionTest {
 
     /**
      * Tests that set union works with iterables.
-     * @since 0.49
+     * @since 1.0
      */
     @Test
     void computesSetUnionWithIterables() {
@@ -106,7 +106,7 @@ final class UnionTest {
 
     /**
      * Tests that set union works with iterators.
-     * @since 0.49
+     * @since 1.0
      */
     @Test
     void computesSetUnionWithIterators() {
@@ -122,7 +122,7 @@ final class UnionTest {
 
     /**
      * Tests that set union with identical sets works correctly.
-     * @since 0.49
+     * @since 1.0
      */
     @Test
     void computesSetUnionWithIdenticalSets() {

--- a/src/test/java/org/cactoos/set/UnionTest.java
+++ b/src/test/java/org/cactoos/set/UnionTest.java
@@ -1,0 +1,138 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2017-2025 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package org.cactoos.set;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.HasSize;
+import org.llorllale.cactoos.matchers.HasValues;
+
+/**
+ * Test case for {@link Union}.
+ *
+ * @since 0.49
+ */
+final class UnionTest {
+
+    /**
+     * Tests that set union can be computed correctly.
+     * @since 0.49
+     */
+    @Test
+    void computesSetUnion() {
+        new Assertion<>(
+            "Can't compute the union of two sets",
+            new Union<>(
+                new SetOf<>(1, 2, 3),
+                new SetOf<>(3, 4, 5)
+            ),
+            new HasValues<>(1, 2, 3, 4, 5)
+        ).affirm();
+    }
+
+    /**
+     * Tests that set union with empty second set returns the first set.
+     * @since 0.49
+     */
+    @Test
+    void computesSetUnionWithEmptySecondSet() {
+        new Assertion<>(
+            "Can't compute the union with empty second set",
+            new Union<>(
+                new SetOf<>(1, 2, 3),
+                new SetOf<>()
+            ),
+            new HasValues<>(1, 2, 3)
+        ).affirm();
+    }
+
+    /**
+     * Tests that set union with empty first set returns the second set.
+     * @since 0.49
+     */
+    @Test
+    void computesSetUnionWithEmptyFirstSet() {
+        new Assertion<>(
+            "Can't compute the union with empty first set",
+            new Union<>(
+                new SetOf<Integer>(),
+                new SetOf<>(1, 2, 3)
+            ),
+            new HasValues<>(1, 2, 3)
+        ).affirm();
+    }
+
+    /**
+     * Tests that set union works with java.util.Set.
+     * @since 0.49
+     */
+    @Test
+    void computesSetUnionWithJavaUtilSets() {
+        final Set<Integer> first = new HashSet<>();
+        first.add(1);
+        first.add(2);
+        first.add(3);
+        final Set<Integer> second = new HashSet<>();
+        second.add(3);
+        second.add(4);
+        second.add(5);
+        new Assertion<>(
+            "Can't compute the union of two java.util.Set",
+            new Union<>(first, second),
+            new HasValues<>(1, 2, 3, 4, 5)
+        ).affirm();
+    }
+
+    /**
+     * Tests that set union works with iterables.
+     * @since 0.49
+     */
+    @Test
+    void computesSetUnionWithIterables() {
+        new Assertion<>(
+            "Can't compute the union of two iterables",
+            new Union<>(
+                Collections.singletonList(1),
+                Collections.singletonList(2)
+            ),
+            new HasValues<>(1, 2)
+        ).affirm();
+    }
+
+    /**
+     * Tests that set union works with iterators.
+     * @since 0.49
+     */
+    @Test
+    void computesSetUnionWithIterators() {
+        new Assertion<>(
+            "Can't compute the union of two iterators",
+            new Union<>(
+                new SetOf<>(1, 2, 3).iterator(),
+                new SetOf<>(3, 4, 5).iterator()
+            ),
+            new HasValues<>(1, 2, 3, 4, 5)
+        ).affirm();
+    }
+
+    /**
+     * Tests that set union with identical sets works correctly.
+     * @since 0.49
+     */
+    @Test
+    void computesSetUnionWithIdenticalSets() {
+        new Assertion<>(
+            "Can't compute the union of identical sets",
+            new Union<>(
+                new SetOf<>(1, 2, 3),
+                new SetOf<>(1, 2, 3)
+            ),
+            new HasSize(3)
+        ).affirm();
+    }
+}


### PR DESCRIPTION
This PR adds a new `Union` class to the  package that represents the union of two sets. The implementation follows the same pattern as the existing Diff class.
The Union class:
Extends `SetEnvelope<T>`
Provides constructors for various input types (iterables, iterators, scalar suppliers)
Includes a private static method to compute the union of two sets
Is fully tested with various scenarios including empty sets, Java's built-in sets, and collections
This implementation complements the existing set operations in the library and follows the same design principles.