### PR TITLE
Replace StringBuffer with StringBuilder in org.cactoos.text.Replaced (#1410)

### DIFF
--- a/src/main/java/org/cactoos/text/Replaced.java
+++ b/src/main/java/org/cactoos/text/Replaced.java
@@ -67,7 +67,7 @@ public final class Replaced extends TextEnvelope {
         super(
             new Mapped(
                 str -> {
-                    final StringBuffer buffer = new StringBuffer();
+                    final StringBuilder buffer = new StringBuilder();
                     final Matcher matcher = regex.value().matcher(str);
                     while (matcher.find()) {
                         matcher.appendReplacement(


### PR DESCRIPTION
Closes #1410.

Replaces `StringBuffer` with `StringBuilder` in `org.cactoos.text.Replaced`. The buffer is scoped to a single lambda invocation and never escapes that thread, so the synchronization `StringBuffer` inherits from `AbstractStringBuilder` is wasted work.

`Matcher.appendReplacement(StringBuilder, String)` and `Matcher.appendTail(StringBuilder)` have been available since Java 9; the project's `pom.xml` already targets Java 17, so the StringBuilder overloads compile cleanly.

The existing `ReplacedTest` covers the public behaviour and stays unchanged.