### PR TITLE
#1858: fix asymmetric equals in collection.Immutable

### DIFF
--- a/src/main/java/org/cactoos/collection/Immutable.java
+++ b/src/main/java/org/cactoos/collection/Immutable.java
@@ -120,6 +120,8 @@ public final class Immutable<X> implements Collection<X> {
 
     @Override
     public boolean equals(final Object obj) {
-        return this.col.equals(obj);
+        return this == obj
+            || obj instanceof Immutable
+            && this.col.equals(((Immutable<?>) obj).col);
     }
 }

--- a/src/test/java/org/cactoos/collection/ImmutableTest.java
+++ b/src/test/java/org/cactoos/collection/ImmutableTest.java
@@ -4,6 +4,7 @@
  */
 package org.cactoos.collection;
 
+import java.util.Collection;
 import java.util.List;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
@@ -232,6 +233,19 @@ final class ImmutableTest {
             new IsEqual<>(
                 new ListOf<>(1, 2, 3).equals(another)
             )
+        );
+    }
+
+    @Test
+    void equalsIsSymmetricWithPlainList() {
+        final List<Integer> plain = new ListOf<>(1, 2, 3);
+        final Collection<Integer> wrapper = new Immutable<>(
+            new ListOf<>(1, 2, 3)
+        );
+        MatcherAssert.assertThat(
+            "equals() must be symmetric between wrapper and plain list",
+            wrapper.equals(plain),
+            new IsEqual<>(plain.equals(wrapper))
         );
     }
 }


### PR DESCRIPTION
@yegor256 — this PR now addresses the remaining half of #1858. The `list.NoNulls` half was already merged via #1878, and the qulice/CI-unblock piece was covered by #1877.

## Problem

`org.cactoos.collection.Immutable` implements `Collection<X>` and delegates `equals()` to the wrapped collection. When the wrapped collection is a `List` (e.g. `ListOf`), `new Immutable<>(list).equals(list)` returns `true` via delegation, while `list.equals(new Immutable<>(list))` returns `false` — `AbstractList.equals` checks `instanceof List` and `Immutable` is a `Collection`, not a `List`. Equality is asymmetric.

## Fix

Restrict `equals()` to accept only other `Immutable` instances and compare their inner collections. The `Collection` interface adds no stipulations to `Object.equals`, so either direction against a plain `List` or `Set` now returns `false` — symmetric. Two wrappers of equal content still compare equal. `hashCode()` keeps delegating to the inner collection (equal objects still get equal hashes; allowing unequal objects to share a hash is permitted by the `Object` contract).

## Tests

Added `ImmutableTest#equalsIsSymmetricWithPlainList` (commit 1) — fails on current master with `true != false`, passes after the fix (commit 2). The existing `testEquals` / `testHashCode` still pass because they compare different-content cases.

## Commits

1. `#1858: add failing test for collection.Immutable asymmetric equals`
2. `#1858: restrict collection.Immutable equals to fellow Immutable wrappers`

Full suite (1765 tests) passes locally under `mvn install -Pqulice`.