### PR TITLE
Implement MapDiff class for map difference operations

### DIFF
--- a/src/main/java/org/cactoos/map/MapDiff.java
+++ b/src/main/java/org/cactoos/map/MapDiff.java
@@ -1,0 +1,115 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2017-2025 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package org.cactoos.map;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import org.cactoos.Scalar;
+import org.cactoos.iterable.IterableOf;
+import org.cactoos.scalar.Unchecked;
+
+/**
+ * Map difference.
+ *
+ * <p>There is no thread-safety guarantee.</p>
+ *
+ * @param <K> Type of key
+ * @param <V> Type of value
+ * @since 0.49
+ */
+public final class MapDiff<K, V> extends MapEnvelope<K, V> {
+
+    /**
+     * Ctor.
+     * @param first First map
+     * @param second Second map
+     * @since 0.49
+     */
+    public MapDiff(final Iterable<Map.Entry<K, V>> first,
+        final Iterable<Map.Entry<K, V>> second) {
+        super(
+            computeDiff(
+                mapFromEntries(first),
+                mapFromEntries(second)
+            )
+        );
+    }
+
+    /**
+     * Ctor.
+     * @param first First iterator
+     * @param second Second iterator
+     * @since 0.49
+     */
+    public MapDiff(final Iterator<Map.Entry<K, V>> first,
+        final Iterator<Map.Entry<K, V>> second) {
+        this(
+            new IterableOf<>(first),
+            new IterableOf<>(second)
+        );
+    }
+
+    /**
+     * Ctor.
+     * @param first First iterable supplier
+     * @param second Second iterable supplier
+     * @since 0.49
+     */
+    public MapDiff(
+        final Scalar<Iterable<Map.Entry<K, V>>> first,
+        final Scalar<Iterable<Map.Entry<K, V>>> second
+    ) {
+        this(
+            new Unchecked<>(first).value(),
+            new Unchecked<>(second).value()
+        );
+    }
+
+    /**
+     * Ctor.
+     * @param first First map
+     * @param second Second map
+     * @since 0.49
+     */
+    public MapDiff(final Map<K, V> first, final Map<K, V> second) {
+        super(computeDiff(first, second));
+    }
+
+    /**
+     * Compute the difference between two maps.
+     * @param first The first map
+     * @param second The second map
+     * @param <K> Type of keys
+     * @param <V> Type of values
+     * @return The difference map (entries in first but not in second)
+     * @since 0.49
+     */
+    private static <K, V> Map<K, V> computeDiff(
+        final Map<K, V> first,
+        final Map<K, V> second
+    ) {
+        final MapOf<K, V> result = new MapOf<>(first);
+        result.keySet().removeAll(second.keySet());
+        return result;
+    }
+
+    /**
+     * Create a map from entries.
+     * @param entries The entries
+     * @param <K> Type of keys
+     * @param <V> Type of values
+     * @return The map
+     */
+    private static <K, V> Map<K, V> mapFromEntries(
+        final Iterable<Map.Entry<K, V>> entries
+    ) {
+        final Map<K, V> map = new HashMap<>();
+        for (final Map.Entry<K, V> entry : entries) {
+            map.put(entry.getKey(), entry.getValue());
+        }
+        return map;
+    }
+}

--- a/src/main/java/org/cactoos/map/MapDiff.java
+++ b/src/main/java/org/cactoos/map/MapDiff.java
@@ -17,7 +17,7 @@ import org.cactoos.scalar.Unchecked;
  *
  * @param <K> Type of key
  * @param <V> Type of value
- * @since 1.0
+ * @since 0.58.0
  */
 public final class MapDiff<K, V> extends MapEnvelope<K, V> {
 
@@ -25,7 +25,6 @@ public final class MapDiff<K, V> extends MapEnvelope<K, V> {
      * Ctor.
      * @param first First map
      * @param second Second map
-     * @since 1.0
      */
     public MapDiff(final Iterable<Map.Entry<K, V>> first,
         final Iterable<Map.Entry<K, V>> second) {
@@ -41,7 +40,6 @@ public final class MapDiff<K, V> extends MapEnvelope<K, V> {
      * Ctor.
      * @param first First iterator
      * @param second Second iterator
-     * @since 1.0
      */
     public MapDiff(final Iterator<Map.Entry<K, V>> first,
         final Iterator<Map.Entry<K, V>> second) {
@@ -55,7 +53,6 @@ public final class MapDiff<K, V> extends MapEnvelope<K, V> {
      * Ctor.
      * @param first First iterable supplier
      * @param second Second iterable supplier
-     * @since 1.0
      */
     public MapDiff(
         final Scalar<Iterable<Map.Entry<K, V>>> first,
@@ -71,7 +68,6 @@ public final class MapDiff<K, V> extends MapEnvelope<K, V> {
      * Ctor.
      * @param first First map
      * @param second Second map
-     * @since 1.0
      */
     public MapDiff(final Map<K, V> first, final Map<K, V> second) {
         super(computeDiff(first, second));
@@ -84,7 +80,6 @@ public final class MapDiff<K, V> extends MapEnvelope<K, V> {
      * @param <K> Type of keys
      * @param <V> Type of values
      * @return The difference map (entries in first but not in second)
-     * @since 1.0
      */
     private static <K, V> MapOf<K, V> computeDiff(
         final Map<K, V> first,

--- a/src/main/java/org/cactoos/map/MapDiff.java
+++ b/src/main/java/org/cactoos/map/MapDiff.java
@@ -4,7 +4,6 @@
  */
 package org.cactoos.map;
 
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import org.cactoos.Scalar;
@@ -87,7 +86,7 @@ public final class MapDiff<K, V> extends MapEnvelope<K, V> {
      * @return The difference map (entries in first but not in second)
      * @since 1.0
      */
-    private static <K, V> Map<K, V> computeDiff(
+    private static <K, V> MapOf<K, V> computeDiff(
         final Map<K, V> first,
         final Map<K, V> second
     ) {
@@ -103,10 +102,10 @@ public final class MapDiff<K, V> extends MapEnvelope<K, V> {
      * @param <V> Type of values
      * @return The map
      */
-    private static <K, V> Map<K, V> mapFromEntries(
+    private static <K, V> MapOf<K, V> mapFromEntries(
         final Iterable<Map.Entry<K, V>> entries
     ) {
-        final Map<K, V> map = new HashMap<>();
+        final MapOf<K, V> map = new MapOf<>();
         for (final Map.Entry<K, V> entry : entries) {
             map.put(entry.getKey(), entry.getValue());
         }

--- a/src/main/java/org/cactoos/map/MapDiff.java
+++ b/src/main/java/org/cactoos/map/MapDiff.java
@@ -18,7 +18,7 @@ import org.cactoos.scalar.Unchecked;
  *
  * @param <K> Type of key
  * @param <V> Type of value
- * @since 0.49
+ * @since 1.0
  */
 public final class MapDiff<K, V> extends MapEnvelope<K, V> {
 
@@ -26,7 +26,7 @@ public final class MapDiff<K, V> extends MapEnvelope<K, V> {
      * Ctor.
      * @param first First map
      * @param second Second map
-     * @since 0.49
+     * @since 1.0
      */
     public MapDiff(final Iterable<Map.Entry<K, V>> first,
         final Iterable<Map.Entry<K, V>> second) {
@@ -42,7 +42,7 @@ public final class MapDiff<K, V> extends MapEnvelope<K, V> {
      * Ctor.
      * @param first First iterator
      * @param second Second iterator
-     * @since 0.49
+     * @since 1.0
      */
     public MapDiff(final Iterator<Map.Entry<K, V>> first,
         final Iterator<Map.Entry<K, V>> second) {
@@ -56,7 +56,7 @@ public final class MapDiff<K, V> extends MapEnvelope<K, V> {
      * Ctor.
      * @param first First iterable supplier
      * @param second Second iterable supplier
-     * @since 0.49
+     * @since 1.0
      */
     public MapDiff(
         final Scalar<Iterable<Map.Entry<K, V>>> first,
@@ -72,7 +72,7 @@ public final class MapDiff<K, V> extends MapEnvelope<K, V> {
      * Ctor.
      * @param first First map
      * @param second Second map
-     * @since 0.49
+     * @since 1.0
      */
     public MapDiff(final Map<K, V> first, final Map<K, V> second) {
         super(computeDiff(first, second));
@@ -85,7 +85,7 @@ public final class MapDiff<K, V> extends MapEnvelope<K, V> {
      * @param <K> Type of keys
      * @param <V> Type of values
      * @return The difference map (entries in first but not in second)
-     * @since 0.49
+     * @since 1.0
      */
     private static <K, V> Map<K, V> computeDiff(
         final Map<K, V> first,

--- a/src/test/java/org/cactoos/map/MapDiffTest.java
+++ b/src/test/java/org/cactoos/map/MapDiffTest.java
@@ -1,0 +1,177 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2017-2025 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package org.cactoos.map;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.HasEntry;
+
+/**
+ * Test case for {@link MapDiff}.
+ *
+ * @since 0.49
+ */
+@SuppressWarnings(
+    {
+        "PMD.AvoidDuplicateLiterals",
+        "PMD.AvoidDirectAccessToStaticFields"
+    }
+)
+final class MapDiffTest {
+
+    /**
+     * String constant for "one".
+     */
+    private static final String ONE = "one";
+
+    /**
+     * String constant for "two".
+     */
+    private static final String TWO = "two";
+
+    /**
+     * String constant for "three".
+     */
+    private static final String THREE = "three";
+
+    /**
+     * String constant for "four".
+     */
+    private static final String FOUR = "four";
+
+    /**
+     * String constant for "five".
+     */
+    private static final String FIVE = "five";
+
+    /**
+     * Tests that map difference can be computed correctly.
+     * @since 0.49
+     */
+    @Test
+    void computesMapDifference() {
+        new Assertion<>(
+            "Can't compute the difference of two maps",
+            new MapDiff<>(
+                new MapOf<>(
+                    new MapEntry<>(1, ONE),
+                    new MapEntry<>(2, TWO),
+                    new MapEntry<>(3, THREE)
+                ),
+                new MapOf<>(
+                    new MapEntry<>(2, TWO),
+                    new MapEntry<>(3, THREE),
+                    new MapEntry<>(4, FOUR)
+                )
+            ),
+            new HasEntry<>(1, ONE)
+        ).affirm();
+    }
+
+    /**
+     * Tests that map difference with empty second map returns the first map.
+     * @since 0.49
+     */
+    @Test
+    void computesMapDifferenceWithEmptySecondMap() {
+        new Assertion<>(
+            "Can't compute the difference with empty second map",
+            new MapDiff<>(
+                new MapOf<>(
+                    new MapEntry<>(1, ONE),
+                    new MapEntry<>(2, TWO),
+                    new MapEntry<>(3, THREE)
+                ),
+                new MapOf<>()
+            ),
+            new HasEntry<>(1, ONE)
+        ).affirm();
+    }
+
+    /**
+     * Tests that map difference with empty first map returns empty map.
+     * @since 0.49
+     */
+    @Test
+    void computesMapDifferenceWithEmptyFirstMap() {
+        new Assertion<>(
+            "Can't compute the difference with empty first map",
+            new MapDiff<Integer, String>(
+                new MapOf<Integer, String>(),
+                new MapOf<>(
+                    new MapEntry<>(1, ONE),
+                    new MapEntry<>(2, TWO),
+                    new MapEntry<>(3, THREE)
+                )
+            ).size(),
+            new IsEqual<>(0)
+        ).affirm();
+    }
+
+    /**
+     * Tests that map difference works with java.util.Map.
+     * @since 0.49
+     */
+    @Test
+    void computesMapDifferenceWithJavaUtilMaps() {
+        final Map<Integer, String> first = new HashMap<>();
+        first.put(1, ONE);
+        first.put(2, TWO);
+        first.put(3, THREE);
+        final Map<Integer, String> second = new HashMap<>();
+        second.put(3, THREE);
+        second.put(4, FOUR);
+        second.put(5, FIVE);
+        new Assertion<>(
+            "Can't compute the difference of two java.util.Map",
+            new MapDiff<>(first, second),
+            new HasEntry<>(1, ONE)
+        ).affirm();
+    }
+
+    /**
+     * Tests that map difference works with iterables.
+     * @since 0.49
+     */
+    @Test
+    void computesMapDifferenceWithIterables() {
+        new Assertion<>(
+            "Can't compute the difference of two iterables",
+            new MapDiff<>(
+                Collections.singletonList(new MapEntry<>(1, ONE)),
+                Collections.singletonList(new MapEntry<>(2, TWO))
+            ),
+            new HasEntry<>(1, ONE)
+        ).affirm();
+    }
+
+    /**
+     * Tests that map difference works with iterators.
+     * @since 0.49
+     */
+    @Test
+    void computesMapDifferenceWithIterators() {
+        new Assertion<>(
+            "Can't compute the difference of two iterators",
+            new MapDiff<>(
+                new MapOf<>(
+                    new MapEntry<>(1, ONE),
+                    new MapEntry<>(2, TWO),
+                    new MapEntry<>(3, THREE)
+                ).entrySet().iterator(),
+                new MapOf<>(
+                    new MapEntry<>(3, THREE),
+                    new MapEntry<>(4, FOUR),
+                    new MapEntry<>(5, FIVE)
+                ).entrySet().iterator()
+            ),
+            new HasEntry<>(1, ONE)
+        ).affirm();
+    }
+}

--- a/src/test/java/org/cactoos/map/MapDiffTest.java
+++ b/src/test/java/org/cactoos/map/MapDiffTest.java
@@ -15,7 +15,7 @@ import org.llorllale.cactoos.matchers.HasEntry;
 /**
  * Test case for {@link MapDiff}.
  *
- * @since 0.49
+ * @since 1.0
  */
 @SuppressWarnings(
     {
@@ -52,7 +52,7 @@ final class MapDiffTest {
 
     /**
      * Tests that map difference can be computed correctly.
-     * @since 0.49
+     * @since 1.0
      */
     @Test
     void computesMapDifference() {
@@ -76,7 +76,7 @@ final class MapDiffTest {
 
     /**
      * Tests that map difference with empty second map returns the first map.
-     * @since 0.49
+     * @since 1.0
      */
     @Test
     void computesMapDifferenceWithEmptySecondMap() {
@@ -96,7 +96,7 @@ final class MapDiffTest {
 
     /**
      * Tests that map difference with empty first map returns empty map.
-     * @since 0.49
+     * @since 1.0
      */
     @Test
     void computesMapDifferenceWithEmptyFirstMap() {
@@ -116,7 +116,7 @@ final class MapDiffTest {
 
     /**
      * Tests that map difference works with java.util.Map.
-     * @since 0.49
+     * @since 1.0
      */
     @Test
     void computesMapDifferenceWithJavaUtilMaps() {
@@ -137,7 +137,7 @@ final class MapDiffTest {
 
     /**
      * Tests that map difference works with iterables.
-     * @since 0.49
+     * @since 1.0
      */
     @Test
     void computesMapDifferenceWithIterables() {
@@ -153,7 +153,7 @@ final class MapDiffTest {
 
     /**
      * Tests that map difference works with iterators.
-     * @since 0.49
+     * @since 1.0
      */
     @Test
     void computesMapDifferenceWithIterators() {

--- a/src/test/java/org/cactoos/map/MapDiffTest.java
+++ b/src/test/java/org/cactoos/map/MapDiffTest.java
@@ -15,44 +15,13 @@ import org.llorllale.cactoos.matchers.HasEntry;
 /**
  * Test case for {@link MapDiff}.
  *
- * @since 1.0
+ * @since 0.58.0
  */
-@SuppressWarnings(
-    {
-        "PMD.AvoidDuplicateLiterals",
-        "PMD.AvoidDirectAccessToStaticFields"
-    }
-)
 final class MapDiffTest {
 
     /**
-     * String constant for "one".
-     */
-    private static final String ONE = "one";
-
-    /**
-     * String constant for "two".
-     */
-    private static final String TWO = "two";
-
-    /**
-     * String constant for "three".
-     */
-    private static final String THREE = "three";
-
-    /**
-     * String constant for "four".
-     */
-    private static final String FOUR = "four";
-
-    /**
-     * String constant for "five".
-     */
-    private static final String FIVE = "five";
-
-    /**
      * Tests that map difference can be computed correctly.
-     * @since 1.0
+     * @since 0.58.0
      */
     @Test
     void computesMapDifference() {
@@ -60,23 +29,23 @@ final class MapDiffTest {
             "Can't compute the difference of two maps",
             new MapDiff<>(
                 new MapOf<>(
-                    new MapEntry<>(1, ONE),
-                    new MapEntry<>(2, TWO),
-                    new MapEntry<>(3, THREE)
+                    new MapEntry<>(1, "one"),
+                    new MapEntry<>(2, "two"),
+                    new MapEntry<>(3, "three")
                 ),
                 new MapOf<>(
-                    new MapEntry<>(2, TWO),
-                    new MapEntry<>(3, THREE),
-                    new MapEntry<>(4, FOUR)
+                    new MapEntry<>(2, "two"),
+                    new MapEntry<>(3, "three"),
+                    new MapEntry<>(4, "four")
                 )
             ),
-            new HasEntry<>(1, ONE)
+            new HasEntry<>(1, "one")
         ).affirm();
     }
 
     /**
      * Tests that map difference with empty second map returns the first map.
-     * @since 1.0
+     * @since 0.58.0
      */
     @Test
     void computesMapDifferenceWithEmptySecondMap() {
@@ -84,19 +53,19 @@ final class MapDiffTest {
             "Can't compute the difference with empty second map",
             new MapDiff<>(
                 new MapOf<>(
-                    new MapEntry<>(1, ONE),
-                    new MapEntry<>(2, TWO),
-                    new MapEntry<>(3, THREE)
+                    new MapEntry<>(5, "five"),
+                    new MapEntry<>(6, "six"),
+                    new MapEntry<>(7, "seven")
                 ),
                 new MapOf<>()
             ),
-            new HasEntry<>(1, ONE)
+            new HasEntry<>(5, "five")
         ).affirm();
     }
 
     /**
      * Tests that map difference with empty first map returns empty map.
-     * @since 1.0
+     * @since 0.58.0
      */
     @Test
     void computesMapDifferenceWithEmptyFirstMap() {
@@ -105,9 +74,9 @@ final class MapDiffTest {
             new MapDiff<Integer, String>(
                 new MapOf<Integer, String>(),
                 new MapOf<>(
-                    new MapEntry<>(1, ONE),
-                    new MapEntry<>(2, TWO),
-                    new MapEntry<>(3, THREE)
+                    new MapEntry<>(8, "eight"),
+                    new MapEntry<>(9, "nine"),
+                    new MapEntry<>(10, "ten")
                 )
             ).size(),
             new IsEqual<>(0)
@@ -116,44 +85,44 @@ final class MapDiffTest {
 
     /**
      * Tests that map difference works with java.util.Map.
-     * @since 1.0
+     * @since 0.58.0
      */
     @Test
     void computesMapDifferenceWithJavaUtilMaps() {
         final Map<Integer, String> first = new HashMap<>();
-        first.put(1, ONE);
-        first.put(2, TWO);
-        first.put(3, THREE);
+        first.put(11, "eleven");
+        first.put(12, "twelve");
+        first.put(13, "thirteen");
         final Map<Integer, String> second = new HashMap<>();
-        second.put(3, THREE);
-        second.put(4, FOUR);
-        second.put(5, FIVE);
+        second.put(13, "thirteen");
+        second.put(14, "fourteen");
+        second.put(15, "fifteen");
         new Assertion<>(
             "Can't compute the difference of two java.util.Map",
             new MapDiff<>(first, second),
-            new HasEntry<>(1, ONE)
+            new HasEntry<>(11, "eleven")
         ).affirm();
     }
 
     /**
      * Tests that map difference works with iterables.
-     * @since 1.0
+     * @since 0.58.0
      */
     @Test
     void computesMapDifferenceWithIterables() {
         new Assertion<>(
             "Can't compute the difference of two iterables",
             new MapDiff<>(
-                Collections.singletonList(new MapEntry<>(1, ONE)),
-                Collections.singletonList(new MapEntry<>(2, TWO))
+                Collections.singletonList(new MapEntry<>(16, "sixteen")),
+                Collections.singletonList(new MapEntry<>(17, "seventeen"))
             ),
-            new HasEntry<>(1, ONE)
+            new HasEntry<>(16, "sixteen")
         ).affirm();
     }
 
     /**
      * Tests that map difference works with iterators.
-     * @since 1.0
+     * @since 0.58.0
      */
     @Test
     void computesMapDifferenceWithIterators() {
@@ -161,17 +130,17 @@ final class MapDiffTest {
             "Can't compute the difference of two iterators",
             new MapDiff<>(
                 new MapOf<>(
-                    new MapEntry<>(1, ONE),
-                    new MapEntry<>(2, TWO),
-                    new MapEntry<>(3, THREE)
+                    new MapEntry<>(18, "eighteen"),
+                    new MapEntry<>(19, "nineteen"),
+                    new MapEntry<>(20, "twenty")
                 ).entrySet().iterator(),
                 new MapOf<>(
-                    new MapEntry<>(3, THREE),
-                    new MapEntry<>(4, FOUR),
-                    new MapEntry<>(5, FIVE)
+                    new MapEntry<>(20, "twenty"),
+                    new MapEntry<>(21, "twenty-one"),
+                    new MapEntry<>(22, "twenty-two")
                 ).entrySet().iterator()
             ),
-            new HasEntry<>(1, ONE)
+            new HasEntry<>(18, "eighteen")
         ).affirm();
     }
 }


### PR DESCRIPTION
This PR introduces a new `MapDiff` class that allows computing the difference between two maps. The implementation follows the functional programming principles of Cactoos.
Features
Computes the difference between two maps (entries in the first map that are not in the second map)
Supports various input types:
Maps
Iterables of `Map.Entry`
Iterators of `Map.Entry`
Scalar suppliers of `Iterables`
Implementation Details
`MapDiff` extends `MapEnvelope` to maintain the immutability principle
The difference is computed by removing all keys from the first map that exist in the second map
Comprehensive test coverage ensures correct behavior with different input types and edge cases
Testing
The implementation includes tests for:
Basic map difference computation
Empty map handling (both as first and second argument)
Working with standard Java Map implementations
Working with `Iterables` and `Iterators`
This implementation will be useful for functional operations on maps where finding differences between collections is needed.
