### PR TITLE
Add org.cactoos.map.Immutable decorator

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -15,6 +15,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
         java: [23]
@@ -32,4 +33,11 @@ jobs:
             ${{ runner.os }}-jdk-${{ matrix.java }}-maven-
       - run: java -version
       - run: mvn -version
-      - run: mvn --errors --batch-mode clean install -Pqulice
+      # hone-maven-plugin needs a working Docker daemon.
+      # - skipWithoutDocker: macOS runners have no docker binary
+      # - skipOnWindows: Windows runners ship docker CLI but no usable daemon for hone
+      # Quote -D args for PowerShell on Windows.
+      - run: >-
+          mvn --errors --batch-mode clean install -Pqulice
+          "-Dhone.skipWithoutDocker=true"
+          "-Dhone.skipOnWindows=true"

--- a/README.md
+++ b/README.md
@@ -110,6 +110,63 @@ new Upper(
 );
 ```
 
+### Splitting Text
+
+To split text using Java's standard behavior:
+
+```java
+Iterable<Text> parts = new Split("hello,world", ",");
+// Result: ["hello", "world"]
+```
+
+### Splitting with Preserved Empty Tokens
+
+Java's `String.split()` discards trailing empty tokens.
+Use `SplitPreserveAllTokens` when you need to preserve ALL tokens,
+including empty ones created by adjacent or trailing delimiters:
+
+```java
+// Standard split loses trailing empty token
+"a,b,".split(",")  // Returns: ["a", "b"] - trailing empty LOST!
+
+// SplitPreserveAllTokens preserves it
+Iterable<Text> parts = new SplitPreserveAllTokens("a,b,", ",");
+// Result: ["a", "b", ""]  - all tokens preserved!
+```
+
+This is essential for parsing CSV/TSV data where empty fields are meaningful:
+
+```java
+// Parse CSV with empty fields
+Iterable<Text> fields = new SplitPreserveAllTokens(
+  "John,,Smith,,"
+  ","
+);
+// Result: ["John", "", "Smith", "", ""]  - all 5 fields!
+
+// With spaces as delimiter
+Iterable<Text> words = new SplitPreserveAllTokens(" hello  world ");
+// Result: ["", "hello", "", "world", ""]
+
+// Default delimiter is space
+Iterable<Text> tokens = new SplitPreserveAllTokens("a b c");
+// Result: ["a", "b", "c"]
+
+// With limit on number of tokens
+Iterable<Text> limited = new SplitPreserveAllTokens("a,b,c,d", ",", 2);
+// Result: ["a", "b"]
+```
+
+**Key guarantee**: With N delimiters, you always get exactly N+1 tokens.
+
+| Input | Delimiter | `String.split()` | `SplitPreserveAllTokens` |
+| ------- | ----------- | ------------------ | -------------------------- |
+| `"a,b,"` | `,` | `["a", "b"]` | `["a", "b", ""]` |
+| `",,"` | `,` | `[]` | `["", "", ""]` |
+| `","` | `,` | `[]` | `["", ""]` |
+
+> **Note**: The delimiter is matched as a literal string, not a regex.
+
 ## Iterables/Collections/Lists/Sets
 
 More about it here:
@@ -254,6 +311,54 @@ final Set<String> sorted = new org.cactoos.set.Sorted<>(
 );
 ```
 
+## Maps
+
+To create a simple map:
+
+```java
+Map<String, Integer> map = new MapOf<>(
+  new MapEntry<>("one", 1),
+  new MapEntry<>("two", 2),
+  new MapEntry<>("three", 3)
+);
+```
+
+### Immutable Maps
+
+To create an immutable (read-only) map that prevents any modifications:
+
+```java
+Map<String, Integer> map = new org.cactoos.map.Immutable<>(
+  new MapOf<>(
+    new MapEntry<>("one", 1),
+    new MapEntry<>("two", 2)
+  )
+);
+map.get("one");      // returns 1
+map.put("three", 3); // throws UnsupportedOperationException!
+map.clear();         // throws UnsupportedOperationException!
+```
+
+The `Immutable` map decorator guarantees that:
+
+- Mutating methods (`put`, `remove`, `putAll`, `clear`) are blocked
+- Views from `keySet()`, `values()`, and `entrySet()` are immutable
+- `Entry.setValue()` is blocked on entries from `entrySet()`
+
+This is useful when you need to pass a map to untrusted code or ensure
+a map cannot be accidentally modified:
+
+```java
+// Safe to pass to any method - cannot be modified
+public Map<String, Config> getConfiguration() {
+  return new Immutable<>(this.config);
+}
+```
+
+> **Note**: This is a decorator, not a copy. If the underlying map is modified
+> through another reference, changes will be visible. For a true snapshot,
+> copy the data first.
+
 ## Funcs and Procs
 
 This is a traditional `foreach` loop:
@@ -331,6 +436,7 @@ final String text = new TextOfDateTime(date).asString();
 | `And` | `Iterables.all()` | - | - |
 | `Filtered` | `Iterables.filter()` | ? | - |
 | `FormattedText` | - | - | `String.format()` |
+| `map.Immutable` | `ImmutableMap` | `UnmodifiableMap` | `unmodifiableMap()` |
 | `IsBlank` | - | `StringUtils.isBlank()` | - |
 | `Joined` | - | - | `String.join()` |
 | `LengthOf` | - | - | `String#length()` |
@@ -342,6 +448,7 @@ final String text = new TextOfDateTime(date).asString();
 | `Reversed` | - | - | `StringBuilder#reverse()` |
 | `Rotated` | - | `StringUtils.rotate()` | - |
 | `Split` | - | - | `String#split()` |
+| `SplitPreserveAllTokens` | - | `StringUtils.splitPreserveAllTokens()` | - |
 | `StickyList` | `Lists.newArrayList()` | ? | `Arrays.asList()` |
 | `Sub` | - | - | `String#substring()` |
 | `SwappedCase` | - | `StringUtils.swapCase()` | - |
@@ -449,26 +556,26 @@ in GitHub precommits.
 
 ## Contributors
 
-* [@yegor256](https://github.com/yegor256) as Yegor Bugayenko ([Blog](http://www.yegor256.com))
-* [@g4s8](https://github.com/g4s8) as [Kirill Che.](mailto:g4s8.public@gmail.com)
-* [@fabriciofx](https://github.com/fabriciofx) as Fabrício Cabral
-* [@englishman](https://github.com/englishman) as Andriy Kryvtsun
-* [@VsSekorin](https://github.com/VsSekorin) as Vseslav Sekorin
-* [@DronMDF](https://github.com/DronMDF) as Andrey Valyaev
-* [@dusan-rychnovsky](https://github.com/dusan-rychnovsky) as Dušan Rychnovský ([Blog](http://blog.dusanrychnovsky.cz/))
-* [@timmeey](https://github.com/timmeey) as Tim Hinkes ([Blog](https://blog.timmeey.de))
-* [@alex-semenyuk](https://github.com/alex-semenyuk) as Alexey Semenyuk
-* [@smallcreep](https://github.com/smallcreep) as Ilia Rogozhin
-* [@memoyil](https://github.com/memoyil) as Mehmet Yildirim
-* [@llorllale](https://github.com/llorllale) as George Aristy
-* [@driver733](https://github.com/driver733) as Mikhail Yakushin
-* [@izrik](https://github.com/izrik) as Richard Sartor
-* [@Vatavuk](https://github.com/Vatavuk) as Vedran Grgo Vatavuk
-* [@dgroup](https://github.com/dgroup) as Yurii Dubinka
-* [@iakunin](https://github.com/iakunin) as Maksim Iakunin
-* [@fanifieiev](https://github.com/fanifieiev) as Fevzi Anifieiev
-* [@victornoel](https://github.com/victornoel) as Victor Noël
-* [@paulodamaso](https://github.com/paulodamaso) as Paulo Lobo
+- [@yegor256](https://github.com/yegor256) as Yegor Bugayenko ([Blog](http://www.yegor256.com))
+- [@g4s8](https://github.com/g4s8) as [Kirill Che.](mailto:g4s8.public@gmail.com)
+- [@fabriciofx](https://github.com/fabriciofx) as Fabrício Cabral
+- [@englishman](https://github.com/englishman) as Andriy Kryvtsun
+- [@VsSekorin](https://github.com/VsSekorin) as Vseslav Sekorin
+- [@DronMDF](https://github.com/DronMDF) as Andrey Valyaev
+- [@dusan-rychnovsky](https://github.com/dusan-rychnovsky) as Dušan Rychnovský ([Blog](http://blog.dusanrychnovsky.cz/))
+- [@timmeey](https://github.com/timmeey) as Tim Hinkes ([Blog](https://blog.timmeey.de))
+- [@alex-semenyuk](https://github.com/alex-semenyuk) as Alexey Semenyuk
+- [@smallcreep](https://github.com/smallcreep) as Ilia Rogozhin
+- [@memoyil](https://github.com/memoyil) as Mehmet Yildirim
+- [@llorllale](https://github.com/llorllale) as George Aristy
+- [@driver733](https://github.com/driver733) as Mikhail Yakushin
+- [@izrik](https://github.com/izrik) as Richard Sartor
+- [@Vatavuk](https://github.com/Vatavuk) as Vedran Grgo Vatavuk
+- [@dgroup](https://github.com/dgroup) as Yurii Dubinka
+- [@iakunin](https://github.com/iakunin) as Maksim Iakunin
+- [@fanifieiev](https://github.com/fanifieiev) as Fevzi Anifieiev
+- [@victornoel](https://github.com/victornoel) as Victor Noël
+- [@paulodamaso](https://github.com/paulodamaso) as Paulo Lobo
 
 [blog]: http://www.yegor256.com/2017/06/22/object-oriented-input-output-in-cactoos.html
 [OffsetDateTime]: https://docs.oracle.com/javase/8/docs/api/java/time/OffsetDateTime.html

--- a/src/main/java/org/cactoos/map/Immutable.java
+++ b/src/main/java/org/cactoos/map/Immutable.java
@@ -1,0 +1,329 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2017-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package org.cactoos.map;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Decorator that doesn't allow mutations of the wrapped {@link Map}.
+ *
+ * <p>There is no thread-safety guarantee.</p>
+ *
+ * @param <K> Type of key
+ * @param <V> Type of value
+ * @since 0.67
+ */
+@SuppressWarnings("PMD.TooManyMethods")
+public final class Immutable<K, V> implements Map<K, V> {
+
+    /**
+     * Encapsulated map.
+     */
+    private final Map<K, V> map;
+
+    /**
+     * Ctor.
+     * @param src Source map
+     */
+    @SuppressWarnings("unchecked")
+    public Immutable(final Map<? extends K, ? extends V> src) {
+        this.map = (Map<K, V>) src;
+    }
+
+    @Override
+    public int size() {
+        return this.map.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return this.map.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(final Object key) {
+        return this.map.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(final Object value) {
+        return this.map.containsValue(value);
+    }
+
+    @Override
+    public V get(final Object key) {
+        return this.map.get(key);
+    }
+
+    @Override
+    public V put(final K key, final V value) {
+        throw new UnsupportedOperationException(
+            "#put(K,V): the map is read-only"
+        );
+    }
+
+    @Override
+    public V remove(final Object key) {
+        throw new UnsupportedOperationException(
+            "#remove(Object): the map is read-only"
+        );
+    }
+
+    @Override
+    public void putAll(final Map<? extends K, ? extends V> entries) {
+        throw new UnsupportedOperationException(
+            "#putAll(Map): the map is read-only"
+        );
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException(
+            "#clear(): the map is read-only"
+        );
+    }
+
+    @Override
+    public Set<K> keySet() {
+        return new org.cactoos.set.Immutable<>(this.map.keySet());
+    }
+
+    @Override
+    public Collection<V> values() {
+        return new org.cactoos.collection.Immutable<>(this.map.values());
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        return new Immutable.ImmutableEntries<>(this.map.entrySet());
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return this.map.equals(other);
+    }
+
+    @Override
+    public int hashCode() {
+        return this.map.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return this.map.toString();
+    }
+
+    /**
+     * Immutable set of map entries.
+     * @param <X> Key type
+     * @param <Y> Value type
+     * @since 0.67
+     */
+    @SuppressWarnings("PMD.TooManyMethods")
+    private static final class ImmutableEntries<X, Y> implements Set<Entry<X, Y>> {
+
+        /**
+         * Original entries.
+         */
+        private final Set<Entry<X, Y>> entries;
+
+        /**
+         * Ctor.
+         * @param src Source entries
+         */
+        ImmutableEntries(final Set<Entry<X, Y>> src) {
+            this.entries = src;
+        }
+
+        @Override
+        public int size() {
+            return this.entries.size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return this.entries.isEmpty();
+        }
+
+        @Override
+        public boolean contains(final Object item) {
+            return this.entries.contains(item);
+        }
+
+        @Override
+        public Iterator<Entry<X, Y>> iterator() {
+            return new Immutable.ImmutableEntryIterator<>(this.entries.iterator());
+        }
+
+        @Override
+        public Object[] toArray() {
+            return this.entries.toArray();
+        }
+
+        @Override
+        public <Z> Z[] toArray(final Z[] array) {
+            return this.entries.toArray(array);
+        }
+
+        @Override
+        public boolean add(final Entry<X, Y> item) {
+            throw new UnsupportedOperationException(
+                "#add(Entry): the entry set is read-only"
+            );
+        }
+
+        @Override
+        public boolean remove(final Object item) {
+            throw new UnsupportedOperationException(
+                "#remove(Object): the entry set is read-only"
+            );
+        }
+
+        @Override
+        public boolean containsAll(final Collection<?> items) {
+            return this.entries.containsAll(items);
+        }
+
+        @Override
+        public boolean addAll(final Collection<? extends Entry<X, Y>> items) {
+            throw new UnsupportedOperationException(
+                "#addAll(Collection): the entry set is read-only"
+            );
+        }
+
+        @Override
+        public boolean retainAll(final Collection<?> items) {
+            throw new UnsupportedOperationException(
+                "#retainAll(Collection): the entry set is read-only"
+            );
+        }
+
+        @Override
+        public boolean removeAll(final Collection<?> items) {
+            throw new UnsupportedOperationException(
+                "#removeAll(Collection): the entry set is read-only"
+            );
+        }
+
+        @Override
+        public void clear() {
+            throw new UnsupportedOperationException(
+                "#clear(): the entry set is read-only"
+            );
+        }
+
+        @Override
+        public boolean equals(final Object other) {
+            return this.entries.equals(other);
+        }
+
+        @Override
+        public int hashCode() {
+            return this.entries.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return this.entries.toString();
+        }
+    }
+
+    /**
+     * Iterator over immutable map entries.
+     * @param <X> Key type
+     * @param <Y> Value type
+     * @since 0.67
+     */
+    private static final class ImmutableEntryIterator<X, Y> implements
+        Iterator<Entry<X, Y>> {
+
+        /**
+         * Original iterator.
+         */
+        private final Iterator<Entry<X, Y>> iterator;
+
+        /**
+         * Ctor.
+         * @param src Source iterator
+         */
+        ImmutableEntryIterator(final Iterator<Entry<X, Y>> src) {
+            this.iterator = src;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return this.iterator.hasNext();
+        }
+
+        @Override
+        public Entry<X, Y> next() {
+            return new Immutable.ImmutableEntry<>(this.iterator.next());
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException(
+                "#remove(): the iterator is read-only"
+            );
+        }
+    }
+
+    /**
+     * Immutable map entry.
+     * @param <X> Key type
+     * @param <Y> Value type
+     * @since 0.67
+     */
+    private static final class ImmutableEntry<X, Y> implements Entry<X, Y> {
+
+        /**
+         * Original entry.
+         */
+        private final Entry<X, Y> entry;
+
+        /**
+         * Ctor.
+         * @param src Source entry
+         */
+        ImmutableEntry(final Entry<X, Y> src) {
+            this.entry = src;
+        }
+
+        @Override
+        public X getKey() {
+            return this.entry.getKey();
+        }
+
+        @Override
+        public Y getValue() {
+            return this.entry.getValue();
+        }
+
+        @Override
+        public Y setValue(final Y value) {
+            throw new UnsupportedOperationException(
+                "#setValue(V): the entry is read-only"
+            );
+        }
+
+        @Override
+        public boolean equals(final Object other) {
+            return this.entry.equals(other);
+        }
+
+        @Override
+        public int hashCode() {
+            return this.entry.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return this.entry.toString();
+        }
+    }
+}

--- a/src/test/java/org/cactoos/func/TriFuncSplitPreserveTest.java
+++ b/src/test/java/org/cactoos/func/TriFuncSplitPreserveTest.java
@@ -1,0 +1,118 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2017-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package org.cactoos.func;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link TriFuncSplitPreserve}.
+ * @since 0.0
+ */
+@SuppressWarnings("PMD.TooManyMethods")
+final class TriFuncSplitPreserveTest {
+
+    @Test
+    void splitsSimpleString() {
+        MatcherAssert.assertThat(
+            "Must split simple string",
+            new TriFuncSplitPreserve().apply("a,b,c", ",", 0),
+            new IsEqual<>(Arrays.asList("a", "b", "c"))
+        );
+    }
+
+    @Test
+    void preservesEmptyTokenInMiddle() {
+        MatcherAssert.assertThat(
+            "Must preserve empty token between adjacent delimiters",
+            new TriFuncSplitPreserve().apply("a,,b", ",", 0),
+            new IsEqual<>(Arrays.asList("a", "", "b"))
+        );
+    }
+
+    @Test
+    void preservesTrailingEmptyToken() {
+        MatcherAssert.assertThat(
+            "Must preserve trailing empty token",
+            new TriFuncSplitPreserve().apply("a,b,", ",", 0),
+            new IsEqual<>(Arrays.asList("a", "b", ""))
+        );
+    }
+
+    @Test
+    void preservesLeadingEmptyToken() {
+        MatcherAssert.assertThat(
+            "Must preserve leading empty token",
+            new TriFuncSplitPreserve().apply(",a,b", ",", 0),
+            new IsEqual<>(Arrays.asList("", "a", "b"))
+        );
+    }
+
+    @Test
+    void preservesOnlyDelimiters() {
+        MatcherAssert.assertThat(
+            "Must preserve tokens for only delimiters",
+            new TriFuncSplitPreserve().apply(",,", ",", 0),
+            new IsEqual<>(Arrays.asList("", "", ""))
+        );
+    }
+
+    @Test
+    void preservesSingleDelimiter() {
+        MatcherAssert.assertThat(
+            "Must preserve tokens for single delimiter",
+            new TriFuncSplitPreserve().apply(",", ",", 0),
+            new IsEqual<>(Arrays.asList("", ""))
+        );
+    }
+
+    @Test
+    void returnsEmptyTokenForEmptyInput() {
+        MatcherAssert.assertThat(
+            "Must return one empty token for empty input",
+            new TriFuncSplitPreserve().apply("", ",", 0),
+            new IsEqual<>(Collections.singletonList(""))
+        );
+    }
+
+    @Test
+    void returnsWholeStringWithoutDelimiter() {
+        MatcherAssert.assertThat(
+            "Must return whole string when delimiter is missing",
+            new TriFuncSplitPreserve().apply("abc", ",", 0),
+            new IsEqual<>(Collections.singletonList("abc"))
+        );
+    }
+
+    @Test
+    void respectsPositiveLimit() {
+        MatcherAssert.assertThat(
+            "Must respect positive limit",
+            new TriFuncSplitPreserve().apply("a,b,c,d", ",", 2),
+            new IsEqual<>(Arrays.asList("a", "b"))
+        );
+    }
+
+    @Test
+    void splitsByMultiCharDelimiter() {
+        MatcherAssert.assertThat(
+            "Must split by multi-char delimiter",
+            new TriFuncSplitPreserve().apply("a::b::c", "::", 0),
+            new IsEqual<>(Arrays.asList("a", "b", "c"))
+        );
+    }
+
+    @Test
+    void splitsBySpace() {
+        MatcherAssert.assertThat(
+            "Must split by space preserving edges",
+            new TriFuncSplitPreserve().apply(" hello  world ", " ", 0),
+            new IsEqual<>(Arrays.asList("", "hello", "", "world", ""))
+        );
+    }
+}

--- a/src/test/java/org/cactoos/map/ImmutableTest.java
+++ b/src/test/java/org/cactoos/map/ImmutableTest.java
@@ -1,0 +1,377 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2017-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package org.cactoos.map;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
+import org.junit.jupiter.api.Test;
+import org.llorllale.cactoos.matchers.HasValues;
+import org.llorllale.cactoos.matchers.Throws;
+
+/**
+ * Test case for {@link Immutable}.
+ * @since 0.67
+ */
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.UnnecessaryLocalRule"})
+final class ImmutableTest {
+
+    @Test
+    void size() {
+        MatcherAssert.assertThat(
+            "size() must be equals to original",
+            new Immutable<String, Integer>(
+                new MapOf<String, Integer>(
+                    new MapEntry<>("a", 1),
+                    new MapEntry<>("b", 2)
+                )
+            ).size(),
+            new IsEqual<>(2)
+        );
+    }
+
+    @Test
+    void isEmpty() {
+        MatcherAssert.assertThat(
+            "isEmpty() must be equals to original",
+            new Immutable<String, Integer>(
+                new MapOf<String, Integer>(
+                    new MapEntry<>("a", 1)
+                )
+            ).isEmpty(),
+            new IsEqual<>(false)
+        );
+    }
+
+    @Test
+    void containsKey() {
+        MatcherAssert.assertThat(
+            "containsKey() must be equals to original",
+            new Immutable<String, Integer>(
+                new MapOf<String, Integer>(
+                    new MapEntry<>("a", 1),
+                    new MapEntry<>("b", 2)
+                )
+            ).containsKey("b"),
+            new IsEqual<>(true)
+        );
+    }
+
+    @Test
+    void containsValue() {
+        MatcherAssert.assertThat(
+            "containsValue() must be equals to original",
+            new Immutable<String, Integer>(
+                new MapOf<String, Integer>(
+                    new MapEntry<>("a", 1),
+                    new MapEntry<>("b", 2)
+                )
+            ).containsValue(2),
+            new IsEqual<>(true)
+        );
+    }
+
+    @Test
+    void get() {
+        MatcherAssert.assertThat(
+            "get() must be equals to original",
+            new Immutable<String, Integer>(
+                new MapOf<String, Integer>(
+                    new MapEntry<>("a", 1),
+                    new MapEntry<>("b", 2)
+                )
+            ).get("a"),
+            new IsEqual<>(1)
+        );
+    }
+
+    @Test
+    void put() {
+        MatcherAssert.assertThat(
+            "put(K,V) must throw exception",
+            () -> new Immutable<String, Integer>(
+                new MapOf<String, Integer>(
+                    new MapEntry<>("a", 1)
+                )
+            ).put("b", 2),
+            new Throws<>(
+                "#put(K,V): the map is read-only",
+                UnsupportedOperationException.class
+            )
+        );
+    }
+
+    @Test
+    void remove() {
+        MatcherAssert.assertThat(
+            "remove(Object) must throw exception",
+            () -> new Immutable<String, Integer>(
+                new MapOf<String, Integer>(
+                    new MapEntry<>("a", 1)
+                )
+            ).remove("a"),
+            new Throws<>(
+                "#remove(Object): the map is read-only",
+                UnsupportedOperationException.class
+            )
+        );
+    }
+
+    @Test
+    void putAll() {
+        MatcherAssert.assertThat(
+            "putAll(Map) must throw exception",
+            () -> {
+                new Immutable<String, Integer>(
+                    new MapOf<String, Integer>(
+                        new MapEntry<>("a", 1)
+                    )
+                ).putAll(
+                    new MapOf<String, Integer>(
+                        new MapEntry<>("b", 2)
+                    )
+                );
+                return new Object();
+            },
+            new Throws<>(
+                "#putAll(Map): the map is read-only",
+                UnsupportedOperationException.class
+            )
+        );
+    }
+
+    @Test
+    void clear() {
+        MatcherAssert.assertThat(
+            "clear() must throw exception",
+            () -> {
+                new Immutable<String, Integer>(
+                    new MapOf<String, Integer>(
+                        new MapEntry<>("a", 1)
+                    )
+                ).clear();
+                return new Object();
+            },
+            new Throws<>(
+                "#clear(): the map is read-only",
+                UnsupportedOperationException.class
+            )
+        );
+    }
+
+    @Test
+    void keySet() {
+        MatcherAssert.assertThat(
+            "keySet() must contain original keys",
+            () -> new Immutable<String, Integer>(
+                new MapOf<String, Integer>(
+                    new MapEntry<>("a", 1),
+                    new MapEntry<>("b", 2)
+                )
+            ).keySet().iterator(),
+            new HasValues<>("a", "b")
+        );
+    }
+
+    @Test
+    void values() {
+        MatcherAssert.assertThat(
+            "values() must contain original values",
+            () -> new Immutable<String, Integer>(
+                new MapOf<String, Integer>(
+                    new MapEntry<>("a", 1),
+                    new MapEntry<>("b", 2)
+                )
+            ).values().iterator(),
+            new HasValues<>(1, 2)
+        );
+    }
+
+    @Test
+    void entrySetSize() {
+        MatcherAssert.assertThat(
+            "entrySet() size must be equals to original",
+            new Immutable<String, Integer>(
+                new MapOf<String, Integer>(
+                    new MapEntry<>("a", 1),
+                    new MapEntry<>("b", 2)
+                )
+            ).entrySet().size(),
+            new IsEqual<>(2)
+        );
+    }
+
+    @Test
+    void keySetIsImmutable() {
+        MatcherAssert.assertThat(
+            "keySet().add() must throw exception",
+            () -> new Immutable<String, Integer>(
+                new MapOf<String, Integer>(
+                    new MapEntry<>("a", 1)
+                )
+            ).keySet().add("b"),
+            new Throws<>(UnsupportedOperationException.class)
+        );
+    }
+
+    @Test
+    void valuesAreImmutable() {
+        MatcherAssert.assertThat(
+            "values().clear() must throw exception",
+            () -> {
+                new Immutable<String, Integer>(
+                    new MapOf<String, Integer>(
+                        new MapEntry<>("a", 1)
+                    )
+                ).values().clear();
+                return new Object();
+            },
+            new Throws<>(UnsupportedOperationException.class)
+        );
+    }
+
+    @Test
+    void entrySetIsImmutable() {
+        MatcherAssert.assertThat(
+            "entrySet().clear() must throw exception",
+            () -> {
+                new Immutable<String, Integer>(
+                    new MapOf<String, Integer>(
+                        new MapEntry<>("a", 1)
+                    )
+                ).entrySet().clear();
+                return new Object();
+            },
+            new Throws<>(UnsupportedOperationException.class)
+        );
+    }
+
+    @Test
+    void entrySetValueIsBlocked() {
+        MatcherAssert.assertThat(
+            "Entry.setValue() must throw exception",
+            () -> {
+                final Iterator<Map.Entry<String, Integer>> iterator =
+                    new Immutable<String, Integer>(
+                        new MapOf<String, Integer>(
+                            new MapEntry<>("a", 1)
+                        )
+                    ).entrySet().iterator();
+                iterator.next().setValue(2);
+                return new Object();
+            },
+            new Throws<>(
+                "#setValue(V): the entry is read-only",
+                UnsupportedOperationException.class
+            )
+        );
+    }
+
+    @Test
+    void notEqualsToObjectOfAnotherType() {
+        MatcherAssert.assertThat(
+            "must not equal to object of another type",
+            new Immutable<String, Integer>(new MapOf<String, Integer>()),
+            new IsNot<>(new IsEqual<>(new Object()))
+        );
+    }
+
+    @Test
+    void isEqualToItself() {
+        final Map<String, Integer> map = new Immutable<>(
+            new MapOf<String, Integer>(
+                new MapEntry<>("a", 1)
+            )
+        );
+        MatcherAssert.assertThat(
+            "must be equal to itself",
+            map,
+            new IsEqual<>(map)
+        );
+    }
+
+    @Test
+    void isEqualToMapWithSameEntries() {
+        MatcherAssert.assertThat(
+            "must be equal to Map with the same entries",
+            new Immutable<String, Integer>(
+                new MapOf<String, Integer>(
+                    new MapEntry<>("a", 1),
+                    new MapEntry<>("b", 2)
+                )
+            ),
+            new IsEqual<>(
+                new MapOf<String, Integer>(
+                    new MapEntry<>("a", 1),
+                    new MapEntry<>("b", 2)
+                )
+            )
+        );
+    }
+
+    @Test
+    void hashes() {
+        MatcherAssert.assertThat(
+            "hashCode() must be equal to hashCode of the corresponding Map",
+            new Immutable<String, Integer>(
+                new MapOf<String, Integer>(
+                    new MapEntry<>("a", 1)
+                )
+            ).hashCode(),
+            new IsEqual<>(
+                new MapOf<String, Integer>(
+                    new MapEntry<>("a", 1)
+                ).hashCode()
+            )
+        );
+    }
+
+    @Test
+    void stringRepresentation() {
+        final Map<String, Integer> origin = new MapOf<String, Integer>(
+            new MapEntry<>("a", 1)
+        );
+        MatcherAssert.assertThat(
+            "toString() must be equal to toString of the corresponding Map",
+            new Immutable<>(origin).toString(),
+            new IsEqual<>(origin.toString())
+        );
+    }
+
+    @Test
+    void innerMapIsDecorated() {
+        final Map<String, Integer> mutable = new HashMap<>();
+        mutable.put("a", 1);
+        final Map<String, Integer> immutable = new Immutable<>(mutable);
+        mutable.put("b", 2);
+        MatcherAssert.assertThat(
+            "Must reflect inner map in the decorator",
+            immutable,
+            new IsEqual<>(mutable)
+        );
+    }
+
+    @Test
+    void returnsIteratorWithUnsupportedRemove() {
+        MatcherAssert.assertThat(
+            "Must return an iterator that does not support remove()",
+            () -> {
+                final Iterator<Map.Entry<String, Integer>> iterator =
+                    new Immutable<String, Integer>(
+                        new MapOf<String, Integer>(
+                            new MapEntry<>("one", 1)
+                        )
+                    ).entrySet().iterator();
+                iterator.next();
+                iterator.remove();
+                return true;
+            },
+            new Throws<>(UnsupportedOperationException.class)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds `org.cactoos.map.Immutable`, a read-only `Map` decorator aligned with the existing `list.Immutable` / `set.Immutable` pattern, plus documentation and tests.

This PR also documents the existing `SplitPreserveAllTokens` API in the README and adds focused tests for `TriFuncSplitPreserve` (the implementation itself is already on `master`).

Closes #1835

Relates to #1722 (docs/tests only — implementation already merged)

## Changes

| Area | Details |
|------|--------|
| **New** | `src/main/java/org/cactoos/map/Immutable.java` — blocks `put` / `remove` / `putAll` / `clear`, immutable views (`keySet`, `values`, `entrySet`), and `Entry.setValue()` |
| **Tests** | `ImmutableTest` (map decorator behavior and mutation rejection) |
| **Tests** | `TriFuncSplitPreserveTest` (core split-preserve algorithm coverage) |
| **Docs** | README sections for splitting text / preserving empty tokens, Maps / Immutable maps, and comparison-table entries |
| **CI** | Maven matrix kept on `ubuntu-24.04`, `windows-2022`, `macos-15`; pass `-Dhone.skipWithoutDocker=true` / `-Dhone.skipOnWindows=true` so hone runs on Ubuntu (Docker available) and is skipped cleanly on macOS/Windows |

## Design notes

- Implements `Map` directly (same approach as other `Immutable` decorators in this codebase), not via `MapEnvelope`.
- Decorator semantics: it is a **view**, not a defensive copy. Underlying map mutations through another reference remain visible; callers who need a snapshot should copy first.
- Constructor accepts `Map<? extends K, ? extends V>` for covariance, consistent with typical Cactoos collection decorators.
- README documents `SplitPreserveAllTokens` for discoverability; that class is **not** introduced by this PR (already present on `master`).

## Test plan

- [x] `ImmutableTest` — mutation attempts throw `UnsupportedOperationException`; views/iterators/entry updates are blocked; read operations delegate correctly
- [x] `TriFuncSplitPreserveTest` — delimiter / limit / empty-token edge cases
- [x] CI green on `ubuntu-24.04`, `windows-2022`, and `macos-15`

## Commit hygiene

History kept to a **single commit** on `rehan_Split_Map_issue_fix` for a clean review surface.
