### PR TITLE
Update dependency org.takes:takes to v1.26.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>org.takes</groupId>
       <artifactId>takes</artifactId>
-      <version>1.25.1</version>
+      <version>1.26.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
@yegor256, this PR upgrades the test-scoped dependency `org.takes:takes` from `1.25.1` to `1.26.0`.

## What changed

- `pom.xml`: bump `org.takes:takes` from `1.25.1` to `1.26.0`.

That is the only outdated dependency Maven could find for this project — `mvn versions:display-dependency-updates` and `versions:display-plugin-updates` confirmed everything else (parent POM `com.jcabi:parent` `0.73.1`, all plugins like `qulice 0.27.5`, `pitest 1.23.1`, `revapi 0.15.1`, `forbiddenapis 3.10`, `maven-compiler-plugin 3.15.0`, `sonar-maven-plugin 5.6.0.6792`, etc.) was already on the latest stable release. Updates flagged but skipped intentionally because they are not stable: `junit-jupiter 6.1.0-RC1`, `maven-compiler-plugin 4.0.0-beta-*`, `slf4j-reload4j 2.1.0-alpha1`, `clojure 1.12.5-rc1`.

## Why it is safe

`takes` is `test`-scoped, used only in `InputOfTest` via the public `FtRemote(Take)` and `TkHtml(String)` constructors, both of which are unchanged in `1.26.0`.

## Verification

- Local `mvn --batch-mode --errors -Pqulice clean install` passed (BUILD SUCCESS in 5:16 min, including `pitest` mutation testing, `qulice` checkstyle/PMD/error-prone, `forbiddenapis`, `revapi`, `jacoco` and the verifier-plugin).
- All 13 CI jobs are green: `actionlint`, `copyrights`, `markdown-lint`, `mvn (ubuntu-24.04, 23)`, `mvn (macos-15, 23)`, `mvn (windows-2022, 23)`, `ort`, `pdd`, `reuse`, `simian`, `typos`, `xcop`, `yamllint`.

Ready for merge.