### PR TITLE
Fix #1912: rethrow original exception in ScalarWithFallback

### DIFF
--- a/src/main/java/org/cactoos/scalar/ScalarWithFallback.java
+++ b/src/main/java/org/cactoos/scalar/ScalarWithFallback.java
@@ -104,13 +104,18 @@ public final class ScalarWithFallback<T> implements Scalar<T> {
                     ).entrySet().iterator()
                 )
             );
-        if (candidates.hasNext()) {
-            return candidates.next().getKey().apply(exp);
-        } else {
-            throw new Exception(
-                "No fallback found - throw the original exception",
-                exp
-            );
+        if (!candidates.hasNext()) {
+            if (exp instanceof RuntimeException) {
+                throw (RuntimeException) exp;
+            }
+            if (exp instanceof Error) {
+                throw (Error) exp;
+            }
+            if (exp instanceof Exception) {
+                throw (Exception) exp;
+            }
+            throw new Exception(exp);
         }
+        return candidates.next().getKey().apply(exp);
     }
 }

--- a/src/test/java/org/cactoos/scalar/ScalarWithFallbackTest.java
+++ b/src/test/java/org/cactoos/scalar/ScalarWithFallbackTest.java
@@ -182,4 +182,38 @@ final class ScalarWithFallbackTest {
             new Throws<>(Exception.class)
         );
     }
+
+    @Test
+    void rethrowsOriginalUncheckedException() {
+        MatcherAssert.assertThat(
+            "Must rethrow the original unchecked exception when no fallback matches",
+            () -> new ScalarWithFallback<>(
+                () -> {
+                    throw new IllegalArgumentException("Unchecked failure");
+                },
+                new Fallback.From<>(
+                    IOException.class,
+                    exp -> "Fallback from IOException"
+                )
+            ).value(),
+            new Throws<>("Unchecked failure", IllegalArgumentException.class)
+        );
+    }
+
+    @Test
+    void rethrowsOriginalCheckedException() {
+        MatcherAssert.assertThat(
+            "Must rethrow the original checked exception when no fallback matches",
+            () -> new ScalarWithFallback<>(
+                () -> {
+                    throw new IOException("Checked failure");
+                },
+                new Fallback.From<>(
+                    IllegalArgumentException.class,
+                    exp -> "Fallback from IllegalArgumentException"
+                )
+            ).value(),
+            new Throws<>("Checked failure", IOException.class)
+        );
+    }
 }


### PR DESCRIPTION
Closes #1912.

## Problem

In `ScalarWithFallback.fallback()`, when no registered `Fallback` supports the throwable, the `else` branch threw `new Exception("No fallback found - throw the original exception", exp)`. This *wrapped* the original throwable instead of rethrowing it — the message said the opposite of what the code did.

Because `value()` catches `Throwable`, this branch is reached by everything the origin throws that no fallback matches. The consequences:

- An unchecked exception (e.g. `IllegalArgumentException`) was silently turned into a checked `java.lang.Exception`, with the original only visible as the cause.
- The original exception type was no longer visible to the caller.
- An `Error` (e.g. `StackOverflowError`) was flattened the same way.

This also contradicted the method's own Javadoc, which promises to "throw the original error if no fallback found".

## Fix

`fallback()` now rethrows the original throwable instead of wrapping it:

- `RuntimeException` and `Error` are rethrown unchanged (type and identity preserved).
- Checked `Exception`s are rethrown directly.
- Only a raw `Throwable` that is neither `Exception` nor `Error` is wrapped (kept for type-safety, as the enclosing method is declared `throws Exception`).

## Tests

Added two tests to `ScalarWithFallbackTest` covering the issue's scenarios:

- `rethrowsOriginalUncheckedException` — an `IllegalArgumentException` from the origin, with only an `IOException` fallback, is rethrown as `IllegalArgumentException` (message preserved).
- `rethrowsOriginalCheckedException` — an `IOException` from the origin, with only an `IllegalArgumentException` fallback, is rethrown as `IOException` (message preserved).

All 11 tests in `ScalarWithFallbackTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yf9dgnsJJqPtakMKmdCVP

---
_Generated by [Claude Code](https://claude.ai/code/session_014yf9dgnsJJqPtakMKmdCVP)_