### PR TITLE
#1864: add PaddedEnd text decorator

### DIFF
--- a/src/main/java/org/cactoos/text/PaddedEnd.java
+++ b/src/main/java/org/cactoos/text/PaddedEnd.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2017-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package org.cactoos.text;
+
+import org.cactoos.Text;
+
+/**
+ * Text padded at end to reach the given length.
+ *
+ * <p>There is thread safe.
+ *
+ * @since 0.32
+ */
+public final class PaddedEnd extends TextEnvelope {
+
+    /**
+     * Ctor.
+     * @param text The text
+     * @param length The minimum length of the resulting string
+     * @param symbol The padding symbol
+     */
+    public PaddedEnd(
+        final Text text, final int length, final char symbol) {
+        super(
+            new Flattened(
+                () -> {
+                    final String original = text.asString();
+                    return new Concatenated(
+                        new TextOf(original),
+                        new Repeated(
+                            new TextOf(symbol), length - original.length()
+                        )
+                    );
+                }
+            )
+        );
+    }
+}

--- a/src/test/java/org/cactoos/text/PaddedEndTest.java
+++ b/src/test/java/org/cactoos/text/PaddedEndTest.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2017-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package org.cactoos.text;
+
+import org.junit.jupiter.api.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.HasString;
+
+/**
+ * Test case for {@link PaddedEnd}.
+ *
+ * @since 0.32
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+final class PaddedEndTest {
+
+    @Test
+    void noPaddingIfOrigTextIsAsLongAsRequestedLength() {
+        new Assertion<>(
+            "Shouldn't pad the text",
+            new PaddedEnd(
+                new TextOf("x"),
+                1,
+                '-'
+            ),
+            new HasString("x")
+        ).affirm();
+    }
+
+    @Test
+    void somePaddingIfOrigTextIsShorterThanRequestedLength() {
+        new Assertion<>(
+            "Should pad chars at end",
+            new PaddedEnd(
+                new TextOf("x"),
+                2,
+                '-'
+            ),
+            new HasString("x-")
+        ).affirm();
+    }
+
+    @Test
+    void noPaddingIfRequestedLengthIsNegative() {
+        new Assertion<>(
+            "Shouldn't consider negative min length",
+            new PaddedEnd(
+                new TextOf("x"),
+                -1,
+                '-'
+            ),
+            new HasString("x")
+        ).affirm();
+    }
+}


### PR DESCRIPTION
## Summary
Adds `PaddedEnd` class to pad text at the end. Symmetric to the existing `PaddedStart`.

## Changes
- Added `PaddedEnd.java` in `src/main/java/org/cactoos/text/` following the `PaddedStart` pattern
- Added `PaddedEndTest.java` with 3 tests mirroring `PaddedStartTest`

## Example
```java
new PaddedEnd(new TextOf("123"), 5, '0').asString() // "12300"
```

Closes #1864

This contribution was developed with AI assistance (Claude Code).