### PR TITLE
Add Architecture section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,61 @@ Ask your questions related to cactoos library on
 [Stackoverflow](https://stackoverflow.com/questions/ask)
 with the [cactoos](https://stackoverflow.com/tags/cactoos/info) tag.
 
+## Architecture
+
+**Interfaces as the sole public abstraction.**
+Every primitive is declared as a Java [`@FunctionalInterface`][fi]—`Scalar<T>`,
+  `Text`, `Func<X,Y>`, `Input`, `Output`, `Bytes`, and `Proc`—with no static
+  utility classes at this level.
+This contrasts with [Guava][guava] and [Apache Commons][commons], where
+  functionality is delivered through static methods on utility classes
+  (`Iterables.filter()`, `StringUtils.isBlank()`).
+Because every concept is a real object, it can be subclassed, mocked, and
+  composed without reflection or special tooling.
+
+**Decorator pattern for all behavior extension.**
+Thread safety, memoization, null validation, and exception translation are
+  each added by wrapping one object in another, not by modifying the class.
+`Sticky<T>` caches a `Scalar<T>` result; `Synced<T>` makes it thread-safe;
+  `NoNulls` rejects null inputs; `Unchecked<T>` rethrows checked exceptions
+  as unchecked ones.
+This follows the [Decorator pattern][decorator] from GoF: every class has
+  exactly one responsibility, and capabilities are composed at call sites
+  rather than inherited.
+
+**Envelope pattern for safe inheritance.**
+Abstract base classes—`IterableEnvelope`, `TextEnvelope`, `ScalarEnvelope`,
+  and others—accept an inner object through the constructor and delegate to
+  it via `final` methods.
+Concrete classes extend an envelope and supply only the inner object; no
+  method bodies are overridden.
+This eliminates the [fragile base class][fbc] problem: because delegation
+  methods are `final`, a subclass cannot accidentally alter delegated behavior.
+
+**Lazy evaluation as the default.**
+No computation occurs until the caller explicitly requests it—`.value()`,
+  `.asString()`, or `.iterator()`.
+An `IterableOf<>` wrapping a transformation does no work until iterated.
+This contrasts with [Guava's `ImmutableList.copyOf()`][guava-imm] and
+  [Apache Commons Collections][commons-col], which materialize elements at
+  construction time.
+Explicit caching requires opting in with `Sticky` or `StickyList`.
+
+**Checked exceptions as first-class interface contracts.**
+All core interfaces declare `throws Exception`; the library never silently
+  converts checked exceptions to unchecked ones at the interface boundary.
+When a caller needs unchecked access, it wraps with `Unchecked<T>` (rethrows
+  as `UncheckedIOException`), `IoChecked<T>` (narrows to `IOException`), or
+  `Checked<T,E>` (converts to any target exception type).
+The decision about exception handling stays with the call site, not the library.
+
+**Zero runtime dependencies.**
+The library ships with no runtime dependencies.
+[Guava][guava] adds a ~3 MB JAR; [Apache Commons][commons] splits across
+  multiple JARs (`commons-lang3`, `commons-io`, etc.).
+Cactoos requires only [JDK 17][jdk17]+, making it suitable for environments
+  where classpath size and dependency audits matter.
+
 ## How to Contribute
 
 Just fork the repo and send us a pull request.
@@ -418,3 +473,11 @@ in GitHub precommits.
 [blog]: http://www.yegor256.com/2017/06/22/object-oriented-input-output-in-cactoos.html
 [OffsetDateTime]: https://docs.oracle.com/javase/8/docs/api/java/time/OffsetDateTime.html
 [lazy-blog]: http://www.yegor256.com/2017/10/17/lazy-loading-caching-sticky-cactoos.html
+[fi]: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/FunctionalInterface.html
+[guava]: https://github.com/google/guava
+[commons]: https://commons.apache.org/
+[decorator]: https://en.wikipedia.org/wiki/Decorator_pattern
+[fbc]: https://en.wikipedia.org/wiki/Fragile_base_class
+[guava-imm]: https://guava.dev/releases/snapshot/api/docs/com/google/common/collect/ImmutableList.html
+[commons-col]: https://commons.apache.org/proper/commons-collections/
+[jdk17]: https://openjdk.org/projects/jdk/17/


### PR DESCRIPTION
@yegor256, this PR adds an **Architecture** section to `README.md`, placed right before the *How to Contribute* section.

## What changed

The new `## Architecture` section explains six key architectural decisions that distinguish Cactoos from Guava and Apache Commons:

1. **Interfaces as the sole public abstraction** — every primitive (`Scalar<T>`, `Text`, `Func<X,Y>`, `Input`, `Output`, `Bytes`, `Proc`) is a `@FunctionalInterface`; no static utility classes exist at the top level.
2. **Decorator pattern for behavior extension** — thread safety (`Synced`), memoization (`Sticky`), null validation (`NoNulls`), and exception translation (`Unchecked`, `IoChecked`, `Checked`) are added by wrapping, not by modifying.
3. **Envelope pattern for safe inheritance** — `IterableEnvelope`, `TextEnvelope`, `ScalarEnvelope`, etc. delegate via `final` methods, preventing the fragile base class problem.
4. **Lazy evaluation as the default** — nothing is computed until `.value()`, `.asString()`, or `.iterator()` is called; `Sticky`/`StickyList` opt into caching.
5. **Checked exceptions as first-class contracts** — all core interfaces declare `throws Exception`; callers choose their exception strategy through decorators.
6. **Zero runtime dependencies** — only JDK 17+ is required.

Each decision includes Markdown reference links to relevant standards, patterns, and competing libraries (Guava, Apache Commons).

## Formatting

All new lines follow the repository's formatting convention: hard-wrapped at 80 characters, continuation lines indented by two spaces. `markdownlint-cli` reports no warnings.

Ready for your review, @yegor256.