### PR TITLE
#1817 add Walked iterable as Elegant Files.walk equivalent

### DIFF
--- a/src/main/java/org/cactoos/io/Walked.java
+++ b/src/main/java/org/cactoos/io/Walked.java
@@ -1,0 +1,78 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2017-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package org.cactoos.io;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.cactoos.Scalar;
+import org.cactoos.scalar.Unchecked;
+
+/**
+ * Walked file tree.
+ *
+ * <p>An Elegant equivalent of
+ * {@link Files#walk(Path, int, java.nio.file.FileVisitOption...)},
+ * iterating every path under a starting directory up to a given depth.
+ * Use {@link Directory} when the walk should be unbounded.
+ *
+ * <p>There is no thread-safety guarantee.
+ *
+ * @since 1.0
+ */
+@SuppressWarnings("PMD.UnnecessaryLocalRule")
+public final class Walked implements Iterable<Path> {
+
+    /**
+     * Path of the starting directory.
+     */
+    private final Scalar<Path> start;
+
+    /**
+     * Maximum depth to walk.
+     */
+    private final int depth;
+
+    /**
+     * Ctor.
+     * @param file File as a path to the starting directory
+     * @param max Maximum number of directory levels to visit
+     */
+    public Walked(final File file, final int max) {
+        this(file::toPath, max);
+    }
+
+    /**
+     * Ctor.
+     * @param path Path of the starting directory
+     * @param max Maximum number of directory levels to visit
+     */
+    public Walked(final Path path, final int max) {
+        this(() -> path, max);
+    }
+
+    /**
+     * Ctor.
+     * @param source Path of the starting directory, deferred
+     * @param max Maximum number of directory levels to visit
+     */
+    private Walked(final Scalar<Path> source, final int max) {
+        this.start = source;
+        this.depth = max;
+    }
+
+    @Override
+    public Iterator<Path> iterator() {
+        try (Stream<Path> paths = Files.walk(new Unchecked<>(this.start).value(), this.depth)) {
+            return paths.collect(Collectors.toList()).iterator();
+        } catch (final IOException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+}

--- a/src/test/java/org/cactoos/io/WalkedTest.java
+++ b/src/test/java/org/cactoos/io/WalkedTest.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2017-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package org.cactoos.io;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.llorllale.cactoos.matchers.HasSize;
+
+/**
+ * Test case for {@link Walked}.
+ * @since 1.0
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+final class WalkedTest {
+
+    @Test
+    void walksFileTreeUpToGivenDepth(@TempDir final Path dir) throws IOException {
+        dir.resolve("a/b/c").toFile().mkdirs();
+        Files.write(
+            dir.resolve("a/b/c/leaf"),
+            "".getBytes(StandardCharsets.UTF_8)
+        );
+        MatcherAssert.assertThat(
+            "must visit start and direct children only when depth is 1",
+            new Walked(dir, 1),
+            new HasSize(2)
+        );
+    }
+
+    @Test
+    void walksFileTreeWhenStartedFromFile(@TempDir final Path dir) throws IOException {
+        dir.resolve("x/y").toFile().mkdirs();
+        Files.write(
+            dir.resolve("x/y/file"),
+            "".getBytes(StandardCharsets.UTF_8)
+        );
+        MatcherAssert.assertThat(
+            "must visit every path under the start when depth is unbounded",
+            new Walked(dir.toFile(), Integer.MAX_VALUE),
+            new HasSize(4)
+        );
+    }
+}


### PR DESCRIPTION
Closes #1817

Adds `org.cactoos.io.Walked` as the Elegant equivalent of `Files.walk(Path, int)`, iterating every path under a starting directory up to a bounded depth. `Directory` already wraps the unbounded `Files.walk(Path)` call, so this PR fills in the depth-controlled variant the issue asked for. Constructors mirror `Directory`: `Walked(Path, int)` and `Walked(File, int)`, both delegating to a private `Walked(Scalar<Path>, int)`.

A caller that today writes `try (Stream<Path> paths = Files.walk(start, 2)) { ... }` can now write `new Walked(start, 2)` and treat it as any other cactoos `Iterable<Path>`.

Locally ran `mvn -Dtest='DirectoryTest,WalkedTest' -Dhone.skip=true -Djacoco.skip=true test` (4 tests pass) and `mvn -Pqulice -Dhone.skip=true -Djacoco.skip=true -DskipTests verify` (BUILD SUCCESS, qulice clean). Could not exercise the full `mvn` matrix here because `hone-maven-plugin` requires Docker; CI on the PR will cover the rest.
